### PR TITLE
NSBrowser column positionning and size calculation fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-12-18  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/NSBrowser.m (frameOfColumn:): shift up column only for browser
+	with separated sparated columns layout.
+	(tile): fix column height calculation; moved sanity check of column
+	height closer to calculation; removed code that duplicates code below.
+
 2019-12-17  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/NSScrollView.m (tile): tweak location and height of vertical

--- a/Source/NSBrowser.m
+++ b/Source/NSBrowser.m
@@ -1974,10 +1974,10 @@ static BOOL browserUseBezels;
 	  else
 	    rect.origin.y = scrollerWidth + bezelBorderSize.width;
 	}
-      else
-	{
-	  rect.origin.y += bezelBorderSize.width;
-	}
+      else if (!_separatesColumns)
+        {
+          rect.origin.y += bezelBorderSize.width;
+        }
     }
   else
     {
@@ -2105,11 +2105,16 @@ static BOOL browserUseBezels;
   else
     {
       _scrollerRect = NSZeroRect;
-      _columnSize.height -= 2 * bezelBorderSize.width;
+      if (!_separatesColumns)
+        _columnSize.height -= 2 * bezelBorderSize.width;
     }
 
+  if (_columnSize.height < 0)
+    _columnSize.height = 0;
+  
   num = _lastVisibleColumn - _firstVisibleColumn + 1;
 
+  // Column count
   if (_minColumnWidth > 0)
     {
       CGFloat colWidth = _minColumnWidth + scrollerWidth;
@@ -2130,6 +2135,7 @@ static BOOL browserUseBezels;
   if (_maxVisibleColumns > 0 && columnCount > _maxVisibleColumns)
     columnCount = _maxVisibleColumns;
 
+  // Create extra columns
   if (columnCount != num)
     {
       if (num > 0)
@@ -2149,7 +2155,7 @@ static BOOL browserUseBezels;
       _lastVisibleColumn = _firstVisibleColumn + columnCount - 1;
     }
 
-  // Columns
+  // Column width
   if (_separatesColumns)
     frameWidth = _frame.size.width - ((columnCount - 1) * browserColumnSeparation);
   else
@@ -2158,9 +2164,6 @@ static BOOL browserUseBezels;
 
   _columnSize.width = (int)(frameWidth / (CGFloat)columnCount);
 
-  if (_columnSize.height < 0)
-    _columnSize.height = 0;
-  
   for (i = _firstVisibleColumn; i <= _lastVisibleColumn; i++)
     {
       NSBrowserColumn *bc;
@@ -2177,11 +2180,6 @@ static BOOL browserUseBezels;
           NSLog(@"NSBrowser error, sc != [bc columnScrollView]");
           return;
         }
-
-      {
-	NSBorderType bt = _separatesColumns ? NSBezelBorder : NSNoBorder;
-	[sc setBorderType: bt];
-      }
 
       [sc setBorderType: [self _resolvedBorderType]];
       [sc setFrame: [self frameOfColumn: i]];


### PR DESCRIPTION
There is difference in column positionning with and without horizontal scroller in separated columns mode.