### PR TITLE
Miniwindow image and title fixes.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-12-12  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/NSFont.m (smallSystemFontSize): return 10 as default value.
+	Update documention comment regarding default values for NSMiniFontSize
+	ans NSSmallFontSize.
+
 2019-12-11  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/NSWindow.m

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,16 @@
 2019-12-11  Sergii Stoian  <stoyan255@gmail.com>
 
+	* Source/NSWindow.m
+	(initialize): use MiniWindowTile image for miniwindow tile.
+	(drawRect:): adjusted position of title cell to fit tile image.
+	(setTitle:): disable drawing of title cell background;
+	use NSMiniControlSize font size for miniwindow title cell.
+
+	* Source/NSFont.m (systemFontSizeForControlSize:): increased default font
+	size for NSMiniControlSize.
+
+2019-12-11  Sergii Stoian  <stoyan255@gmail.com>
+
 	* Source/GSHorizontalTypesetter.m: removed extra imports left from
 	last 2 commits.
 

--- a/Source/NSFont.m
+++ b/Source/NSFont.m
@@ -166,10 +166,10 @@ keyForFont(NSString *name, const CGFloat *matrix,
     <item>NSFontSize                12 (System Font Size)</item>
     <item>NSLabelFontSize           (none)</item>
     <item>NSMenuFontSize            (none)</item>
-    <item>NSMiniFontSize            6</item>
+    <item>NSMiniFontSize            8</item>
     <item>NSMessageFontSize         (none)</item>
     <item>NSPaletteFontSize         (none)</item>
-    <item>NSSmallFontSize           9</item>
+    <item>NSSmallFontSize           10</item>
     <item>NSTitleBarFontSize        (none)</item>
     <item>NSToolTipsFontSize        (none)</item>
     <item>NSUserFixedPitchFontSize  (none)</item>
@@ -656,7 +656,7 @@ static void setNSFont(NSString *key, NSFont *font)
   
   if (fontSize == 0)
     {
-      fontSize = 9;
+      fontSize = 10;
     }
 
   return fontSize;

--- a/Source/NSFont.m
+++ b/Source/NSFont.m
@@ -684,7 +684,7 @@ static void setNSFont(NSString *key, NSFont *font)
   
           if (fontSize == 0)
             {
-              fontSize = 6;
+              fontSize = 8;
             }
           
           return fontSize;

--- a/Source/NSWindow.m
+++ b/Source/NSWindow.m
@@ -481,7 +481,7 @@ static NSSize scaledIconSizeForSize(NSSize imageSize)
   
   iconSize = GSGetIconSize();
   
-  tileImage = [[GSCurrentServer() iconTileImage] copy];
+  tileImage = [[NSImage imageNamed:@"common_MiniWindowTile"] copy];
   [tileImage setScalesWhenResized: YES];
   [tileImage setSize: iconSize];
   
@@ -514,8 +514,8 @@ static NSSize scaledIconSizeForSize(NSSize imageSize)
                                  iconSize.width - ((iconSize.width / 8) * 2),
                                  iconSize.height - ((iconSize.height / 8) * 2))
               inView: self];
-  [titleCell drawWithFrame: NSMakeRect(1, iconSize.height - 12,
-                                       iconSize.width - 2, 11)
+  [titleCell drawWithFrame: NSMakeRect(3, iconSize.height - 13,
+                                       iconSize.width - 6, 10)
                     inView: self];
 }
 
@@ -600,15 +600,17 @@ static NSSize scaledIconSizeForSize(NSSize imageSize)
 {
   if (titleCell == nil)
     {
+      CGFloat fontSize;
+      
       titleCell = [[NSTextFieldCell alloc] initTextCell: aString];
       [titleCell setSelectable: NO];
       [titleCell setEditable: NO];
       [titleCell setBordered: NO];
       [titleCell setAlignment: NSCenterTextAlignment];
-      [titleCell setDrawsBackground: YES];
-      [titleCell setBackgroundColor: [NSColor blackColor]];
+      [titleCell setDrawsBackground: NO];
       [titleCell setTextColor: [NSColor whiteColor]];
-      [titleCell setFont: [NSFont systemFontOfSize: 8]];
+      fontSize = [NSFont systemFontSizeForControlSize: NSMiniControlSize];
+      [titleCell setFont: [NSFont systemFontOfSize: fontSize]];
     }
   else
     {


### PR DESCRIPTION
I've made some tweaks to miniwindow:
1. Made use of common_MiniWindowTile image instead of appicon tile image.
2. Title font size can now be configured with `NSMiniFontSize` setting in `NSGlobalDomain`.
Also I've increased default font size for NSMiniControlSize if defaults missed NSMiniFontSize setting.

Here are the screenshots to visialize changes. I placed 2 mininwindows side by side: to the left is a GNUstep miniwindow (with UNIX icon), to the right - WindowMaker miniwindow (with emacs icon).
To see the differences look at left and top border of miniwindow title and font size of title text.

Before the change:
![Minwindow-0](https://user-images.githubusercontent.com/23114975/70622718-32cec200-1c25-11ea-8b33-d852343401cc.png)

After the change:
![Minwindow-1](https://user-images.githubusercontent.com/23114975/70622735-3b26fd00-1c25-11ea-8f43-9e82f8aa7013.png)


