### PR TITLE
Clean up -[NSImage initWithCoder:] and reduce amount of releases of self.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-12-07 Ivan Vucica <ivan@vucica.net>
+
+	* Source/NSImage.m (-initWithCoder:): Clean up and reduce amount
+	of releases of self.
+
 2017-12-03 Fred Kiefer <FredKiefer@gmx.de>
 
 	* Headers/AppKit/NSScreen.h

--- a/Source/NSImage.m
+++ b/Source/NSImage.m
@@ -1967,25 +1967,25 @@ static NSSize GSResolutionOfImageRep(NSImageRep *rep)
 - (id) initWithCoder: (NSCoder*)coder
 {
   BOOL flag;
-  NSImage *replacementImage;
-  NSString *imageName;
   
   _reps = [[NSMutableArray alloc] initWithCapacity: 2];
   if ([coder allowsKeyedCoding])
     {
       if ([coder containsValueForKey: @"NSName"])
         {
-          RELEASE(self);
+          NSImage *replacementImage;
+          NSString *imageName;
+
           imageName = [coder decodeObjectForKey: @"NSName"];
           replacementImage = [NSImage imageNamed: imageName];
           if (replacementImage)
             {
+              RELEASE(self);
               return RETAIN(replacementImage);
             }
-          replacementImage = [[NSImage alloc] init];
-          [replacementImage setName: imageName];
-          replacementImage->_flags.archiveByName = YES;
-          self = replacementImage;
+
+          [self setName: imageName];
+          self->_flags.archiveByName = YES;
         }
       if ([coder containsValueForKey: @"NSColor"])
         {
@@ -2062,17 +2062,17 @@ static NSSize GSResolutionOfImageRep(NSImageRep *rep)
       [coder decodeValueOfObjCType: @encode(BOOL) at: &flag];
       if (flag == YES)
         {
+          NSImage *replacementImage;
           NSString *theName = [coder decodeObject];
 
-          RELEASE(self);
           replacementImage = [NSImage imageNamed: theName];
           if (replacementImage)
             {
+              RELEASE(self);
               self = RETAIN(replacementImage);
             }
           else
             {
-              self = [[NSImage alloc] init];
               [self setName: theName];
               self->_flags.archiveByName = YES;
             }


### PR DESCRIPTION
Some context available in PR #12 and  PR #13.

Requesting code review, as I feel this is a change with potential for subtle bugs.

@tedge Despite the comment you made in PR #12, I've omitted adding `[self init]` to the top, as it might substantially change the values of some ivars when `NSImage`s are decoded from nibs (or otherwise).

Specifically, these values would be defaulting differently (see [`-[NSImage initWithSize:]`](https://github.com/gnustep/libs-gui/blob/ab488e1d781e5076bbccfae6a0a85ed6bcc4f592/Source/NSImage.m#L514)):

```
  _flags.colorMatchPreferred = YES;
  _flags.multipleResolutionMatching = YES;
  ASSIGN(_color, clearColor);
  _cacheMode = NSImageCacheDefault;
```

It should not be a problem, but given that I have only done editing on GitHub's web UI, I feel uncomfortable making the change without a chance to try it out on at least a few more complicated nibs.

@fredkiefer Any thoughts?