### PR TITLE
NSTextView: support drop for NSFilenamesPboardType

### DIFF
--- a/Source/NSTextView.m
+++ b/Source/NSTextView.m
@@ -4990,7 +4990,7 @@ right.)
 	  id<NSFastEnumeration> enumerator = list;
 	  FOR_IN (NSString*, filename, enumerator)
 	   {
-	      NSFileWrapper *fw = [[NSFileWrapper alloc] initWithPath:filename];
+	      NSFileWrapper *fw = [[NSFileWrapper alloc] initWithPath: filename];
 	      if (fw) 
 	        {
 	          NSTextAttachment *attachment = [[NSTextAttachment alloc] 
@@ -5015,8 +5015,9 @@ right.)
 	      [self didChangeText];
 	      changeRange.length = [as length];
 	      [self setSelectedRange: NSMakeRange(NSMaxRange(changeRange),0)];
-	      RELEASE(as);
 	    }
+
+	  RELEASE(as);
 	  return YES;
 	}
     }

--- a/Source/NSTextView.m
+++ b/Source/NSTextView.m
@@ -4982,6 +4982,40 @@ right.)
 	  RELEASE(attachment);
 	  return YES;
 	}
+      if ([type isEqualToString: NSFilenamesPboardType])
+	{
+          NSArray *list = [pboard propertyListForType: NSFilenamesPboardType];
+          NSMutableAttributedString *as = [[NSMutableAttributedString alloc] init]; 
+
+	  for (NSString *filename in list)
+	   {
+	      NSFileWrapper *fw = [[NSFileWrapper alloc] initWithPath:filename];
+	      if (fw) 
+	        {
+	          NSTextAttachment *attachment = [[NSTextAttachment alloc] 
+					         initWithFileWrapper: fw];
+	          NSAttributedString *asat =
+	            [NSAttributedString attributedStringWithAttachment: attachment];
+
+	          RELEASE(fw);
+	          RELEASE(attachment);
+
+	          [as appendAttributedString:asat];
+	        }
+	   }
+
+	  if (as && changeRange.location != NSNotFound &&
+	      [self shouldChangeTextInRange: changeRange
+		replacementString: [as string]])
+	    {
+	      [self replaceCharactersInRange: changeRange
+		withAttributedString: as];
+	      [self didChangeText];
+	      changeRange.length = [as length];
+	      [self setSelectedRange: NSMakeRange(NSMaxRange(changeRange),0)];
+	    }
+	  return YES;
+	}
     }
 
   // color accepting
@@ -5078,6 +5112,7 @@ right.)
       [ret addObject: NSRTFDPboardType];
       [ret addObject: NSTIFFPboardType];
       [ret addObject: NSFileContentsPboardType];
+      [ret addObject: NSFilenamesPboardType];
     }
   if (_tf.is_rich_text)
     {

--- a/Source/NSTextView.m
+++ b/Source/NSTextView.m
@@ -4987,7 +4987,8 @@ right.)
           NSArray *list = [pboard propertyListForType: NSFilenamesPboardType];
           NSMutableAttributedString *as = [[NSMutableAttributedString alloc] init]; 
 
-	  for (NSString *filename in list)
+	  id<NSFastEnumeration> enumerator = list;
+	  FOR_IN (NSString*, filename, enumerator)
 	   {
 	      NSFileWrapper *fw = [[NSFileWrapper alloc] initWithPath:filename];
 	      if (fw) 
@@ -5000,9 +5001,10 @@ right.)
 	          RELEASE(fw);
 	          RELEASE(attachment);
 
-	          [as appendAttributedString:asat];
+	          [as appendAttributedString: asat];
 	        }
 	   }
+	  END_FOR_IN(enumerator)
 
 	  if (as && changeRange.location != NSNotFound &&
 	      [self shouldChangeTextInRange: changeRange
@@ -5013,6 +5015,7 @@ right.)
 	      [self didChangeText];
 	      changeRange.length = [as length];
 	      [self setSelectedRange: NSMakeRange(NSMaxRange(changeRange),0)];
+	      RELEASE(as);
 	    }
 	  return YES;
 	}


### PR DESCRIPTION
Enable files to be dragged into NSTextView to create attachments (e.g. from GWorkspace)