### PR TITLE
Reduce number of appicon flickering cases

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-04-08  Sergii Stoian  <stoyan255@ukr.net>
+
+	* Source/NSApplication.m (becomesKeyOnlyIfNeeded)
+	(needsPanelToBecomeKey): override NSWindow and NSView methods
+	in appicon to reduce number of order front calls. The source
+	of the call is NSWindow's sendEvent:.
+
 2019-04-06  Sergii Stoian  <stoyan255@ukr.net>
 
 	* Headers/Additions/GNUstepGUI/GSDisplayServer.h,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,13 +1,7 @@
-2019-04-08  Sergii Stoian  <stoyan255@gmail.com>
-
-	* Source/NSApplication.m: (needsPanelToBecomeKey): removed superfluous
-	override - superclass (NSView) already returns `NO`.
-
 2019-04-08  Sergii Stoian  <stoyan255@ukr.net>
 
-	* Source/NSApplication.m (becomesKeyOnlyIfNeeded)
-	(needsPanelToBecomeKey): override NSWindow and NSView methods
-	in appicon to reduce number of order front calls. The source
+	* Source/NSApplication.m (becomesKeyOnlyIfNeeded): override NSWindow
+	methodin appicon to reduce number of order front calls. The source
 	of the call is NSWindow's sendEvent:.
 
 2019-04-06  Sergii Stoian  <stoyan255@ukr.net>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-04-08  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/NSApplication.m: (needsPanelToBecomeKey): removed superfluous
+	override - superclass (NSView) already returns `NO`.
+
 2019-04-08  Sergii Stoian  <stoyan255@ukr.net>
 
 	* Source/NSApplication.m (becomesKeyOnlyIfNeeded)

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -547,11 +547,6 @@ static NSSize scaledIconSizeForSize(NSSize imageSize)
   return YES;
 }
 
-- (BOOL) needsPanelToBecomeKey
-{
-  return NO;
-}
-
 - (void) concludeDragOperation: (id<NSDraggingInfo>)sender
 {
 }

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -434,6 +434,11 @@ NSApplication	*NSApp = nil;
   return NO;
 }
 
+- (BOOL) becomesKeyOnlyIfNeeded
+{
+  return YES;
+}
+
 - (BOOL) worksWhenModal
 {
   return YES;
@@ -540,6 +545,11 @@ static NSSize scaledIconSizeForSize(NSSize imageSize)
 - (BOOL) acceptsFirstMouse: (NSEvent*)theEvent
 {
   return YES;
+}
+
+- (BOOL) needsPanelToBecomeKey
+{
+  return NO;
 }
 
 - (void) concludeDragOperation: (id<NSDraggingInfo>)sender


### PR DESCRIPTION
Override NSWindow's `becomesKeyOnlyIfNeeded` and NSView `needsPanelToBecomeKey` in appicon implementation to reduce number of order front calls. The source of the calls is NSWindow's sendEvent:.
Steps to reproduce includes: double-click on appicon of inactive application, activate visible windows of inactive application (click on titlebar or window contents). 
Result: appicon flickers (redraws). It can be observed in `cairo` backend. `art` backend doesn't show appicon flickering.