### PR TITLE
Insertion point height fix for NSText* objects

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-12-11  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/GSHorizontalTypesetter.m: removed extra imports left from
+	last 2 commits.
+
 2019-12-10  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Headers/Additions/GNUstepGUI/GSLayoutManager.h,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,18 @@
 2019-12-10  Sergii Stoian  <stoyan255@gmail.com>
 
-	* Source/GSHorizontalTypesetter.m: (_addExtraLineFragment) get paragraph style and
-	font from NSLayoutManager's typing attributes. Fixes insertion point height for empty
-	text objects (NSTextView, NSTexField etc.).
+	* Headers/Additions/GNUstepGUI/GSLayoutManager.h,
+	* Source/GSLayoutManager.m: new method -typingAttributes returns default
+	typing attributes of NSTextView.
+	* Source/NSLayoutManager.m: override GSLayoutManager's -typingAttributes
+	- primitive method - provides access to _typingAttributes ivar.
+	* Source/GSHorizontalTypesetter.m: use new GSLayoutManager's
+	-typingAttributes method to get paragraph style and font of new empty text
+	container. Normally `curLayoutManager` is a NSLayoutManager object so,
+	actually, we get NSLayoutManager's _typingAttributes.
+
+	* Source/GSHorizontalTypesetter.m: (_addExtraLineFragment) get paragraph
+	style and font from NSLayoutManager's typing attributes. Fixes insertion
+	point height for empty text objects (NSTextView, NSTexField etc.).
 
 2019-12-09  Sergii Stoian  <stoyan255@gmail.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-12-10  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/GSHorizontalTypesetter.m: (_addExtraLineFragment) get paragraph style and
+	font from NSLayoutManager's typing attributes. Fixes insertion point height for empty
+	text objects (NSTextView, NSTexField etc.).
+
 2019-12-09  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/NSStringDrawing.m: fixed incorrect string drawing (shortened, misplaced)

--- a/Headers/Additions/GNUstepGUI/GSLayoutManager.h
+++ b/Headers/Additions/GNUstepGUI/GSLayoutManager.h
@@ -168,6 +168,7 @@ If characters have been edited, lengthChange has the text length delta.
 forStartingGlyphAtIndex: (NSUInteger)glyph
        characterIndex: (NSUInteger)index;
 
+- (NSDictionary *) typingAttributes;
 
 @end
 

--- a/Source/GSHorizontalTypesetter.m
+++ b/Source/GSHorizontalTypesetter.m
@@ -40,6 +40,8 @@
 #import "AppKit/NSTextAttachment.h"
 #import "AppKit/NSTextContainer.h"
 #import "AppKit/NSTextStorage.h"
+#import "AppKit/NSLayoutManager.h"
+#import "AppKit/NSTextView.h"
 #import "GNUstepGUI/GSLayoutManager.h"
 #import "GNUstepGUI/GSHorizontalTypesetter.h"
 
@@ -534,9 +536,20 @@ For bigger values the width gets ignored.
     }
   else
     {
-      // FIXME These should come from the typing attributes
-      curParagraphStyle = [NSParagraphStyle defaultParagraphStyle];
-      curFont = [NSFont userFontOfSize: 0];
+      NSLayoutManager *layoutManager = [[curTextContainer textView] layoutManager];
+
+      if (layoutManager)
+        {
+          NSDictionary *typingAttributes = layoutManager->_typingAttributes;
+          curParagraphStyle = [typingAttributes
+                                  objectForKey: NSParagraphStyleAttributeName];
+          curFont = [typingAttributes objectForKey: NSFontAttributeName];
+        }
+      else
+        {
+          curParagraphStyle = [NSParagraphStyle defaultParagraphStyle];
+          curFont = [NSFont userFontOfSize: 0];
+        }
     }
   
   line_height = [curFont defaultLineHeightForFont];

--- a/Source/GSHorizontalTypesetter.m
+++ b/Source/GSHorizontalTypesetter.m
@@ -40,8 +40,6 @@
 #import "AppKit/NSTextAttachment.h"
 #import "AppKit/NSTextContainer.h"
 #import "AppKit/NSTextStorage.h"
-#import "AppKit/NSLayoutManager.h"
-#import "AppKit/NSTextView.h"
 #import "GNUstepGUI/GSLayoutManager.h"
 #import "GNUstepGUI/GSHorizontalTypesetter.h"
 

--- a/Source/GSHorizontalTypesetter.m
+++ b/Source/GSHorizontalTypesetter.m
@@ -536,20 +536,10 @@ For bigger values the width gets ignored.
     }
   else
     {
-      NSLayoutManager *layoutManager = [[curTextContainer textView] layoutManager];
-
-      if (layoutManager)
-        {
-          NSDictionary *typingAttributes = layoutManager->_typingAttributes;
-          curParagraphStyle = [typingAttributes
-                                  objectForKey: NSParagraphStyleAttributeName];
-          curFont = [typingAttributes objectForKey: NSFontAttributeName];
-        }
-      else
-        {
-          curParagraphStyle = [NSParagraphStyle defaultParagraphStyle];
-          curFont = [NSFont userFontOfSize: 0];
-        }
+      NSDictionary *typingAttributes = [curLayoutManager typingAttributes];
+      curParagraphStyle = [typingAttributes
+                            objectForKey: NSParagraphStyleAttributeName];
+      curFont = [typingAttributes objectForKey: NSFontAttributeName];
     }
   
   line_height = [curFont defaultLineHeightForFont];

--- a/Source/GSLayoutManager.m
+++ b/Source/GSLayoutManager.m
@@ -34,6 +34,7 @@
 #import "AppKit/NSAttributedString.h"
 #import "AppKit/NSTextStorage.h"
 #import "AppKit/NSTextContainer.h"
+#import "AppKit/NSTextView.h"
 
 /* just for NSAttachmentCharacter */
 #import "AppKit/NSTextAttachment.h"
@@ -3280,7 +3281,13 @@ forStartingGlyphAtIndex: (NSUInteger)glyph
       else if (attributeTag == NSGlyphAttributeBidiLevel)
         g->bidilevel = anInt;
     }
- }
+}
+
+- (NSDictionary *) typingAttributes
+{
+  return [NSTextView defaultTypingAttributes];
+}
+
 
 /*
  * NSCoding protocol

--- a/Source/NSLayoutManager.m
+++ b/Source/NSLayoutManager.m
@@ -3017,6 +3017,11 @@ no_soft_invalidation:
     }
 }
 
+- (NSDictionary *) typingAttributes
+{
+  return _typingAttributes;
+}
+
 @end
 
 


### PR DESCRIPTION
Initial intention was to fix insertion point height in Login.app text fields. These text fields use font larger than default 12-point system font. While text field is empty, insertion point drawn as for 12-point font size. After first character was entered insertion point get correct size for large font.

This change fixes insertion point height no matter if text object is empty or not.