### PR TITLE
Keep menu inside visible screen frame.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2020-01-31  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/GSTitleView.m (mouseDown:): limit menu movement to screen
+	frame for top/left/right edges. Menu can be moved to the bottom until
+	title is completely visible.
+
 2020-01-27  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/NSWindow.m (applicationDidChangeScreenParameters): take into

--- a/Source/GSTitleView.m
+++ b/Source/GSTitleView.m
@@ -249,7 +249,7 @@
   // Define move constrains for menu
   if (_ownedByMenu)
     {
-      NSRect screenFrame = [[NSScreen mainScreen] frame];
+      NSRect screenFrame = [[_window screen] frame];
       leftLimit = screenFrame.origin.x;
       topLimit = NSMaxY(screenFrame) - [_window frame].size.height;
       rightLimit = NSMaxX(screenFrame) - [_window frame].size.width;

--- a/Source/GSTitleView.m
+++ b/Source/GSTitleView.m
@@ -2,7 +2,7 @@
 
    Copyright (C) 2003 Free Software Foundation, Inc.
 
-   Author: Serg Stoyan <stoyan@on.com.ua>
+   Author: Sergii Stoian <stoyan255@gmail.com>
    Date:   Mar 2003
    
    This file is part of the GNUstep GUI Library.
@@ -41,6 +41,7 @@
 #import "AppKit/NSStringDrawing.h"
 #import "AppKit/NSView.h"
 #import "AppKit/NSWindow.h"
+#import "AppKit/NSScreen.h"
 
 #import "GNUstepGUI/GSTitleView.h"
 #import "GNUstepGUI/GSTheme.h"
@@ -238,8 +239,23 @@
   NSDate   *theDistantFuture = [NSDate distantFuture];
   NSPoint  startWindowOrigin;
   NSPoint  endWindowOrigin;
+  CGFloat  leftLimit;
+  CGFloat  topLimit;
+  CGFloat  rightLimit;
+  CGFloat  bottomLimit;
 
   NSDebugLLog (@"NSMenu", @"Mouse down in title!");
+
+  // Define move constrains for menu
+  if (_ownedByMenu)
+    {
+      NSRect screenFrame = [[NSScreen mainScreen] frame];
+      leftLimit = screenFrame.origin.x;
+      topLimit = NSMaxY(screenFrame) - [_window frame].size.height;
+      rightLimit = NSMaxX(screenFrame) - [_window frame].size.width;
+      bottomLimit = screenFrame.origin.y -
+        ([_window frame].size.height - [self frame].size.height);
+    }
 
   // Remember start position of window
   startWindowOrigin = [_window frame].origin;
@@ -275,6 +291,16 @@
               origin.y += (location.y - lastLocation.y);
               if (_ownedByMenu)
                 {
+                  if (origin.x <= leftLimit)
+                    origin.x = leftLimit;
+                  else if (origin.x >= rightLimit)
+                    origin.x = rightLimit;
+
+                  if (origin.y >= topLimit)
+                    origin.y = topLimit;
+                  else if (origin.y <= bottomLimit)
+                    origin.y = bottomLimit;
+                 
                   [_owner nestedSetFrameOrigin: origin];
                 }
               else

--- a/Source/GSTitleView.m
+++ b/Source/GSTitleView.m
@@ -239,22 +239,30 @@
   NSDate   *theDistantFuture = [NSDate distantFuture];
   NSPoint  startWindowOrigin;
   NSPoint  endWindowOrigin;
-  CGFloat  leftLimit;
-  CGFloat  topLimit;
-  CGFloat  rightLimit;
-  CGFloat  bottomLimit;
+  NSRect   screenFrame = NSZeroRect;
+  CGFloat  leftLimit = -1.0;
+  CGFloat  topLimit = -1.0 ;
+  CGFloat  rightLimit = -1.0;
+  CGFloat  bottomLimit = 0.0;
 
   NSDebugLLog (@"NSMenu", @"Mouse down in title!");
 
   // Define move constrains for menu
   if (_ownedByMenu)
     {
-      NSRect screenFrame = [[_window screen] frame];
-      leftLimit = screenFrame.origin.x;
-      topLimit = NSMaxY(screenFrame) - [_window frame].size.height;
-      rightLimit = NSMaxX(screenFrame) - [_window frame].size.width;
-      bottomLimit = screenFrame.origin.y -
-        ([_window frame].size.height - [self frame].size.height);
+      NSRect   windowFrame;
+      NSScreen *screen;
+
+      if (_window && (screen = [_window screen]))
+        {
+          windowFrame = [_window frame];
+          screenFrame = [screen frame];
+          leftLimit = screenFrame.origin.x;
+          topLimit = NSMaxY(screenFrame) - windowFrame.size.height;
+          rightLimit = NSMaxX(screenFrame) - windowFrame.size.width;
+          bottomLimit = screenFrame.origin.y -
+            (windowFrame.size.height - [self frame].size.height);
+        }
     }
 
   // Remember start position of window
@@ -291,15 +299,18 @@
               origin.y += (location.y - lastLocation.y);
               if (_ownedByMenu)
                 {
-                  if (origin.x <= leftLimit)
-                    origin.x = leftLimit;
-                  else if (origin.x >= rightLimit)
-                    origin.x = rightLimit;
+                  if (screenFrame.size.width > 0 && screenFrame.size.height > 0)
+                    {
+                      if (origin.x <= leftLimit)
+                        origin.x = leftLimit;
+                      else if (origin.x >= rightLimit)
+                        origin.x = rightLimit;
 
-                  if (origin.y >= topLimit)
-                    origin.y = topLimit;
-                  else if (origin.y <= bottomLimit)
-                    origin.y = bottomLimit;
+                      if (origin.y >= topLimit)
+                        origin.y = topLimit;
+                      else if (origin.y <= bottomLimit)
+                        origin.y = bottomLimit;
+                    }
                  
                   [_owner nestedSetFrameOrigin: origin];
                 }


### PR DESCRIPTION
Limit menu movement to screen frame for top/left/right edges. 
Menu can be moved to the bottom of the screen while title is completely visible.

Prerequisite: backend should be compiled with XRandR support for per-monitor limits.

Side effects:
- user can easily place main application menu to default top-left position of the screen;
- no usability confusion after implementation of "main menu follows key window" on multi-monitor setups - menu won't cross monitors boundaries.