### PR TITLE
NSTextAttachment: make double click handling more robust

### DIFF
--- a/Source/NSTextAttachment.m
+++ b/Source/NSTextAttachment.m
@@ -110,7 +110,7 @@
       
       if (type == NSLeftMouseUp)
         {
-	  if ([theEvent clickCount] == 2)
+	  if ([theEvent clickCount] >= 2)
 	    {
 	      if (delegate != nil && [delegate respondsToSelector: 
 		@selector(textView:doubleClickedOnCell:inRect:)])
@@ -167,7 +167,7 @@
       
       if (type == NSLeftMouseDown)
         { 
-	  if ([theEvent clickCount] == 2)
+	  if ([theEvent clickCount] >= 2)
 	    {
               if (delegate != nil)
                 {

--- a/Source/NSTextView.m
+++ b/Source/NSTextView.m
@@ -4982,6 +4982,40 @@ right.)
 	  RELEASE(attachment);
 	  return YES;
 	}
+      if ([type isEqualToString: NSFilenamesPboardType])
+	{
+          NSArray *list = [pboard propertyListForType: NSFilenamesPboardType];
+          NSMutableAttributedString *as = [[NSMutableAttributedString alloc] init]; 
+
+	  for (NSString *filename in list)
+	   {
+	      NSFileWrapper *fw = [[NSFileWrapper alloc] initWithPath:filename];
+	      if (fw) 
+	        {
+	          NSTextAttachment *attachment = [[NSTextAttachment alloc] 
+					         initWithFileWrapper: fw];
+	          NSAttributedString *asat =
+	            [NSAttributedString attributedStringWithAttachment: attachment];
+
+	          RELEASE(fw);
+	          RELEASE(attachment);
+
+	          [as appendAttributedString:asat];
+	        }
+	   }
+
+	  if (as && changeRange.location != NSNotFound &&
+	      [self shouldChangeTextInRange: changeRange
+		replacementString: [as string]])
+	    {
+	      [self replaceCharactersInRange: changeRange
+		withAttributedString: as];
+	      [self didChangeText];
+	      changeRange.length = [as length];
+	      [self setSelectedRange: NSMakeRange(NSMaxRange(changeRange),0)];
+	    }
+	  return YES;
+	}
     }
 
   // color accepting
@@ -5078,6 +5112,7 @@ right.)
       [ret addObject: NSRTFDPboardType];
       [ret addObject: NSTIFFPboardType];
       [ret addObject: NSFileContentsPboardType];
+      [ret addObject: NSFilenamesPboardType];
     }
   if (_tf.is_rich_text)
     {


### PR DESCRIPTION
the existing implementation of doubleClickedOnCell will not be called because the click count is likely to more more than 2 by that point. I suspect it has to do with double click being interpreted as select word first.

I propose to change the condition to work after 2 or more clicks to make it more robust.