### PR TITLE
NSGraphicsContext: When creating w/ graphics port, actually pass it in.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2018-07-24 Ivan Vucica <ivan@vucica.net>
+
+	* Source/NSGraphicsContext.m (+graphicsContextWithGraphicsPort:flipped:):
+	If the underlying graphics context supports it, pass nil to GSSetDevice.
+
+	In Opal backend, this is intended to trigger creation of backing surface
+	no matter that we don't have a window device. This should make the
+	CGContextRef passed into graphicsPort usable.
+
 2018-07-14 Fred Kiefer <FredKiefer@gmx.de>
 
 	* Source/NSPrinter.m (-addPPDKeyword:withScanner:withPPDPath:):

--- a/Source/NSGraphicsContext.m
+++ b/Source/NSGraphicsContext.m
@@ -241,6 +241,13 @@ NSGraphicsContext	*GSCurrentContext(void)
   new->_graphicsPort = port;
   new->_isFlipped = flag;
 
+  if ([new supportsDevicelessSurface])
+    {
+      // FIXME: How best to initialize backing surfaces in case a backend
+      // requires a backing device?
+      [new GSSetDevice: nil : 0 : 0];
+    }
+
   return new;
 }
 
@@ -249,6 +256,16 @@ NSGraphicsContext	*GSCurrentContext(void)
 {
   return [NSGraphicsContext graphicsContextWithGraphicsPort: (void *)context
 						    flipped: flipped];
+}
+
+/** <override-dummy />
+Returns whether the backend supports surfaces without a device.
+
+By default, returns NO.<br />
+*/
+- (BOOL) supportsDevicelessSurface
+{
+  return NO;
 }
 
 + (void) restoreGraphicsState

--- a/Source/NSGraphicsContext.m
+++ b/Source/NSGraphicsContext.m
@@ -241,6 +241,11 @@ NSGraphicsContext	*GSCurrentContext(void)
   new->_graphicsPort = port;
   new->_isFlipped = flag;
 
+  if ([new respondsToSelector: @selector(setupGraphicsPort)])
+    {
+      [new setupGraphicsPort];
+    }
+
   return new;
 }
 

--- a/Source/NSGraphicsContext.m
+++ b/Source/NSGraphicsContext.m
@@ -241,13 +241,6 @@ NSGraphicsContext	*GSCurrentContext(void)
   new->_graphicsPort = port;
   new->_isFlipped = flag;
 
-  if ([new supportsDevicelessSurface])
-    {
-      // FIXME: How best to initialize backing surfaces in case a backend
-      // requires a backing device?
-      [new GSSetDevice: nil : 0 : 0];
-    }
-
   return new;
 }
 
@@ -256,16 +249,6 @@ NSGraphicsContext	*GSCurrentContext(void)
 {
   return [NSGraphicsContext graphicsContextWithGraphicsPort: (void *)context
 						    flipped: flipped];
-}
-
-/** <override-dummy />
-Returns whether the backend supports surfaces without a device.
-
-By default, returns NO.<br />
-*/
-- (BOOL) supportsDevicelessSurface
-{
-  return NO;
 }
 
 + (void) restoreGraphicsState


### PR DESCRIPTION
Pass the requested graphics port into the newly created graphics
context using `-GSSetDevice:::.`

---

Hi Fred,

While trying to help @whiteShtef with his project, this seemed like something that prevented Opal backend from using the correct passed `graphicsPort`. Can you take a look and see if this would be the right way to go about this?