### PR TITLE
NSPopUpButton's popup menu in pulldown mode displaying fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+2019-12-19  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/NSMenuView.m (setHighlightedItemIndex:): do not highlight first
+	item for pulldown popup button's menu.
+	(sizeToFit): removed commented useless code; fixed formatting.
+	(rectOfItemAtIndex:): draw first item cell of pulldown popup menu.
+	(setWindowFrameForAttachingToRect:onScreen:preferredEdge:popUpSelectedItem:):
+	remove useless (was used for old-style popup menu) positionning code for
+	popup menu. Check if owning popup is not pulldown before vertical
+	position correction.
+
+	* Source/NSPopUpButtonCell.m (attachPopUpWithFrame:inView:): make setting
+	selected item code more generic for pulldown and non-pulldown button.
+	Fixed formatting.
+
 2019-12-18  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/NSBrowser.m (frameOfColumn:): shift up column only for browser

--- a/Source/NSMenuView.m
+++ b/Source/NSMenuView.m
@@ -405,7 +405,15 @@ static float menuBarHeight = 0.0;
     }
 
   // Set ivar to new index.
-  _highlightedItemIndex = index;
+  if ([_attachedMenu _ownedByPopUp] &&
+      index == 0 && [[_attachedMenu _owningPopUp] pullsDown])
+    {
+      _highlightedItemIndex = -1;
+    }
+  else
+    {  
+      _highlightedItemIndex = index;
+    }
 
   // Highlight new
   if (_highlightedItemIndex != -1) 
@@ -764,15 +772,8 @@ static float menuBarHeight = 0.0;
       unsigned i;
       unsigned howMany = [_itemCells count];
       float currentX = HORIZONTAL_MENU_LEFT_PADDING;
-//      NSRect scRect = [[NSScreen mainScreen] frame];
-
       GSIArrayRemoveAllItems(cellRects);
 
-/*
-      scRect.size.height = [NSMenuView menuBarHeight];
-      [self setFrameSize: scRect.size];
-      _cellSize.height = scRect.size.height;
-*/
       _cellSize.height = [NSMenuView menuBarHeight];
 
       if (howMany && isPullDown)
@@ -967,10 +968,9 @@ static float menuBarHeight = 0.0;
         }
 
       [self setFrameSize: NSMakeSize(_cellSize.width + _leftBorderOffset, 
-                                     [self totalHeight] 
-                                     + menuBarHeight)];
-      [_titleView setFrame: NSMakeRect (0, [self totalHeight],
-                                        NSWidth (_bounds), menuBarHeight)];
+                                     [self totalHeight] + menuBarHeight)];
+      [_titleView setFrame: NSMakeRect(0, [self totalHeight],
+                                       NSWidth (_bounds), menuBarHeight)];
     }
   _needsSizing = NO;
 }
@@ -1047,13 +1047,6 @@ static float menuBarHeight = 0.0;
     {
       [self sizeToFit];
     } 
-
-  // The first item of a pull down menu holds its title and isn't displayed
-  if (index == 0 && [_attachedMenu _ownedByPopUp] &&
-      [[_attachedMenu _owningPopUp] pullsDown])
-    {
-      return NSZeroRect;
-    }
 
   if (_horizontal == YES)
     {
@@ -1212,37 +1205,6 @@ static float menuBarHeight = 0.0;
   if (_needsSizing)
     [self sizeToFit];
 
-  /* FIXME: Perhaps all of this belongs into NSPopupButtonCell and
-     should be used to determine the proper screenRect to pass on into
-     this method.
-   */
-  /* certain style of pulldowns don't want sizing on the _cellSize.height */
-  if ([_attachedMenu _ownedByPopUp])
-    {
-      NSPopUpButtonCell *bcell;
-
-      bcell = [_attachedMenu _owningPopUp];
-      if ([bcell pullsDown])
-        {
-          if ([bcell isBordered] == NO)
-            {
-              growHeight = NO;
-            }
-          else
-            {
-              switch ([bcell bezelStyle])
-                {
-                  case NSRegularSquareBezelStyle:
-                  case NSShadowlessSquareBezelStyle:
-                    growHeight = NO;
-                    break;
-                  default:
-                    break;
-                }
-            }
-        }
-    }
-
   cellFrame = screenRect;
 
   /*
@@ -1296,22 +1258,11 @@ static float menuBarHeight = 0.0;
           popUpFrame.size.width += borderOffsetInBaseCoords;
           popUpFrame.origin.x -= borderOffsetInBaseCoords;
 
-	  // If the menu is a pull down menu the first item, which would
-	  // appear at the top of the menu, holds the title and is omitted
-	  if ([_attachedMenu _ownedByPopUp])
-	    {
-	      if ([[_attachedMenu _owningPopUp] pullsDown])
-		{
-		  popUpFrame.size.height -= cellFrame.size.height;
-		  popUpFrame.origin.y += cellFrame.size.height;
-		}
-	    }
-
           // Compute position for popups, if needed
-          if (selectedItemIndex != -1) 
+          if (selectedItemIndex != -1
+              && [[_attachedMenu _owningPopUp] pullsDown] == NO)
             {
-              popUpFrame.origin.y
-                  += cellFrame.size.height * selectedItemIndex;
+              popUpFrame.origin.y += cellFrame.size.height * selectedItemIndex;
             }
         }
       else
@@ -1319,23 +1270,14 @@ static float menuBarHeight = 0.0;
           f = cellFrame.size.width * (items - 1);
           popUpFrame.size.width += f;
 
-	  // If the menu is a pull down menu the first item holds the
-	  // title and is omitted
-	  if ([_attachedMenu _ownedByPopUp])
-	    {
-	      if ([[_attachedMenu _owningPopUp] pullsDown])
-		{
-		  popUpFrame.size.width -= cellFrame.size.width;
-		}
-	    }
-
           // Compute position for popups, if needed
-          if (selectedItemIndex != -1) 
+          if (selectedItemIndex != -1
+              && [[_attachedMenu _owningPopUp] pullsDown] == NO)
             {
               popUpFrame.origin.x -= cellFrame.size.width * selectedItemIndex;
             }
         }
-    }  
+    }
   
   // Update position, if needed, using the preferredEdge
   if (selectedItemIndex == -1)

--- a/Source/NSPopUpButtonCell.m
+++ b/Source/NSPopUpButtonCell.m
@@ -905,7 +905,7 @@ static NSImage *_pbc_image[5];
   NSNotificationCenter  *nc = [NSNotificationCenter defaultCenter];
   NSWindow              *cvWin = [controlView window];
   NSMenuView            *mr = [_menu menuRepresentation];
-  NSInteger                   selectedItem;
+  NSInteger             selectedItem;
 
   [nc postNotificationName: NSPopUpButtonCellWillPopUpNotification
                     object: self];
@@ -918,14 +918,17 @@ static NSImage *_pbc_image[5];
   cellFrame.origin = [cvWin convertBaseToScreen: cellFrame.origin];
 
   if (_pbcFlags.pullsDown)
-    selectedItem = -1;
+    {
+      selectedItem = -1;
+    }
   else
     {
       selectedItem = [self indexOfSelectedItem];
-      if (selectedItem == -1)
-	{
-	  selectedItem = 0;
-	}
+    }
+
+  if (selectedItem == -1)
+    {
+      selectedItem = 0;
     }
 
   if (selectedItem > 0)
@@ -953,9 +956,9 @@ static NSImage *_pbc_image[5];
 		       selectedItem: selectedItem];
 
   [nc addObserver: self
-      selector: @selector(_handleNotification:)
-      name: NSMenuDidSendActionNotification
-      object: _menu];
+         selector: @selector(_handleNotification:)
+             name: NSMenuDidSendActionNotification
+           object: _menu];
 }
 
 /**


### PR DESCRIPTION
I've changed the way how poup menu is displayed when popup button operates in pulldown mode. Before this change popup menu doesn't display first item and was placed to the bottom edge of popup button. Although popup menu can't draw dark gray border around poup button.

With this change pulldown menu draws exatrly the same way as in normal mode except first item is not highlighted. So now popup menu looks visually consistent no matter what mode it opeartes in. 
Plus, NSMenuView contains less popup button specific code.