### PR TITLE
Incorrect string drawing fix for ART backend.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-12-09  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/NSStringDrawing.m: fixed incorrect string drawing (shortened, misplaced)
+	in ART backend. It seems that third parameter to `cache_lookup` function
+	(BOOL useScreenFonts) is valuable for ART but not for Cairo backend.
+
 2019-12-07 Fred Kiefer <FredKiefer@gmx.de>
 
 	* .travis.yml

--- a/Source/NSStringDrawing.m
+++ b/Source/NSStringDrawing.m
@@ -510,7 +510,7 @@ static void draw_in_rect(cache_t *c, NSRect rect)
   NS_DURING
     {    
       prepare_attributed_string(self);
-      c = cache_lookup(hasSize, size, NO);
+      c = cache_lookup(hasSize, size, YES);
       result = c->usedRect;
     }
   NS_HANDLER
@@ -603,7 +603,7 @@ static void draw_in_rect(cache_t *c, NSRect rect)
   NS_DURING
     {
       prepare_string(self, attrs);
-      c = cache_lookup(hasSize, size, NO);
+      c = cache_lookup(hasSize, size, YES);
       result = c->usedRect;
     }
   NS_HANDLER


### PR DESCRIPTION
It seems that third parameter to `cache_lookup` function (useScreenFonts) is valuable for ART but not for Cairo backend. So ART backend draws strings shortened or misplaced especially in popup buttons. Also some applications menus right border missed by several pixels so it rendered invisible.