### PR TITLE
fix to build GSSpell in custom build dir

### DIFF
--- a/Tools/GNUmakefile
+++ b/Tools/GNUmakefile
@@ -50,7 +50,7 @@ include GNUmakefile.preamble
 ifeq ($(CROSS_COMPILING),yes)
   GNUSTEP_MAKE_SERVICES=:
 else
-  GNUSTEP_MAKE_SERVICES=./$(GNUSTEP_OBJ_DIR)/make_services
+  GNUSTEP_MAKE_SERVICES=$(GNUSTEP_OBJ_DIR)/make_services
 endif
 
 include $(GNUSTEP_MAKEFILES)/tool.make


### PR DESCRIPTION
GSspell can't be built if GNUSTEP_BUILD_DIR is set to something other than the default.

Try:
mkdir  "$HOME/tmp/build"
GNUSTEP_BUILD_DIR=~/tmp/build make 

Building in such a way ended up:

> Making all for service GSspell...
>  Creating /home/dev/tmp/build/Tools/GSspell.service/....
>  Compiling file GSspell.m ...
>  Linking service GSspell ...
>  Creating /home/dev/tmp/build/Tools/GSspell.service/Resources...
>  Creating /home/dev/tmp/build/Tools/GSspell.service/Resources/Info-gnustep.plist...
> /bin/sh: 7: .//home/dev/tmp/build/Tools/obj/make_services: not found
> make[3]: *** [/opt/gnustep/System/Library/Makefiles/Instance/service.make:141: /home/dev/tmp/build/Tools/GSspell.service/Resources/Info-gnustep.plist] Error 1
> make[2]: *** [/opt/gnustep/System/Library/Makefiles/Master/rules.make:297: GSspell.all.service.variables] Error 2
> make[1]: *** [/opt/gnustep/System/Library/Makefiles/Master/service.make:37: internal-all] Error 2
> make: *** [/opt/gnustep/System/Library/Makefiles/Master/serial-subdirectories.make:53: internal-all] Error 2

