### PR TITLE
Added support for WindowMaker's WMFHideApplication action.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 2019-04-06  Sergii Stoian  <stoyan255@ukr.net>
 
+	* Source/NSApplication.m (hide:): Change comment before call to `hidwindow`.
+
 	* Source/GSDisplayServer.m (hidewindow:): fixes to return value and type.
+	Change comment.
 
 2019-04-05  Sergii Stoian  <stoyan255@gmail.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
 2019-04-06  Sergii Stoian  <stoyan255@ukr.net>
 
-	* Source/NSApplication.m (hide:): Change comment before call to `hidwindow`.
+	* Headers/Additions/GNUstepGUI/GSDisplayServer.h,
+	* Source/NSApplication.m,
+	* Source/GSDisplayServer.m: `hidewindow` method  was renamed to
+	`hideApplication`
+
+	* Source/NSApplication.m (hide:): Change comment before call to
+	`hidewindow`.
 
 	* Source/GSDisplayServer.m (hidewindow:): fixes to return value and type.
 	Change comment.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2019-04-05  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Headers/AppKit/NSEvent.h: new event subtype `GSAppKitAppHide` was added.
+	* Source/NSWindow.m (sendEvent:): handle "GSAppKitAppHide" event subtype.
+
+	* Headers/Additions/GNUstepGUI/GSDisplayServer.h,
+	* Source/GSDisplayServer.m (hidewindow:): new methods was added.
+
+	* Source/NSApplication.m (hide:): Send -hidewindow: to to the main menu.
+	If window manager doesn't support _GNUSTEP_HIDE_APP atom - hide windows
+	by ourself.
+
 2019-04-03  Sergii Stoian  <stoyan255@ukr.net>
 
 	* Source/NSApplication.m (activateIgnoringOtherApps:):

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2019-04-06  Sergii Stoian  <stoyan255@ukr.net>
+
+	* Source/GSDisplayServer.m (hidewindow:): fixes to return value and type.
+
 2019-04-05  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Headers/AppKit/NSEvent.h: new event subtype `GSAppKitAppHide` was added.

--- a/Headers/Additions/GNUstepGUI/GSDisplayServer.h
+++ b/Headers/Additions/GNUstepGUI/GSDisplayServer.h
@@ -136,6 +136,7 @@ APPKIT_EXPORT NSString *GSScreenNumber;
 - (void) windowbacking: (NSBackingStoreType)type : (int)win;
 - (void) titlewindow: (NSString *)window_title : (int)win;
 - (void) miniwindow: (int)win;
+- (BOOL) hidewindow: (int)win;
 - (BOOL) appOwnsMiniwindow;
 - (void) setWindowdevice: (int)win forContext: (NSGraphicsContext *)ctxt;
 // Deprecated

--- a/Headers/Additions/GNUstepGUI/GSDisplayServer.h
+++ b/Headers/Additions/GNUstepGUI/GSDisplayServer.h
@@ -136,7 +136,7 @@ APPKIT_EXPORT NSString *GSScreenNumber;
 - (void) windowbacking: (NSBackingStoreType)type : (int)win;
 - (void) titlewindow: (NSString *)window_title : (int)win;
 - (void) miniwindow: (int)win;
-- (BOOL) hidewindow: (int)win;
+- (BOOL) hideApplication: (int)win;
 - (BOOL) appOwnsMiniwindow;
 - (void) setWindowdevice: (int)win forContext: (NSGraphicsContext *)ctxt;
 // Deprecated

--- a/Headers/AppKit/NSEvent.h
+++ b/Headers/AppKit/NSEvent.h
@@ -532,6 +532,7 @@ typedef enum {
   GSAppKitDraggingFinished,
   GSAppKitRegionExposed,
   GSAppKitWindowDeminiaturize,
+  GSAppKitAppHide
 } GSAppKitSubtype;
 #endif
 

--- a/Source/GSDisplayServer.m
+++ b/Source/GSDisplayServer.m
@@ -601,7 +601,8 @@ GSCurrentServer(void)
   [self subclassResponsibility: _cmd];
 }
 
-/** Hides all application windows */
+/** Ask the window manager to hide all the application windows for us. 
+    Return whether they have been hidden. */
 - (BOOL) hidewindow: (int) win
 {
   return NO;

--- a/Source/GSDisplayServer.m
+++ b/Source/GSDisplayServer.m
@@ -603,7 +603,7 @@ GSCurrentServer(void)
 
 /** Ask the window manager to hide all the application windows for us. 
     Return whether they have been hidden. */
-- (BOOL) hidewindow: (int) win
+- (BOOL) hideApplication: (int) win
 {
   return NO;
 }

--- a/Source/GSDisplayServer.m
+++ b/Source/GSDisplayServer.m
@@ -601,6 +601,12 @@ GSCurrentServer(void)
   [self subclassResponsibility: _cmd];
 }
 
+/** Hides all application windows */
+- (void) hidewindow: (int) win
+{
+  [self subclassResponsibility: _cmd];
+}
+
 /** Returns YES if the application should create the miniwindow counterpart
     to the full size window and own it. Some display systems handle the
     miniwindow themselves. In this case the backend subclass should

--- a/Source/GSDisplayServer.m
+++ b/Source/GSDisplayServer.m
@@ -602,9 +602,9 @@ GSCurrentServer(void)
 }
 
 /** Hides all application windows */
-- (void) hidewindow: (int) win
+- (BOOL) hidewindow: (int) win
 {
-  [self subclassResponsibility: _cmd];
+  return NO;
 }
 
 /** Returns YES if the application should create the miniwindow counterpart

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -2499,7 +2499,7 @@ image.</p><p>See Also: -applicationIconImage</p>
           /** Ask the window manager to hide all the application windows for us. 
               Return whether they have been hidden. */
           win = [[self mainMenu] window];
-          if ([GSServerForWindow(win) hidewindow: [win windowNumber]] == NO)
+          if ([GSServerForWindow(win) hideApplication: [win windowNumber]] == NO)
             {
               windows_list = GSOrderedWindows();
               iter = [windows_list reverseObjectEnumerator];

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -2496,9 +2496,8 @@ image.</p><p>See Also: -applicationIconImage</p>
 	      [_hidden_main resignMainWindow];
 	    }
 	  
-          // Sends -hidewindow: to the main menu. If window manager supports
-          // _GNUSTEP_WM_HIDE_APP atom - call succeeds - our windows will be
-          // hidden by window manager, next application should be activated.
+          /** Ask the window manager to hide all the application windows for us. 
+              Return whether they have been hidden. */
           win = [[self mainMenu] window];
           if ([GSServerForWindow(win) hidewindow: [win windowNumber]] == NO)
             {

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -2496,30 +2496,37 @@ image.</p><p>See Also: -applicationIconImage</p>
 	      [_hidden_main resignMainWindow];
 	    }
 	  
-	  windows_list = GSOrderedWindows();
-	  iter = [windows_list reverseObjectEnumerator];
+          // Sends -hidewindow: to the main menu. If window manager supports
+          // _GNUSTEP_WM_HIDE_APP atom - call succeeds - our windows will be
+          // hidden by window manager, next application should be activated.
+          win = [[self mainMenu] window];
+          if ([GSServerForWindow(win) hidewindow: [win windowNumber]] == NO)
+            {
+              windows_list = GSOrderedWindows();
+              iter = [windows_list reverseObjectEnumerator];
 	  
-	  while ((win = [iter nextObject]))
-	    {
-	      if ([win isVisible] == NO && ![win isMiniaturized])
-		{
-		  continue;		/* Already invisible	*/
-		}
-	      if ([win canHide] == NO)
-		{
-		  continue;		/* Not hideable	*/
-		}
-	      if (win == _app_icon_window)
-		{
-		  continue;		/* can't hide the app icon.	*/
-		}
-	      if (_app_is_active == YES && [win hidesOnDeactivate] == YES)
-		{
-		  continue;		/* Will be hidden by deactivation	*/
-		}
-	      [_hidden addObject: win];
-	      [win orderOut: self];
-	    }
+              while ((win = [iter nextObject]))
+                {
+                  if ([win isVisible] == NO && ![win isMiniaturized])
+                    {
+                      continue;		/* Already invisible	*/
+                    }
+                  if ([win canHide] == NO)
+                    {
+                      continue;		/* Not hideable	*/
+                    }
+                  if (win == _app_icon_window)
+                    {
+                      continue;		/* can't hide the app icon.	*/
+                    }
+                  if (_app_is_active == YES && [win hidesOnDeactivate] == YES)
+                    {
+                      continue;		/* Will be hidden by deactivation	*/
+                    }
+                  [_hidden addObject: win];
+                  [win orderOut: self];
+                }
+            }
 	  _app_is_hidden = YES;
 	  
 	  if (YES == [[NSUserDefaults standardUserDefaults]

--- a/Source/NSWindow.m
+++ b/Source/NSWindow.m
@@ -4224,6 +4224,10 @@ checkCursorRectanglesExited(NSView *theView,  NSEvent *theEvent, NSPoint lastPoi
               [self performMiniaturize: NSApp];
               break;
 
+            case GSAppKitAppHide:
+              [NSApp hide: self];
+              break;
+
             case GSAppKitWindowFocusIn:
               if (_f.is_miniaturized)
 		{


### PR DESCRIPTION
This is a first part of "Hide Application" functionality (the next in the -back), but I describe changes here.
Problem: Application can be hidden in 2 ways: fist - using application's "Hide" menu item or key equivalent Cmd-h (Alt-h); second - WindowMaker's right-click on miniaturize titlebar button. Any of these actions are independent of each other - there's a weak/absent interconnection between application and window manager (WindowMaker). As a result, if you hide app in a first way window manager knows nothing  besides withdrawing of windows from screen. If you hide app with window manager application is not considered as hidden inside app's code.
Solution:
1. When [NSApp hide] method called application first tries to send client message to WindowMaker. If this message succeds, application marked as hidden (sets ivar, draws dot on appicon) without ordering out of windows (it will be done by WindowMaker). WindowMaker withdraws windows from screen and switch focus to the next application in focus ring. Otherwise (no support from window manager), application hides it's windows by itself.
2. If the source of "Hide" action is WindowMaker - client message will be send to GNUstep Back, NSEvent generated with subtype `GSAppKitAppHide` and application now knows that it was hidden.

The -back part of changes is here https://github.com/gnustep/libs-back/pull/9.