### PR TITLE
GSImageMagickImageRep: Update to work with ImageMagick 7

### DIFF
--- a/Source/GSImageMagickImageRep.m
+++ b/Source/GSImageMagickImageRep.m
@@ -82,11 +82,19 @@
       NSSize res;
       if (image->units == PixelsPerCentimeterResolution)
 	{
+#if (MagickLibVersion >= 0x700)
 	  res = NSMakeSize(image->resolution.x * 2.54, image->resolution.y * 2.54);
+#else
+	  res = NSMakeSize(image->x_resolution * 2.54, image->y_resolution * 2.54);
+#endif
 	}
       else
 	{
+#if (MagickLibVersion >= 0x700)
 	  res = NSMakeSize(image->resolution.x, image->resolution.y);
+#else
+	  res = NSMakeSize(image->x_resolution, image->y_resolution);
+#endif
 	}
 
       if (res.width > 0 && res.height > 0)
@@ -121,7 +129,11 @@
   
   // Set the background color to transparent
   // (otherwise SVG's are rendered against a white background by default)
+#if (MagickLibVersion >= 0x700)
   QueryColorCompliance("none", AllCompliance, &imageinfo->background_color, exception);
+#else
+  QueryColorDatabase("none", &imageinfo->background_color, exception);
+#endif
 
   images = BlobToImage(imageinfo, [data bytes], [data length], exception);
 

--- a/Source/GSImageMagickImageRep.m
+++ b/Source/GSImageMagickImageRep.m
@@ -82,11 +82,11 @@
       NSSize res;
       if (image->units == PixelsPerCentimeterResolution)
 	{
-	  res = NSMakeSize(image->x_resolution * 2.54, image->y_resolution * 2.54);
+	  res = NSMakeSize(image->resolution.x * 2.54, image->resolution.y * 2.54);
 	}
       else
 	{
-	  res = NSMakeSize(image->x_resolution, image->y_resolution);
+	  res = NSMakeSize(image->resolution.x, image->resolution.y);
 	}
 
       if (res.width > 0 && res.height > 0)
@@ -121,7 +121,7 @@
   
   // Set the background color to transparent
   // (otherwise SVG's are rendered against a white background by default)
-  QueryColorDatabase("none", &imageinfo->background_color, exception);
+  QueryColorCompliance("none", AllCompliance, &imageinfo->background_color, exception);
 
   images = BlobToImage(imageinfo, [data bytes], [data length], exception);
 


### PR DESCRIPTION
QueryColorDatabase() has been deprecated it appears. (you'll get missing symbol errors...)
So this should address that.

Issue #108 still lists that some formats, like .TGA cannot be decoded. However because other format blobs get sent properly I'm not sure if that is just an issue with imageMagick itself.