### PR TITLE
Attributed key equivalents in menu

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2019-04-09  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/NSMenuItemCell.m (_keyEquivalentString): if modifier key string
+	is not defined - set key equivalent font trait: Italic for Alternate modifier
+	Bold - for Control.
+	(_sizeKeyEquivalentText:): new method to calculate string size wrt font
+	set in `_keyEquivalentString:`.
+	(drawKeyEquivalentWithFrame:inView:): draw key equivalent as attributed
+	string.
+
 2019-04-08  Sergii Stoian  <stoyan255@ukr.net>
 
 	* Source/NSApplication.m (becomesKeyOnlyIfNeeded): override NSWindow

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-04-10  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/NSMenuItemCell.m (drawKeyEquivalentWithFrame:inView:):
+	use NCell's textColor instead of check if we're disabled/enabled.
+
 2019-04-10  Sergii Stoian  <stoyan255@ukr.net>
 
 	* Source/NSMenuItemCell.m (drawKeyEquivalentWithFrame:inView:):

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-04-10  Sergii Stoian  <stoyan255@ukr.net>
+
+	* Source/NSMenuItemCell.m (drawKeyEquivalentWithFrame:inView:):
+	check if item is disabled/enabled and set color attribute for attributed
+	key equivalent string.
+
 2019-04-09  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/NSMenuItemCell.m (_keyEquivalentString): if modifier key string

--- a/Source/NSMenuItemCell.m
+++ b/Source/NSMenuItemCell.m
@@ -789,15 +789,9 @@ static NSString *commandKeyString = @"#";
           NSDictionary       *attrs;
           NSArray            *attrObjects, *attrKeys;
           NSAttributedString *aString;
-          NSColor            *aColor;
-
-          if (_cell.is_disabled)
-            aColor = [NSColor disabledControlTextColor];
-          else
-            aColor = [NSColor controlTextColor];
 
           attrObjects = [NSArray arrayWithObjects: _keyEquivalentFont,
-                                 aColor, nil];
+                                 [self textColor], nil];
           attrKeys = [NSArray arrayWithObjects: NSFontAttributeName,
                               NSForegroundColorAttributeName, nil];
           attrs = [NSDictionary dictionaryWithObjects: attrObjects

--- a/Source/NSMenuItemCell.m
+++ b/Source/NSMenuItemCell.m
@@ -787,10 +787,21 @@ static NSString *commandKeyString = @"#";
       if (_keyEquivalentFont != nil)
         {
           NSDictionary       *attrs;
+          NSArray            *attrObjects, *attrKeys;
           NSAttributedString *aString;
-          
-          attrs = [NSDictionary dictionaryWithObject: _keyEquivalentFont
-                                              forKey: NSFontAttributeName];
+          NSColor            *aColor;
+
+          if (_cell.is_disabled)
+            aColor = [NSColor disabledControlTextColor];
+          else
+            aColor = [NSColor controlTextColor];
+
+          attrObjects = [NSArray arrayWithObjects: _keyEquivalentFont,
+                                 aColor, nil];
+          attrKeys = [NSArray arrayWithObjects: NSFontAttributeName,
+                              NSForegroundColorAttributeName, nil];
+          attrs = [NSDictionary dictionaryWithObjects: attrObjects
+                                              forKeys: attrKeys];
           aString = [[NSAttributedString alloc]
                       initWithString: [self _keyEquivalentString]
                           attributes: attrs];


### PR DESCRIPTION
Fontify menu key equivalents according to the ["OpenStep User Interface Guidelines"](http://www.gnustep.org/resources/documentation/OpenStepUserInterfaceGuidelines.pdf), page 3-25, section "Application-Specific Keyboard Alternatives". Here is the example, how it looks like after applying patch:

![AttributedKeyEquivalents](https://user-images.githubusercontent.com/23114975/55816045-1c9ebe00-5afa-11e9-9c53-a2cb710216f5.png)


For info: my thoughts about key equivalents design principles for NextSpace is here https://github.com/trunkmaster/nextspace/wiki/Keyboard.