### PR TITLE
Make GSHorizontalTypesetter use defaultTabInterval if it has run out …

### DIFF
--- a/Source/GSHorizontalTypesetter.m
+++ b/Source/GSHorizontalTypesetter.m
@@ -870,6 +870,11 @@ restart: ;
 		*/
 		NSArray *tabs = [curParagraphStyle tabStops];
 		NSTextTab *tab = nil;
+		float defaultInterval = [curParagraphStyle defaultTabInterval];
+		/* Set it to something reasonable if unset */
+		if (defaultInterval == 0.0) {
+			defaultInterval = 100.0;
+		}
 		int i, c = [tabs count];
 		/* Find first tab beyond our current position. */
 		for (i = 0; i < c; i++)
@@ -888,12 +893,11 @@ restart: ;
 		  }
 		if (i == c)
 		  {
-		    /* TODO: we're already past all the tab stops. what
-		    should we do?
-
-		    Pretend that we have tabs every 100 points.
+		    /*
+		    Tabs after the last value in tabStops should use the
+		    defaultTabInterval provided by NSParagraphStyle.
 		    */
-		    p.x = (floor(p.x / 100.0) + 1.0) * 100.0;
+		    p.x = (floor(p.x / defaultInterval) + 1.0) * defaultInterval;
 		  }
 		else
 		  {


### PR DESCRIPTION
…of defined tabstops

As per the documentation here: https://developer.apple.com/documentation/uikit/nsparagraphstyle/1535614-defaulttabinterval tabs should fall back to the value provided by NSParagraphStye defaultTabInterval (presumably only if non zero) rather than this constant value of 100pt. 

Cheers.