### PR TITLE
GSStandardWindowDecorationView: Apply userSpaceScaleFactor to calcula…

### DIFF
--- a/Source/GSStandardWindowDecorationView.m
+++ b/Source/GSStandardWindowDecorationView.m
@@ -67,7 +67,7 @@
   if (style
     & (NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask))
     {
-      *t = [theme titlebarHeight];
+      *t = [[NSScreen mainScreen] userSpaceScaleFactor] * [theme titlebarHeight];
     }
   if (style & NSResizableWindowMask)
     {


### PR DESCRIPTION
…tions involving the title bar height

This resolves this issue #129 that I noticed when using client side decorations. I've tested this with a number of apps TalkSoup, GWorkspace, Terminal. With the default theme and also with Rik.theme on arch linux, kernel 5.15.12-arch1-1, x86_64.