### PR TITLE
Window placement fix on screen change

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,8 +2,8 @@
 
 	* Source/NSWindow.m (applicationDidChangeScreenParameters:):
 	Call backend's `placewindow::` directly because our origin in OpenStep
-        coordinates might left unchanged and `setFrame:display:` has check
-        for it.
+	coordinates might left unchanged and `setFrame:display:` has check
+	for it.
 
 2020-02-28  Sergii Stoian  <stoyan255@gmail.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-03-05  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/NSWindow.m (applicationDidChangeScreenParameters:):
+	Call backend's `placewindow::` directly because our origin in OpenStep
+        coordinates might left unchanged and `setFrame:display:` has check
+        for it.
+
 2020-02-28  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/NSWindow.m (center): always center window on main screen -

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-02-26  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/NSWindow.m (sendEvent:): removed usage of extra local variables
+	in GSAppKitWindowMoved code block.
+
 2020-02-23  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/NSWindow.m

--- a/Source/NSScreen.m
+++ b/Source/NSScreen.m
@@ -73,6 +73,31 @@ static NSMutableArray *screenArray = nil;
   DESTROY(screenArray);
 }
 
+/* 
+   Display server's `screenList` method (back) returns `screens` array that
+   contains monitor list. If XRandR is supported, item at index 0 contains 
+   monitor marked as "primary" (XRandR). Primary monitor can be set 
+   programmatically or with `xrandr` utility.
+
+   Apple documentation says that this method should return array of 
+   NSScreen objects with "main screen" (screen where main menu resides) object 
+   at index 0. In our implementation main menu follows key window. 
+   Thus "main screen" (Apple) is not always "primary" (XRandR).
+
+   It may have some advantages: in +screen mathod we know actually configured
+   "main screen" - XRandR's "primary" and we can determine Apples "main screen"
+   by asking main menu window for its screen. In this way we have (at least for x11
+   with XRandR support) flexibility to decide at AppKit level wich is the true main 
+   screen (main menu's or XRandR primary).
+
+   Note that when key window crosses screens several events take place:
+   - screenArray resets ([NSScreen resetScreens] call from back);
+   - NSWindowDidChangeScreenNotification is sent (back);
+   - every NSWindow recalculates its coordiantes and screen is reassigned - retain
+   count to screen is decremented, finally old screenArray is deallocated;
+   - first call to [NSScreen screens] constructs new screenArray - "main menu" is 
+   placed at index 0;
+*/
 /**
  * Returns an NSArray containing NSScreen instances representing all of the
  * screen devices attached to the computer.

--- a/Source/NSScreen.m
+++ b/Source/NSScreen.m
@@ -73,31 +73,6 @@ static NSMutableArray *screenArray = nil;
   DESTROY(screenArray);
 }
 
-/* 
-   Display server's `screenList` method (back) returns `screens` array that
-   contains monitor list. If XRandR is supported, item at index 0 contains 
-   monitor marked as "primary" (XRandR). Primary monitor can be set 
-   programmatically or with `xrandr` utility.
-
-   Apple documentation says that this method should return array of 
-   NSScreen objects with "main screen" (screen where main menu resides) object 
-   at index 0. In our implementation main menu follows key window. 
-   Thus "main screen" (Apple) is not always "primary" (XRandR).
-
-   It may have some advantages: in +screen mathod we know actually configured
-   "main screen" - XRandR's "primary" and we can determine Apples "main screen"
-   by asking main menu window for its screen. In this way we have (at least for x11
-   with XRandR support) flexibility to decide at AppKit level wich is the true main 
-   screen (main menu's or XRandR primary).
-
-   Note that when key window crosses screens several events take place:
-   - screenArray resets ([NSScreen resetScreens] call from back);
-   - NSWindowDidChangeScreenNotification is sent (back);
-   - every NSWindow recalculates its coordiantes and screen is reassigned - retain
-   count to screen is decremented, finally old screenArray is deallocated;
-   - first call to [NSScreen screens] constructs new screenArray - "main menu" is 
-   placed at index 0;
-*/
 /**
  * Returns an NSArray containing NSScreen instances representing all of the
  * screen devices attached to the computer.

--- a/Source/NSWindow.m
+++ b/Source/NSWindow.m
@@ -4175,12 +4175,10 @@ checkCursorRectanglesExited(NSView *theView,  NSEvent *theEvent, NSPoint lastPoi
             {
             case GSAppKitWindowMoved:
               {
-                NSScreen *oldScreen;
-                NSScreen *newScreen;
-                oldScreen = _screen;
+                NSScreen *oldScreen = _screen;
+                
                 _frame.origin.x = (CGFloat)[theEvent data1];
                 _frame.origin.y = (CGFloat)[theEvent data2];
-                newScreen = [self screen];
                 NSDebugLLog(@"Moving", @"Move event: %d %@",
                             (int)_windowNum, NSStringFromPoint(_frame.origin));
                 if (_autosaveName != nil)
@@ -4189,7 +4187,7 @@ checkCursorRectanglesExited(NSView *theView,  NSEvent *theEvent, NSPoint lastPoi
                   }
                 [nc postNotificationName: NSWindowDidMoveNotification
                                   object: self];
-                if (newScreen != oldScreen)
+                if ([self screen] != oldScreen)
                   {
                     [nc postNotificationName: NSWindowDidChangeScreenNotification
                                       object: self];

--- a/Source/NSWindow.m
+++ b/Source/NSWindow.m
@@ -2737,10 +2737,24 @@ titleWithRepresentedFilename(NSString *representedFilename)
   newFrame.origin.y += newScreenFrame.size.height - oldScreenFrame.size.height;
   // Screen X origin change. Screen width change shouldn't affect our frame.
   newFrame.origin.x += newScreenFrame.origin.x - oldScreenFrame.origin.x;
-  [self setFrame: newFrame display: NO];
-  if (_autosaveName != nil)
+
+  if (_windowNum)
     {
-      [self saveFrameUsingName: _autosaveName];
+      /* Call backend's `placewindow::` directly because our origin in OpenStep 
+         coordinates might left unchanged and `setFrame:display:` has check 
+         for it. */
+      [GSServerForWindow(self) placewindow: newFrame : _windowNum];
+      if (_autosaveName != nil)
+        {
+          [self saveFrameUsingName: _autosaveName];
+        }
+      [self display];
+    }
+  else
+    {
+      _frame = newFrame;
+      newFrame.origin = NSZeroPoint;
+      [_wv setFrame: newFrame];
     }
 }
 


### PR DESCRIPTION
Call backend's `placewindow::` directly to change window placement even if `_frame` is not changed. Corresponding PR in back is [#24](https://github.com/gnustep/libs-back/pull/24) - allows window reposition in Xlib coordinate system for this case.
Made cleanup in `GSAppKitWindowMoved` event handling - removed extra variables.