### PR TITLE
chore: add Travis CI build to GUI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,48 @@
+language: cpp
+dist: trusty
+compiler:
+    - clang
+    - gcc
+env:
+    - LIBRARY_COMBO=gnu-gnu-gnu
+    - LIBRARY_COMBO=ng-gnu-gnu
+    - LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixed-abi
+matrix:
+    exclude:
+        - compiler: gcc
+          env: LIBRARY_COMBO=ng-gnu-gnu
+        - compiler: gcc
+          env: LIBRARY_COMBO=ng-gnu-gnu BASE_ABI=--disable-mixed-abi
+        - compiler: clang
+          env: LIBRARY_COMBO=gnu-gnu-gnu
+sudo: required
+before_install:
+    - sudo apt-get -qq update
+    - sudo apt-get install -y cmake pkg-config libgnutls28-dev libgmp-dev libffi-dev libicu-dev libxml2-dev libxslt1-dev libssl-dev libavahi-client-dev zlib1g-dev
+    - >
+        if [ $LIBRARY_COMBO = 'gnu-gnu-gnu' ];
+        then
+          if [ $CC = 'gcc' ];
+          then
+            sudo apt-get install -y gobjc;
+          fi;
+          sudo apt-get install -y libobjc-4.8-dev;
+        else
+          sudo apt-get install -y libkqueue-dev libpthread-workqueue-dev;
+        fi;
+install: ./travis-deps.sh
+before_script: >
+    export LIBRARY_PATH=$HOME/staging/lib:$LIBRARY_PATH;
+    export LD_LIBRARY_PATH=$HOME/staging/lib:$LD_LIBRARY_PATH;
+    if [ $LIBRARY_COMBO = 'ng-gnu-gnu' ];
+    then
+      export CPATH=$HOME/staging/include;
+    else
+      export CPATH=/usr/lib/gcc/x86_64-linux-gnu/4.8/include;
+    fi;
+    export PATH=$HOME/staging/bin:$PATH;
+    export GNUSTEP_MAKEFILES=$HOME/staging/share/GNUstep/Makefiles;
+    . $HOME/staging/share/GNUstep/Makefiles/GNUstep.sh;
+script: >
+    ./configure $BASE_ABI;
+    make && make install && make check || (cat Tests/tests.log && false);

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2017-08-04  Daniel Ferreira <dtf@stanford.edu>
+
+	* .travis.yml
+	* travis-deps.sh:	
+	Add a Travis CI build to gnustep-gui to check if everything is really
+	okay before accepting patches.
+
+	Recent events have shown that bad patches have passed through the review
+	process, specially when it comes to breaking compatibility with GCC. A
+	CI routine would distinctly avoid these cases.
+
 2017-07-31 Fred Kiefer <FredKiefer@gmx.de>
 
 	* Headers/AppKit/NSPasteboardItem.h

--- a/travis-deps.sh
+++ b/travis-deps.sh
@@ -1,0 +1,66 @@
+#! /usr/bin/env sh
+
+set -ex
+
+DEP_SRC=$HOME/dependency_source/
+
+install_gnustep_make() {
+    cd $DEP_SRC
+    git clone https://github.com/gnustep/make.git
+    cd make
+    if [ $LIBRARY_COMBO = 'ng-gnu-gnu' ]
+    then
+        ADDITIONAL_FLAGS="--enable-objc-nonfragile-abi"
+    else
+        ADDITIONAL_FLAGS=""
+    fi
+    ./configure --prefix=$HOME/staging --with-library-combo=$LIBRARY_COMBO $ADDITIONAL_FLAGS
+    make install
+}
+
+install_ng_runtime() {
+    cd $DEP_SRC
+    git clone https://github.com/gnustep/libobjc2.git
+    mkdir libobjc2/build
+    cd libobjc2/build
+    export CC="clang"
+    export CXX="clang++"
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGNUSTEP_INSTALL_TYPE=NONE -DCMAKE_INSTALL_PREFIX:PATH=$HOME/staging ../
+    make install
+}
+
+install_libdispatch() {
+    cd $DEP_SRC
+    git clone https://github.com/ngrewe/libdispatch.git
+    mkdir libdispatch/build
+    cd libdispatch/build
+    export CC="clang"
+    export CXX="clang++"
+    export LIBRARY_PATH=$HOME/staging/lib;
+    export LD_LIBRARY_PATH=$HOME/staging/lib:$LD_LIBRARY_PATH;
+    export CPATH=$HOME/staging/include;
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DCMAKE_INSTALL_PREFIX:PATH=$HOME/staging ../
+    make install
+}
+
+install_gnustep_base() {
+    export GNUSTEP_MAKEFILES=$HOME/staging/share/GNUstep/Makefiles
+    . $HOME/staging/share/GNUstep/Makefiles/GNUstep.sh
+
+    cd $DEP_SRC
+    git clone https://github.com/gnustep/libs-base.git
+    cd libs-base
+    ./configure
+    make
+    make install
+}
+
+mkdir -p $DEP_SRC
+if [ $LIBRARY_COMBO = 'ng-gnu-gnu' ]
+then
+    install_ng_runtime
+    install_libdispatch
+fi
+
+install_gnustep_make
+install_gnustep_base


### PR DESCRIPTION
Add a Travis CI build to gnustep-gui to check if everything is really
okay before accepting patches.

Recent events have shown that bad patches have passed through the review
process, specially when it comes to breaking compatibility with GCC. A
CI routine would distinctly avoid these cases.