### PR TITLE
Moving BOOL ivars definitions down in GSStandardWindowDecorationView …

### DIFF
--- a/Headers/Additions/GNUstepGUI/GSWindowDecorationView.h
+++ b/Headers/Additions/GNUstepGUI/GSWindowDecorationView.h
@@ -106,14 +106,15 @@ Standard OPENSTEP-ish window decorations.
 
 @interface GSStandardWindowDecorationView : GSWindowDecorationView
 {
-  BOOL hasTitleBar, hasResizeBar, hasCloseButton, hasMiniaturizeButton;
-  BOOL isTitled; //, hasToolbar, hasMenu;
   NSRect titleBarRect;
   NSRect resizeBarRect;
   NSRect closeButtonRect;
   NSRect miniaturizeButtonRect;
 
   NSButton *closeButton, *miniaturizeButton;
+  
+  BOOL hasTitleBar, hasResizeBar, hasCloseButton, hasMiniaturizeButton;
+  BOOL isTitled; //, hasToolbar, hasMenu;
 }
 @end
 

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -434,11 +434,6 @@ NSApplication	*NSApp = nil;
   return NO;
 }
 
-- (BOOL) becomesKeyOnlyIfNeeded
-{
-  return YES;
-}
-
 - (BOOL) worksWhenModal
 {
   return YES;
@@ -545,11 +540,6 @@ static NSSize scaledIconSizeForSize(NSSize imageSize)
 - (BOOL) acceptsFirstMouse: (NSEvent*)theEvent
 {
   return YES;
-}
-
-- (BOOL) needsPanelToBecomeKey
-{
-  return NO;
 }
 
 - (void) concludeDragOperation: (id<NSDraggingInfo>)sender

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -434,6 +434,11 @@ NSApplication	*NSApp = nil;
   return NO;
 }
 
+- (BOOL) becomesKeyOnlyIfNeeded
+{
+  return YES;
+}
+
 - (BOOL) worksWhenModal
 {
   return YES;
@@ -540,6 +545,11 @@ static NSSize scaledIconSizeForSize(NSSize imageSize)
 - (BOOL) acceptsFirstMouse: (NSEvent*)theEvent
 {
   return YES;
+}
+
+- (BOOL) needsPanelToBecomeKey
+{
+  return NO;
 }
 
 - (void) concludeDragOperation: (id<NSDraggingInfo>)sender


### PR DESCRIPTION
…fixes applications segfaults on trying to access BOOL ivars.
You can observe segfault with any application that has GSX11HandlesWindowDecorations preference value set to NO. Segfaults at `GSStandardWindowDecorationView.m:98`.
I suppose that this bug can be a signal of some problems in runtime. Probably it's a problem of align or alloc of `BOOL` ivars (AKA `unsigned char`).
I use the following environment:
- CentOS 7
- LLVM/clang 7.0.1 with patch https://svnweb.freebsd.org/ports/head/devel/llvm70/files/clang/patch-tools_clang_lib_CodeGen_CGObjCGNU.cpp?revision=489195&view=markup included
- libobjc2 2.0
- gnustep-config --objc-flags
`-MMD -MP -DGNUSTEP -DGNUSTEP_BASE_LIBRARY=1 -DGNU_GUI_LIBRARY=1 -DGNUSTEP_RUNTIME=1 -D_NONFRAGILE_ABI=1 -DGNUSTEP_BASE_LIBRARY=1 -fno-strict-aliasing -fexceptions -fobjc-exceptions -D_NATIVE_OBJC_EXCEPTIONS -pthread -fPIC -DDEBUG -fno-omit-frame-pointer -Wall -DGSWARN -DGSDIAGNOSE -Wno-import -g -fobjc-runtime=gnustep-1.8 -fblocks -fconstant-string-class=NSConstantString -I. -I/Users/me/Library/Headers -I/Developer/Headers -I/usr/NextSpace/include`