### PR TITLE
Bug33397 missing scriptability attributes

### DIFF
--- a/Headers/AppKit/NSTextStorage.h
+++ b/Headers/AppKit/NSTextStorage.h
@@ -43,6 +43,7 @@
 @class NSString;
 @class GSLayoutManager;
 @class NSFont;
+@class NSColor;
 
 /*
  * When edit:range:changeInLength: is called, it takes a mask saying

--- a/Headers/AppKit/NSTextStorage.h
+++ b/Headers/AppKit/NSTextStorage.h
@@ -188,6 +188,31 @@ enum
 */
 - (NSFont*) font;
 - (void) setFont: (NSFont*)font;
+
+/*
+ * The text storage contents as an array of attribute runs.
+ */
+- (NSArray *)attributeRuns;
+
+/*
+ * The text storage contents as an array of paragraphs.
+ */
+- (NSArray *)paragraphs;
+
+/*
+ * The text storage contents as an array of words.
+ */
+- (NSArray *)words;
+
+/*
+ * The text storage contents as an array of characters.
+ */
+- (NSArray *)characters;
+
+/*
+ * The font color used when drawing text.
+ */
+- (NSColor *)foregroundColor;
 @end
 
 /**** Notifications ****/

--- a/Source/NSTextStorage.m
+++ b/Source/NSTextStorage.m
@@ -30,6 +30,7 @@
 #import <Foundation/NSPortCoder.h>
 #import "AppKit/NSAttributedString.h"
 #import "AppKit/NSTextStorage.h"
+#import "AppKit/NSColor.h"
 #import "GNUstepGUI/GSLayoutManager.h"
 #import "GSTextStorage.h"
 
@@ -412,7 +413,19 @@ static NSNotificationCenter *nc = nil;
  */
 - (NSArray *)paragraphs
 {
-  return nil;
+  NSArray *array = [[self string] componentsSeparatedByCharactersInSet:
+			   [NSCharacterSet newlineCharacterSet]];
+  NSMutableArray *result = [NSMutableArray array];
+  NSEnumerator *en = [array objectEnumerator];
+  NSString *obj = nil;
+
+  while((obj = [en nextObject]) != nil)
+    {
+      NSTextStorage *s = AUTORELEASE([[NSTextStorage alloc] initWithString: obj]);
+      [result addObject: s];
+    }
+
+  return [NSArray arrayWithArray: result]; // make immutable
 }
 
 /*
@@ -420,7 +433,19 @@ static NSNotificationCenter *nc = nil;
  */
 - (NSArray *)words
 {
-  return nil;
+  NSArray *array = [[self string] componentsSeparatedByCharactersInSet:
+			   [NSCharacterSet whitespaceCharacterSet]];
+  NSMutableArray *result = [NSMutableArray array];
+  NSEnumerator *en = [array objectEnumerator];
+  NSString *obj = nil;
+
+  while((obj = [en nextObject]) != nil)
+    {
+      NSTextStorage *s = AUTORELEASE([[NSTextStorage alloc] initWithString: obj]);
+      [result addObject: s];
+    }
+
+  return [NSArray arrayWithArray: result]; // make immutable
 }
 
 /*
@@ -428,7 +453,19 @@ static NSNotificationCenter *nc = nil;
  */
 - (NSArray *)characters
 {
-  return nil;
+  NSMutableArray *array = [NSMutableArray array];
+  NSUInteger len = [self length];
+  NSUInteger i = 0;
+
+  for(i = 0; i < len; i++)
+    {
+      NSRange r = NSMakeRange(i,1);
+      NSString *c = [[self string] substringWithRange: r];
+      NSTextStorage *s = AUTORELEASE([[NSTextStorage alloc] initWithString: c]);
+      [array addObject: s];
+    }
+
+  return [NSArray arrayWithArray: array]; // make immutable
 }
 
 /*
@@ -436,7 +473,10 @@ static NSNotificationCenter *nc = nil;
  */
 - (NSColor *)foregroundColor
 {
-  return nil;
+  NSRange r = NSMakeRange(0, [self length]);
+  NSDictionary *d = [self fontAttributesInRange: r];
+  NSColor *c = (NSColor *)[d objectForKey: NSForegroundColorAttributeName];
+  return c;
 }
 
 @end

--- a/Source/NSTextStorage.m
+++ b/Source/NSTextStorage.m
@@ -405,7 +405,8 @@ static NSNotificationCenter *nc = nil;
  */
 - (NSArray *)attributeRuns
 {
-  return nil;
+  // Return nothing for now
+  return [NSArray array];
 }
 
 /*

--- a/Source/NSTextStorage.m
+++ b/Source/NSTextStorage.m
@@ -398,4 +398,45 @@ static NSNotificationCenter *nc = nil;
     }
 }
 
+
+/*
+ * The text storage contents as an array of attribute runs.
+ */
+- (NSArray *)attributeRuns
+{
+  return nil;
+}
+
+/*
+ * The text storage contents as an array of paragraphs.
+ */
+- (NSArray *)paragraphs
+{
+  return nil;
+}
+
+/*
+ * The text storage contents as an array of words.
+ */
+- (NSArray *)words
+{
+  return nil;
+}
+
+/*
+ * The text storage contents as an array of characters.
+ */
+- (NSArray *)characters
+{
+  return nil;
+}
+
+/*
+ * The font color used when drawing text.
+ */
+- (NSColor *)foregroundColor
+{
+  return nil;
+}
+
 @end


### PR DESCRIPTION
Merging this to fix Bug33397.  This is just a skeletal / slightly inaccurate implementation.  GNUstep doesn't support scripting.  This provides a useful implementation that allows apps which use these methods for scripting on other platforms to compile.