### PR TITLE
only for ImageCell set refuses first responder, as behavior on Mac.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-03-18  Riccardo Mottola <rm@gnu.org>
+
+	* Source/NSCell.m: only for ImageCell set refuses first responder,
+	as behavior on Mac.
+
 2022-02-26  Wolfgang Lux  <wolfgang.lux@gmail.com>
 
 	* Source/NSPopUpButtonCell.m(setMenu:): Select the first item of

--- a/Source/NSCell.m
+++ b/Source/NSCell.m
@@ -2,7 +2,7 @@
 
    <abstract>The abstract cell class</abstract>
 
-   Copyright (C) 1996-2012,2019 Free Software Foundation, Inc.
+   Copyright (C) 1996-2012,2019,2022 Free Software Foundation, Inc.
 
    Author:  Scott Christley <scottc@net-community.com>
    Date: 1996
@@ -175,7 +175,6 @@ static NSColor *dtxtCol;
   //_cell.is_rich_text = NO;
   //_cell.imports_graphics = NO;
   //_cell.shows_first_responder = NO;
-  //_cell.refuses_first_responder = NO;
   //_cell.sends_action_on_end_editing = NO;
   //_cell.is_bordered = NO;
   //_cell.is_bezeled = NO;
@@ -183,6 +182,8 @@ static NSColor *dtxtCol;
   //_cell.is_selectable = NO;
   //_cell.state = 0;
   //_cell.line_break_mode = NSLineBreakByWordWrapping;
+
+  _cell.refuses_first_responder = YES;
   _action_mask = NSLeftMouseUpMask;
   _menu = [object_getClass(self) defaultMenu];
   [self setFocusRingType: [object_getClass(self) defaultFocusRingType]];


### PR DESCRIPTION
With this change I made GS match Mac behavior.
It makes my test case work and match Mac on both GORM instantiated NSImageView and its NSImageCell, as code-instantiated NSImageCell, NSActionCell, NSCell.

However PRICE still doesn't respond properly when copy&paste into the image-view and that still puzzles me.