### PR TITLE
Normalize annoucement file between core libraries

### DIFF
--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -1,5 +1,5 @@
-1 ANNOUNCE
-**********
+1 Announcement
+**************
 
 This is version 0.28.0 of the GNUstep GUI library ('gnustep-gui').
 
@@ -76,7 +76,7 @@ Plus the usual bunch of bug fixes.
 The gnustep-gui-0.28.0.tar.gz distribution file has been placed at
 <ftp://ftp.gnustep.org/pub/gnustep/core>.
 
-   It is accompanied by gnustep-back-0.28.0.tar.gz.sig, a PGP signature
+   It is accompanied by gnustep-gui-0.28.0.tar.gz.sig, a PGP signature
 which you can validate by putting both files in the same directory and
 using:
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-04-13  Ivan Vucica <ivan@vucica.net>
+
+	* Documentation/announce.texi:
+	* ANNOUNCE:
+	Normalize the accompanying text for the release announcement across
+	core packages: standardize chapter name and GPG information.
+
 2020-04-05  Ivan Vucica  <ivan@vucica.net>
 
 	* ANNOUNCE:

--- a/Documentation/announce.texi
+++ b/Documentation/announce.texi
@@ -1,5 +1,5 @@
 @c -*- texinfo -*-
-@chapter ANNOUNCE
+@chapter Announcement
 @ifset TEXT-ONLY
 @include version.texi
 @end ifset
@@ -43,9 +43,10 @@ library, you will need to install Cairo.
 @ifset GNUSTEP-GUI-FTP-MACHINE
 The gnustep-gui-@value{GNUSTEP-GUI-VERSION}.tar.gz distribution
 file has been placed at @url{ftp://@value{GNUSTEP-GUI-FTP-MACHINE}/@value{GNUSTEP-GUI-FTP-DIRECTORY}}.
-@end ifset
 
-It is accompanied by gnustep-back-@value{GNUSTEP-GUI-VERSION}.tar.gz.sig, a PGP signature which you can validate by putting both files in the same directory and using:
+It is accompanied by gnustep-gui-@value{GNUSTEP-GUI-VERSION}.tar.gz.sig, a
+PGP signature which you can validate by putting both files in the same
+directory and using:
 
 @example
 gpg --verify gnustep-gui-@value{GNUSTEP-GUI-VERSION}.tar.gz.sig
@@ -57,6 +58,7 @@ fingerprint:
 @example
 83AA E47C E829 A414 6EF8  3420 CA86 8D4C 9914 9679
 @end example
+@end ifset
 
 Read the INSTALL file or the GNUstep-HOWTO for installation instructions.
 


### PR DESCRIPTION
While preparing the email, I noticed the ANNOUNCE file for `-make` doesn't mention the GPG key, and there are other subtle differences.

I'm creating this pull request across `make`, `base`, `gui` and `back`.
