### PR TITLE
Scroller border drawing fix in NSScrollView

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 	* Source/GSThemeDrawing.m (drawScrollViewRect:inView:): fixed scroller
 	border positionning and length - do not overlap border if any.
+	Use [self sizeForBorderType: borderType] to determine border width.
 
 2019-12-12  Sergii Stoian  <stoyan255@gmail.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-12-17  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/GSThemeDrawing.m (drawScrollViewRect:inView:): fixed scroller
+	border positionning and length - do not overlap border if any.
+
 2019-12-12  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/NSFont.m (smallSystemFontSize): return 10 as default value.

--- a/Source/GSThemeDrawing.m
+++ b/Source/GSThemeDrawing.m
@@ -2597,6 +2597,7 @@ typedef enum {
   NSColor	*color;
   NSString	*name;
   NSBorderType   borderType = [scrollView borderType];
+  CGFloat        borderWidth = 0;
   NSRect         bounds = [view bounds];
   BOOL hasInnerBorder = ![[NSUserDefaults standardUserDefaults]
 			   boolForKey: @"GSScrollViewNoInnerBorder"];
@@ -2624,14 +2625,17 @@ typedef enum {
 	case NSLineBorder:
 	  [color set];
 	  NSFrameRect(bounds);
+          borderWidth = 1;
 	  break;
 	  
 	case NSBezelBorder:
 	  [theme drawGrayBezel: bounds withClip: rect];
+          borderWidth = 2;
 	  break;
 	  
 	case NSGrooveBorder:
 	  [theme drawGroove: bounds withClip: rect];
+          borderWidth = 2;
 	  break;
 	}
     }
@@ -2665,8 +2669,8 @@ typedef enum {
 	    {
               xpos = [vertScroller frame].origin.x + scrollerWidth;
 	    }
-          NSRectFill(NSMakeRect(xpos, [vertScroller frame].origin.y - 1.0, 
-                                1.0, scrollerHeight + 1.0));
+          NSRectFill(NSMakeRect(xpos, [vertScroller frame].origin.y, 
+                                1.0, scrollerHeight - (borderWidth * 2)));
 	}
 
       if ([scrollView hasHorizontalScroller])
@@ -2688,8 +2692,8 @@ typedef enum {
 	    {
 	      ypos = scrollerY + scrollerWidth + 1.0;
 	    }
-          NSRectFill(NSMakeRect([horizScroller frame].origin.x - 1.0, ypos,
-                                scrollerLength + 1.0, 1.0));
+          NSRectFill(NSMakeRect([horizScroller frame].origin.x, ypos,
+                                scrollerLength - (borderWidth * 2), 1.0));
 	}
     }
 }

--- a/Source/GSThemeDrawing.m
+++ b/Source/GSThemeDrawing.m
@@ -2597,7 +2597,6 @@ typedef enum {
   NSColor	*color;
   NSString	*name;
   NSBorderType   borderType = [scrollView borderType];
-  CGFloat        borderWidth = 0;
   NSRect         bounds = [view bounds];
   BOOL hasInnerBorder = ![[NSUserDefaults standardUserDefaults]
 			   boolForKey: @"GSScrollViewNoInnerBorder"];
@@ -2625,17 +2624,14 @@ typedef enum {
 	case NSLineBorder:
 	  [color set];
 	  NSFrameRect(bounds);
-          borderWidth = 1;
 	  break;
 	  
 	case NSBezelBorder:
 	  [theme drawGrayBezel: bounds withClip: rect];
-          borderWidth = 2;
 	  break;
 	  
 	case NSGrooveBorder:
 	  [theme drawGroove: bounds withClip: rect];
-          borderWidth = 2;
 	  break;
 	}
     }
@@ -2650,6 +2646,7 @@ typedef enum {
       NSScroller *vertScroller = [scrollView verticalScroller];
       NSScroller *horizScroller = [scrollView horizontalScroller];
       CGFloat scrollerWidth = [NSScroller scrollerWidth];
+      CGFloat borderWidth = [self sizeForBorderType: borderType].width;
 
       [color set];
 


### PR DESCRIPTION
Fixes scroller border positioning and length - do not overlap border if any. Plus, less magic numbers - more maintainable code.