### PR TITLE
NSDataAsset branch

### DIFF
--- a/Headers/AppKit/AppKit.h
+++ b/Headers/AppKit/AppKit.h
@@ -71,6 +71,7 @@
 #import <AppKit/NSControl.h>
 #import <AppKit/NSCursor.h>
 #import <AppKit/NSCustomImageRep.h>
+#import <AppKit/NSDataAsset.h>
 #import <AppKit/NSDataLink.h>
 #import <AppKit/NSDataLinkManager.h>
 #import <AppKit/NSDataLinkPanel.h>

--- a/Headers/AppKit/NSDataAsset.h
+++ b/Headers/AppKit/NSDataAsset.h
@@ -1,0 +1,68 @@
+/* Definition of class NSDataAsset
+   Copyright (C) 2020 Free Software Foundation, Inc.
+   
+   By: Gregory John Casamento
+   Date: Fri Jan 17 10:25:34 EST 2020
+
+   This file is part of the GNUstep Library.
+   
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+   
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+   
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free
+   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110 USA.
+*/
+
+#ifndef _NSDataAsset_h_GNUSTEP_GUI_INCLUDE
+#define _NSDataAsset_h_GNUSTEP_GUI_INCLUDE
+
+#import <Foundation/NSObject.h>
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
+
+#if	defined(__cplusplus)
+extern "C" {
+#endif
+
+@class NSData, NSBundle, NSString; 
+  
+typedef NSString* NSDataAssetName;
+  
+@interface NSDataAsset : NSObject <NSCopying>
+{
+  NSString *_name;
+  NSBundle *_bundle;
+  NSData *_data;
+  NSString *_typeIdentifier;
+}
+  
+// Initializing the Data Asset
+- (instancetype) initWithName: (NSString *)name;
+- (instancetype) initWithName: (NSString *)name bundle: (NSBundle *)bundle;
+
+// Accessing data...
+- (NSData *) data;
+
+// Getting data asset information
+- (NSString *) name;
+- (NSString *) typeIdentifier;
+
+@end
+
+#if	defined(__cplusplus)
+}
+#endif
+
+#endif	/* GS_API_MACOSX */
+
+#endif	/* _NSDataAsset_h_GNUSTEP_GUI_INCLUDE */
+

--- a/Headers/AppKit/NSDataAsset.h
+++ b/Headers/AppKit/NSDataAsset.h
@@ -39,21 +39,21 @@ typedef NSString* NSDataAssetName;
   
 @interface NSDataAsset : NSObject <NSCopying>
 {
-  NSString *_name;
+  NSDataAssetName _name;
   NSBundle *_bundle;
   NSData *_data;
   NSString *_typeIdentifier;
 }
   
 // Initializing the Data Asset
-- (instancetype) initWithName: (NSString *)name;
-- (instancetype) initWithName: (NSString *)name bundle: (NSBundle *)bundle;
+- (instancetype) initWithName: (NSDataAssetName)name;
+- (instancetype) initWithName: (NSDataAssetName)name bundle: (NSBundle *)bundle;
 
 // Accessing data...
 - (NSData *) data;
 
 // Getting data asset information
-- (NSString *) name;
+- (NSDataAssetName) name;
 - (NSString *) typeIdentifier;
 
 @end

--- a/MISSING
+++ b/MISSING
@@ -14,7 +14,6 @@ MISSING HEADERS
 > NSCollectionViewLayout.h
 > NSCollectionViewTransitionLayout.h
 > NSColorSampler.h
-> NSDataAsset.h
 > NSDictionaryController.h
 > NSDiffableDataSource.h
 > NSDraggingItem.h

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -89,6 +89,7 @@ NSController.m \
 NSCursor.m \
 NSCustomImageRep.m \
 NSCustomTouchBarItem.m \
+NSDataAsset.m \
 NSDataLink.m \
 NSDataLinkManager.m \
 NSDataLinkPanel.m \
@@ -375,6 +376,7 @@ NSController.h \
 NSCursor.h \
 NSCustomImageRep.h \
 NSCustomTouchBarItem.h \
+NSDataAsset.h \
 NSDataLink.h \
 NSDataLinkManager.h \
 NSDataLinkPanel.h \

--- a/Source/NSDataAsset.m
+++ b/Source/NSDataAsset.m
@@ -1,0 +1,85 @@
+/* Implementation of class NSDataAsset
+   Copyright (C) 2019 Free Software Foundation, Inc.
+   
+   By: Gregory John Casamento
+   Date: Fri Jan 17 10:25:34 EST 2020
+
+   This file is part of the GNUstep Library.
+   
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+   
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+   
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free
+   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110 USA.
+*/
+
+#import <AppKit/NSDataAsset.h>
+#import <Foundation/NSBundle.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSData.h>
+
+@implementation NSDataAsset
+
+// Initializing the Data Asset
+- (instancetype) initWithName: (NSString *)name
+{
+  return [self initWithName: name bundle: nil];
+}
+
+- (instancetype) initWithName: (NSString *)name bundle: (NSBundle *)bundle
+{
+  self = [super init];
+  if (self != nil)
+    {
+      ASSIGNCOPY(_name, name);
+      ASSIGN(_bundle, bundle);
+      _data = nil;
+      _typeIdentifier = nil;
+    }
+  return self;
+}
+
+- (void) dealloc
+{
+  RELEASE(_name);
+  RELEASE(_bundle);
+  RELEASE(_data);
+  RELEASE(_typeIdentifier);
+  [super dealloc];
+}
+
+- (id) copyWithZone: (NSZone *)zone
+{
+  NSDataAsset *copy = [[NSDataAsset allocWithZone: zone] initWithName: _name bundle: _bundle];
+  ASSIGNCOPY(copy->_data, _data);
+  ASSIGNCOPY(copy->_typeIdentifier, _typeIdentifier);
+  return copy;
+}
+
+// Accessing data...
+- (NSData *) data
+{
+  return _data;
+}
+
+// Getting data asset information
+- (NSString *) name
+{
+  return _name;
+}
+
+- (NSString *) typeIdentifier
+{
+  return _typeIdentifier;
+}
+@end
+

--- a/Source/NSDataAsset.m
+++ b/Source/NSDataAsset.m
@@ -1,5 +1,5 @@
 /* Implementation of class NSDataAsset
-   Copyright (C) 2019 Free Software Foundation, Inc.
+   Copyright (C) 2020 Free Software Foundation, Inc.
    
    By: Gregory John Casamento
    Date: Fri Jan 17 10:25:34 EST 2020

--- a/Source/NSDataAsset.m
+++ b/Source/NSDataAsset.m
@@ -22,20 +22,20 @@
    Boston, MA 02110 USA.
 */
 
-#import <AppKit/NSDataAsset.h>
 #import <Foundation/NSBundle.h>
 #import <Foundation/NSString.h>
 #import <Foundation/NSData.h>
+#import <AppKit/NSDataAsset.h>
 
 @implementation NSDataAsset
 
 // Initializing the Data Asset
-- (instancetype) initWithName: (NSString *)name
+- (instancetype) initWithName: (NSDataAssetName)name
 {
   return [self initWithName: name bundle: nil];
 }
 
-- (instancetype) initWithName: (NSString *)name bundle: (NSBundle *)bundle
+- (instancetype) initWithName: (NSDataAssetName)name bundle: (NSBundle *)bundle
 {
   self = [super init];
   if (self != nil)
@@ -72,7 +72,7 @@
 }
 
 // Getting data asset information
-- (NSString *) name
+- (NSDataAssetName) name
 {
   return _name;
 }


### PR DESCRIPTION
This class provides a way to pull data assets (from *.xcasset catalogs) for macOS.  For GNUstep this class is pretty much a placeholder because this functionality doesn't really exist in GNUstep.  I am doing further research to see what can be done to implement this, but for now it is a placeholder.