### PR TITLE
correct decoding of named images from keyed archivers

### DIFF
--- a/Source/NSImage.m
+++ b/Source/NSImage.m
@@ -1985,6 +1985,7 @@ static NSSize GSResolutionOfImageRep(NSImageRep *rep)
 	  replacementImage = [[NSImage alloc] init];
 	  [replacementImage setName: imageName];
 	  replacementImage->_flags.archiveByName = YES;
+	  self = replacementImage;
         }
       if ([coder containsValueForKey: @"NSColor"])
         {


### PR DESCRIPTION
As @tedge noted on the original pull request for this work, I didn't return the correct object in the keyed archiver case.