### PR TITLE
Fix memory leak in NSTextView

### DIFF
--- a/Source/NSTextView.m
+++ b/Source/NSTextView.m
@@ -64,6 +64,7 @@
 #import <Foundation/NSTimer.h>
 #import <Foundation/NSUndoManager.h>
 #import <Foundation/NSValue.h>
+#import <Foundation/NSAutoreleasePool.h>
 
 #import "AppKit/NSApplication.h"
 #import "AppKit/NSAttributedString.h"
@@ -1170,6 +1171,9 @@ to this method from the text container or layout manager.
 */
 - (void) setTextContainer: (NSTextContainer *)container
 {
+
+  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+  
   NSUInteger i, c;
   NSArray *tcs;
   NSTextView *other;
@@ -1233,6 +1237,8 @@ to this method from the text container or layout manager.
   _currentInsertionPointMovementDirection = 0;
 
   [self _updateMultipleTextViews];
+  
+  [pool drain];
 }
 
 - (void) replaceTextContainer: (NSTextContainer *)newContainer

--- a/Source/NSTextView.m
+++ b/Source/NSTextView.m
@@ -1172,7 +1172,7 @@ to this method from the text container or layout manager.
 - (void) setTextContainer: (NSTextContainer *)container
 {
 
-  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+  ENTER_POOL
   
   NSUInteger i, c;
   NSArray *tcs;
@@ -1238,7 +1238,7 @@ to this method from the text container or layout manager.
 
   [self _updateMultipleTextViews];
   
-  [pool drain];
+  LEAVE_POOL
 }
 
 - (void) replaceTextContainer: (NSTextContainer *)newContainer


### PR DESCRIPTION
On Windows, there is an occasional sporadic failure of autorelease to work correctly. In particular, this seems to happen when autorelease is invoked on an object while a call stack is in the middle of draining an autorelease pool. So, for example, when dealloc is called on an NSTextContainer, it then calls setTextContainer: on the associated NSTextView, which in turn calls textContainers on the layoutManager, which returns an autoreleased array of NSTextContainers. This array is sometimes released and sometimes it isn't.
Wrapping the setTextContainer: in an autorelease pool, which will then drain at the end of the method, rather than relying on the main autorelease pool in the run loop (which is in the middle of being drained), appears to fix this problem. This adds a small amount of overhead, but also makes the memory usage a little more efficient, since anything autoretained during the course of this method is released more quickly.