### PR TITLE
Don't misuse libgnustep-gui_INTERFACE_VERSION to define Resource Inst…

### DIFF
--- a/Panels/GNUmakefile.postamble
+++ b/Panels/GNUmakefile.postamble
@@ -28,8 +28,7 @@
 # it.
 
 include ../Version
-libgnustep-gui_INTERFACE_VERSION=$(GNUSTEP_GUI_MAJOR_VERSION).$(GNUSTEP_GUI_MINOR_VERSION)
-POSTAMBLE_INSTALL_DIR = $(GNUSTEP_LIBRARY)/Libraries/gnustep-gui/Versions/$(libgnustep-gui_INTERFACE_VERSION)/Resources
+POSTAMBLE_INSTALL_DIR = $(GNUSTEP_LIBRARY)/Libraries/gnustep-gui/Versions/$(GNUSTEP_GUI_MAJOR_VERSION).$(GNUSTEP_GUI_MINOR_VERSION)/Resources
 
 # Things to do after installing
 after-install::

--- a/Resources/GNUmakefile
+++ b/Resources/GNUmakefile
@@ -28,10 +28,9 @@ GNUSTEP_LOCAL_ADDITIONAL_MAKEFILES=../gui.make
 include $(GNUSTEP_MAKEFILES)/common.make
 
 include ../Version
-libgnustep-gui_INTERFACE_VERSION=$(GNUSTEP_GUI_MAJOR_VERSION).$(GNUSTEP_GUI_MINOR_VERSION)
 
 RESOURCE_SET_NAME = gui-resources
-gui-resources_INSTALL_DIR = $(GNUSTEP_LIBRARY)/Libraries/gnustep-gui/Versions/$(libgnustep-gui_INTERFACE_VERSION)/Resources
+gui-resources_INSTALL_DIR = $(GNUSTEP_LIBRARY)/Libraries/gnustep-gui/Versions/$(GNUSTEP_GUI_MAJOR_VERSION).$(GNUSTEP_GUI_MINOR_VERSION)/Resources
 gui-resources_LANGUAGES = English Italian Lojban Esperanto German French Spanish Korean Japanese Polish
 gui-resources_LOCALIZED_RESOURCE_FILES = Localizable.strings
 

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -29,9 +29,6 @@ include $(GNUSTEP_MAKEFILES)/common.make
 include ../Version
 include ../config.make
 
-# Interface version changes with each minor release
-libgnustep-gui_INTERFACE_VERSION=${GNUSTEP_GUI_MAJOR_VERSION}.${GNUSTEP_GUI_MINOR_VERSION}
-
 srcdir = .
 PACKAGE_NAME = gnustep-gui
 LIBRARY_VAR = GNUSTEP_GUI
@@ -671,7 +668,7 @@ HEADERS_INSTALL = ${APPKIT_HEADERS} \
 
 # Resources
 RESOURCE_SET_NAME = libgui-resources
-libgui-resources_INSTALL_DIR = $(GNUSTEP_LIBRARY)/Libraries/gnustep-gui/Versions/$(libgnustep-gui_INTERFACE_VERSION)/Resources
+libgui-resources_INSTALL_DIR = $(GNUSTEP_LIBRARY)/Libraries/gnustep-gui/Versions/${GNUSTEP_GUI_MAJOR_VERSION}.${GNUSTEP_GUI_MINOR_VERSION}/Resources
 libgui-resources_RESOURCE_DIRS =
 libgui-resources_RESOURCE_FILES = Info-gnustep.plist
 


### PR DESCRIPTION
…all paths

$(GNUSTEP_INSTANCE)_INTERFACE_VERSION is used in gnustep-make to define
the version of the shared object.

As a packager, there might be various reasons to
override the $(GNUSTEP_INSTANCE)_INTERFACE_VERSION
in order to control the library version.

So I do for gnustep-gui on OpenBSD packages. The problem here is, that
the libgnustep-gui_INTERFACE_VERSION is additionally used to specify the path
where resources like Panels, Localizations etc. get installed, however,
in Source/NSApplication.m, the use of
GNUSTEP_GUI_MAJOR_VERSION.GNUSTEP_GUI_MINOR_VERSION

As long as the libgnustep-gui_INTERFACE_VERSION is not overridden with
some other value, everything is fine. However, as in my case, Applications
aren't able to find the Panels/Translations provided by -gui anymore.

Decided to just remove the definition of libgnustep-gui_INTERFACE_VERSION
in these three Makefiles, as it was only used once, and used the
GNUSTEP_GUI_MAJOR_VERSION.GNUSTEP_GUI_MINOR_VERSION directly.

Alternatively, libgnustep-gui_INTERFACE_VERSION in these Makefiles
could could have been renamed to avoid this conflict.