### PR TITLE
NSWindow input focus switch fix

### DIFF
--- a/Source/NSWindow.m
+++ b/Source/NSWindow.m
@@ -1757,21 +1757,22 @@ titleWithRepresentedFilename(NSString *representedFilename)
 - (void) makeKeyAndOrderFront: (id)sender
 {
   [self deminiaturize: self];
-  /*
-   * If a window is ordered in, make sure that the application isn't hidden,
-   * and is active.
-   */
-  if ([self canBecomeKeyWindow])
+  [self orderFrontRegardless];
+
+  if ([self canBecomeKeyWindow] != NO)
     {
+      [self makeKeyWindow];
+      /*
+       * OPENSTEP makes a window the main window when it makes it the key window.
+       * So we do the same (though the documentation doesn't mention it).
+       */
+      [self makeMainWindow];
+      /*
+       * If a window is ordered in, make sure that the application isn't hidden,
+       * and is active.
+       */
       [NSApp unhide: self];
     }
-  [self orderFrontRegardless];
-  [self makeKeyWindow];
-  /*
-   * OPENSTEP makes a window the main window when it makes it the key window.
-   * So we do the same (though the documentation doesn't mention it).
-   */
-  [self makeMainWindow];
 }
 
 - (void) makeKeyWindow


### PR DESCRIPTION
Unhide/activate application after ordering and making it key. This prevents focus flickering between current key window and this window during application activation.  Do not try to set key and main if window can't be set as key.