### PR TITLE
Add defines for export of classes to DLL when building on WIndows

### DIFF
--- a/Headers/Additions/GNUstepGUI/GMArchiver.h
+++ b/Headers/Additions/GNUstepGUI/GMArchiver.h
@@ -29,6 +29,7 @@
 
 #ifndef __GMArchiver_h__
 #define __GMArchiver_h__
+#import <AppKit/AppKitDefines.h>
 
 #ifndef GNUSTEP
 #import <Foundation/Foundation.h>
@@ -74,6 +75,7 @@
 @end
 
 
+APPKIT_EXPORT_CLASS
 @interface GMArchiver : NSObject
 {
   NSMutableDictionary*	propertyList;
@@ -136,6 +138,7 @@
 @end /* GMArchiver */
 
 
+APPKIT_EXPORT_CLASS
 @interface GMUnarchiver : NSObject
 {	
   NSMutableDictionary*	propertyList;

--- a/Headers/Additions/GNUstepGUI/GSAnimator.h
+++ b/Headers/Additions/GNUstepGUI/GSAnimator.h
@@ -56,6 +56,7 @@
  * GSAnimator is the front of a class cluster. Instances of a subclass of 
  * GSAnimator manage the timing of an animation.
  */
+APPKIT_EXPORT_CLASS
 @interface GSAnimator : NSObject
 {
   id<GSAnimation> _animation; // The Object to be animated

--- a/Headers/Additions/GNUstepGUI/GSCharacterPanel.h
+++ b/Headers/Additions/GNUstepGUI/GSCharacterPanel.h
@@ -36,6 +36,7 @@
 @class NSSearchField;
 @class NSIndexSet;
 
+APPKIT_EXPORT_CLASS
 @interface GSCharacterPanel : NSPanel
 {
 	NSTableView *table;

--- a/Headers/Additions/GNUstepGUI/GSDisplayServer.h
+++ b/Headers/Additions/GNUstepGUI/GSDisplayServer.h
@@ -61,6 +61,7 @@ APPKIT_EXPORT NSString *GSDisplayName;
 APPKIT_EXPORT NSString *GSDisplayNumber;
 APPKIT_EXPORT NSString *GSScreenNumber;
 
+APPKIT_EXPORT_CLASS
 @interface GSDisplayServer : NSObject
 {
   NSMutableDictionary	*server_info;

--- a/Headers/Additions/GNUstepGUI/GSDragView.h
+++ b/Headers/Additions/GNUstepGUI/GSDragView.h
@@ -54,6 +54,7 @@
 
 #define NSDragOperationIgnoresModifiers  0xffff
 
+APPKIT_EXPORT_CLASS
 @interface GSDragView : NSView <NSDraggingInfo>
 {
   // the graphics that is dragged

--- a/Headers/Additions/GNUstepGUI/GSFontInfo.h
+++ b/Headers/Additions/GNUstepGUI/GSFontInfo.h
@@ -38,6 +38,7 @@
 @class NSBezierPath;
 @class NSFontDescriptor;
 
+APPKIT_EXPORT_CLASS
 @interface GSFontEnumerator : NSObject
 {
   NSArray *allFontNames;
@@ -66,6 +67,7 @@ values. Backends may override these. */
 - (NSString *) defaultFixedPitchFontName;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSFontInfo : NSObject <NSCopying, NSMutableCopying>
 {
   NSMutableDictionary* fontDictionary;

--- a/Headers/Additions/GNUstepGUI/GSGhostscriptImageRep.h
+++ b/Headers/Additions/GNUstepGUI/GSGhostscriptImageRep.h
@@ -34,6 +34,7 @@
 
 @class NSData;
 
+APPKIT_EXPORT_CLASS
 @interface GSGhostscriptImageRep : NSImageRep
 {
   NSBitmapImageRep *_bitmap;

--- a/Headers/Additions/GNUstepGUI/GSGormLoading.h
+++ b/Headers/Additions/GNUstepGUI/GSGormLoading.h
@@ -61,6 +61,7 @@ enum {
 /*
  * This is the class that holds objects within a nib.
  */
+APPKIT_EXPORT_CLASS
 @interface GSNibContainer : NSObject <NSCoding, GSNibContainer>
 {
   NSMutableDictionary	*nameTable;
@@ -85,6 +86,7 @@ enum {
 - (NSString *)className;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSClassSwapper : NSObject <GSTemplate, NSCoding>
 {
   id                   _object;
@@ -94,6 +96,7 @@ enum {
 - (BOOL) shouldSwapClass;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSNibItem : NSObject <NSCoding> 
 {
   NSString		*theClass;
@@ -102,11 +105,13 @@ enum {
 }
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSCustomView : GSNibItem <NSCoding>  
 {
 }
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSWindowTemplate : GSClassSwapper
 {
   BOOL                 _deferFlag;
@@ -123,24 +128,31 @@ enum {
 - (BOOL) deferFlag;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSViewTemplate : GSClassSwapper
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSTextTemplate : GSClassSwapper
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSTextViewTemplate : GSClassSwapper 
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSMenuTemplate : GSClassSwapper
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSControlTemplate : GSClassSwapper
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSObjectTemplate : GSClassSwapper
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSTemplateFactory : NSObject
 + (id) templateForObject: (id) object 
 	   withClassName: (NSString *)className

--- a/Headers/Additions/GNUstepGUI/GSHelpAttachment.h
+++ b/Headers/Additions/GNUstepGUI/GSHelpAttachment.h
@@ -29,6 +29,7 @@
 
 #import <AppKit/NSTextAttachment.h>
 
+APPKIT_EXPORT_CLASS
 @interface GSHelpLinkAttachment : NSTextAttachment
 {
   NSString *fileName, *markerName;
@@ -42,6 +43,7 @@
 
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSHelpMarkerAttachment : NSTextAttachment
 {
   NSString *markerName;

--- a/Headers/Additions/GNUstepGUI/GSHorizontalTypesetter.h
+++ b/Headers/Additions/GNUstepGUI/GSHorizontalTypesetter.h
@@ -35,6 +35,7 @@
 @class NSDictionary;
 @class NSParagraphStyle, NSFont;
 
+APPKIT_EXPORT_CLASS
 @interface GSHorizontalTypesetter : GSTypesetter
 {
   NSLock *lock;

--- a/Headers/Additions/GNUstepGUI/GSImageMagickImageRep.h
+++ b/Headers/Additions/GNUstepGUI/GSImageMagickImageRep.h
@@ -32,6 +32,7 @@
 
 #import <AppKit/NSBitmapImageRep.h>
 
+APPKIT_EXPORT_CLASS
 @interface GSImageMagickImageRep : NSBitmapImageRep
 {
 }

--- a/Headers/Additions/GNUstepGUI/GSLayoutManager.h
+++ b/Headers/Additions/GNUstepGUI/GSLayoutManager.h
@@ -55,8 +55,10 @@ enum {
 };
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_3, GS_API_LATEST)
+APPKIT_EXPORT_CLASS
 @interface GSLayoutManager : NSObject <NSGlyphStorage, NSCoding>
 #else
+APPKIT_EXPORT_CLASS
 @interface GSLayoutManager : NSObject
 #endif
 {

--- a/Headers/Additions/GNUstepGUI/GSModelLoaderFactory.h
+++ b/Headers/Additions/GNUstepGUI/GSModelLoaderFactory.h
@@ -28,6 +28,7 @@
 
 #ifndef _GNUstep_H_GSModelLoaderFactory
 #define _GNUstep_H_GSModelLoaderFactory
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSZone.h>
@@ -38,6 +39,7 @@
 @class NSString;
 @class NSBundle;
 
+APPKIT_EXPORT_CLASS
 @interface GSModelLoader : NSObject
 + (BOOL) canReadData: (NSData *)theData;
 + (NSString *) type;
@@ -51,6 +53,7 @@
 - (NSData *)dataForFile: (NSString *)fileName;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSModelLoaderFactory : NSObject
 + (void) registerModelLoaderClass: (Class)aClass;
 + (Class) classForType: (NSString *)type;

--- a/Headers/Additions/GNUstepGUI/GSNibLoading.h
+++ b/Headers/Additions/GNUstepGUI/GSNibLoading.h
@@ -100,6 +100,7 @@ typedef struct _GSWindowTemplateFlags
 } GSWindowTemplateFlags;
 
 // help connector class...
+APPKIT_EXPORT_CLASS
 @interface NSIBHelpConnector : NSNibConnector
 {
   id _marker;
@@ -113,6 +114,7 @@ typedef struct _GSWindowTemplateFlags
 /**
  * Button image source class.
  */
+APPKIT_EXPORT_CLASS
 @interface NSButtonImageSource : NSObject <NSCoding>
 {
   NSString *imageName;
@@ -127,6 +129,7 @@ typedef struct _GSWindowTemplateFlags
  * when it's unarchived and second, it holds certain attributes (but doesn't set them
  * on the window, when the window is being edited in the application builder.
  */
+APPKIT_EXPORT_CLASS
 @interface NSWindowTemplate : NSObject <OSXNibTemplate, NSCoding, GSNibLoading>
 {
   NSBackingStoreType   _backingStoreType;
@@ -175,6 +178,7 @@ typedef struct _GSWindowTemplateFlags
 - (Class) baseWindowClass;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSViewTemplate : NSView <OSXNibTemplate, NSCoding>
 {
   NSString            *_className;
@@ -184,16 +188,19 @@ typedef struct _GSWindowTemplateFlags
             className: (NSString *)name;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSTextTemplate : NSViewTemplate
 {
 }
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSTextViewTemplate : NSViewTemplate
 {
 }
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSMenuTemplate : NSObject <OSXNibTemplate, NSCoding>
 {
   NSString            *_menuClass;
@@ -210,6 +217,7 @@ typedef struct _GSWindowTemplateFlags
 - (NSString *)className;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSCustomObject : NSObject <NSCoding, GSNibLoading>
 {
   NSString *_className;
@@ -224,6 +232,7 @@ typedef struct _GSWindowTemplateFlags
 - (id) realObject;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSCustomView : NSView <GSNibLoading>
 {
   NSString *_className;
@@ -238,6 +247,7 @@ typedef struct _GSWindowTemplateFlags
 - (id)nibInstantiateWithCoder: (NSCoder *)coder;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSCustomResource : NSObject <NSCoding>
 {
   NSString *_className;
@@ -249,6 +259,7 @@ typedef struct _GSWindowTemplateFlags
 - (NSString *)resourceName;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSClassSwapper : NSObject <NSCoding>
 {
   NSString *_className;
@@ -268,6 +279,7 @@ typedef struct _GSWindowTemplateFlags
 - (NSString *)originalClassName;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSIBObjectData : NSObject <NSCoding, GSInstantiator, GSNibContainer>
 {
   id              _root;
@@ -302,9 +314,11 @@ typedef struct _GSWindowTemplateFlags
 @end
 
 // class needed for nib encoding/decoding by the progress bar...
+APPKIT_EXPORT_CLASS
 @interface NSPSMatrix : NSObject
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSNibAXAttributeConnector : NSObject <NSCoding>
 {
   NSString *_attributeType;
@@ -332,6 +346,7 @@ typedef struct _GSWindowTemplateFlags
 - (void) establishConnection;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSNibAXRelationshipConnector : NSNibConnector
 @end
 
@@ -351,6 +366,7 @@ typedef struct _GSWindowTemplateFlags
 - (void) setOptions: (NSDictionary *)options;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSIBUserDefinedRuntimeAttributesConnector : NSObject <NSCoding>
 {
   id _object;

--- a/Headers/Additions/GNUstepGUI/GSPrinting.h
+++ b/Headers/Additions/GNUstepGUI/GSPrinting.h
@@ -30,11 +30,13 @@
 
 #ifndef _GNUstep_H_GSPrinting
 #define _GNUstep_H_GSPrinting
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
 @class NSBundle;
 
+APPKIT_EXPORT_CLASS
 @interface GSPrinting : NSObject
 {
 }
@@ -44,6 +46,7 @@
 @end
 
 
+APPKIT_EXPORT_CLASS
 @interface GSPrintingPrincipalClass : NSObject
 {
 }

--- a/Headers/Additions/GNUstepGUI/GSServicesManager.h
+++ b/Headers/Additions/GNUstepGUI/GSServicesManager.h
@@ -45,6 +45,7 @@
 @class	NSString;
 @class	NSTimer;
 
+APPKIT_EXPORT_CLASS
 @interface      GSServicesManager : NSObject
 {
   NSApplication         *_application;

--- a/Headers/Additions/GNUstepGUI/GSTheme.h
+++ b/Headers/Additions/GNUstepGUI/GSTheme.h
@@ -482,6 +482,7 @@ APPKIT_EXPORT	NSString	*GSThemeWillDeactivateNotification;
   use the appropriate behavior.
   </p>
 */ 
+APPKIT_EXPORT_CLASS
 @interface GSTheme : NSObject
 {
 @private
@@ -1511,9 +1512,11 @@ withRepeatedImage: (NSImage*)image
 @end
 
 // Panels which can be overridden by the theme...
+APPKIT_EXPORT_CLASS
 @interface GSPrintPanel : NSPrintPanel
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GSPageLayout : NSPageLayout
 @end
 

--- a/Headers/Additions/GNUstepGUI/GSTitleView.h
+++ b/Headers/Additions/GNUstepGUI/GSTitleView.h
@@ -33,6 +33,7 @@
 @class NSButton;
 @class NSImage;
 
+APPKIT_EXPORT_CLASS
 @interface GSTitleView : NSView
 {
   NSButton            *closeButton;

--- a/Headers/Additions/GNUstepGUI/GSToolbarView.h
+++ b/Headers/Additions/GNUstepGUI/GSToolbarView.h
@@ -50,6 +50,7 @@ typedef enum {
   GSToolbarViewBottomBorder = 16
 } GSToolbarViewBorder;
 
+APPKIT_EXPORT_CLASS
 @interface GSToolbarView : NSView
 {
   NSToolbar *_toolbar;

--- a/Headers/Additions/GNUstepGUI/GSTrackingRect.h
+++ b/Headers/Additions/GNUstepGUI/GSTrackingRect.h
@@ -33,6 +33,7 @@
 #import <Foundation/NSObject.h>
 #import <AppKit/NSView.h>
 
+APPKIT_EXPORT_CLASS
 @interface GSTrackingRect : NSObject <NSCoding>
 {
 @public

--- a/Headers/Additions/GNUstepGUI/GSTypesetter.h
+++ b/Headers/Additions/GNUstepGUI/GSTypesetter.h
@@ -41,6 +41,7 @@
 /* This isn't final. It will probably change. If you want to sub-class,
 you'll have to update your code when things change (or wait until it's
 done). */
+APPKIT_EXPORT_CLASS
 @interface GSTypesetter : NSObject
 
 /*

--- a/Headers/Additions/GNUstepGUI/GSWindowDecorationView.h
+++ b/Headers/Additions/GNUstepGUI/GSWindowDecorationView.h
@@ -56,6 +56,7 @@ Abstract superclass for the top-level view in each window. This view is
 responsible for managing window decorations. Concrete subclasses may do
 this, either directly, or indirectly (by using the backend).
 */
+APPKIT_EXPORT_CLASS
 @interface GSWindowDecorationView : NSView
 {
   NSWindow *window; /* not retained */
@@ -101,6 +102,7 @@ windowNumber will be 0.
 /* Manage window decorations by using the backend functions. This only works
  * on backends that can handle window decorations.
  */
+APPKIT_EXPORT_CLASS
 @interface GSBackendWindowDecorationView : GSWindowDecorationView
 @end
 
@@ -110,6 +112,7 @@ Standard OPENSTEP-ish window decorations.
 */
 @class NSButton;
 
+APPKIT_EXPORT_CLASS
 @interface GSStandardWindowDecorationView : GSWindowDecorationView
 {
   BOOL hasTitleBar, hasResizeBar, hasCloseButton, hasMiniaturizeButton;

--- a/Headers/Additions/GNUstepGUI/GSXibKeyedUnarchiver.h
+++ b/Headers/Additions/GNUstepGUI/GSXibKeyedUnarchiver.h
@@ -30,11 +30,13 @@
  Free Software Foundation, 51 Franklin Street, Fifth Floor,
  Boston, MA 02110-1301, USA.
  */
-
+ 
+#import <AppKit/AppKitDefines.h>
 #import <Foundation/Foundation.h>
 
 @class GSXibElement;
 
+APPKIT_EXPORT_CLASS
 @interface GSXibKeyedUnarchiver : NSKeyedUnarchiver
 {
   NSMutableDictionary *objects;

--- a/Headers/Additions/GNUstepGUI/GSXibLoading.h
+++ b/Headers/Additions/GNUstepGUI/GSXibLoading.h
@@ -162,6 +162,7 @@
 - (NSDictionary *) customClassNames;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface IBUserDefinedRuntimeAttributesPlaceholder : NSObject <NSCoding>
 {
   NSArray  *runtimeAttributes;
@@ -176,6 +177,7 @@
 
 @end
 
+APPKIT_EXPORT_CLASS
 @interface IBUserDefinedRuntimeAttribute : NSObject <NSCoding>
 {
   NSString *typeIdentifier;

--- a/Headers/Additions/GNUstepGUI/IMConnectors.h
+++ b/Headers/Additions/GNUstepGUI/IMConnectors.h
@@ -38,6 +38,7 @@
 #include <Foundation/NSObject.h>
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface IMConnector : NSObject
 {
   id source;
@@ -54,6 +55,7 @@
 - (void)establishConnection;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface IMOutletConnector : IMConnector
 - (void)establishConnection;
 @end

--- a/Headers/Additions/GNUstepGUI/IMCustomObject.h
+++ b/Headers/Additions/GNUstepGUI/IMCustomObject.h
@@ -49,6 +49,7 @@
 @end
 
 
+APPKIT_EXPORT_CLASS
 @interface IMCustomObject : NSObject
 {
   NSString* className;
@@ -61,6 +62,7 @@
 @end
 
 
+APPKIT_EXPORT_CLASS
 @interface IMCustomView : NSView
 {
   NSString* className;

--- a/Headers/Additions/GNUstepGUI/IMLoading.h
+++ b/Headers/Additions/GNUstepGUI/IMLoading.h
@@ -41,6 +41,7 @@
 - (void)awakeFromModel;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface GMModel : NSObject
 {
   NSArray* objects;

--- a/Headers/AppKit/AppKit.h
+++ b/Headers/AppKit/AppKit.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_AppKit
 #define _GNUstep_H_AppKit
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 /* Define library version */
 #import <GNUstepGUI/GSVersion.h>

--- a/Headers/AppKit/AppKitDefines.h
+++ b/Headers/AppKit/AppKitDefines.h
@@ -37,24 +37,37 @@
 
 #if BUILD_libgnustep_gui_DLL
 #
-# if defined(__MINGW32__)
+# if defined(__MINGW__)
   /* On Mingw, the compiler will export all symbols automatically, so
    * __declspec(dllexport) is not needed.
    */
+#  define APPKIT_EXPORT_CLASS
 #  define APPKIT_EXPORT  APPKIT_EXTERN
-#  define APPKIT_DECLARE 
+#  define APPKIT_IMPORT  __declspec(dllimport)
+#  define APPKIT_DECLARE
 # else
-#  define APPKIT_EXPORT  __declspec(dllexport) APPKIT_EXTERN
+#  define APPKIT_EXPORT_CLASS  __declspec(dllexport)
+#  define APPKIT_EXPORT  APPKIT_EXTERN __declspec(dllexport)
+#  define APPKIT_IMPORT  __declspec(dllimport)
 #  define APPKIT_DECLARE __declspec(dllexport)
 # endif
 #else
+# if defined(__MINGW__)
+   /* MinGW does not need dllimport on ObjC classes and produces warnings. */
+#  define APPKIT_EXPORT_CLASS
+# else
+#  define APPKIT_EXPORT_CLASS  __declspec(dllimport)
+# endif
+#  define APPKIT_IMPORT  __declspec(dllimport)
 #  define APPKIT_EXPORT  APPKIT_EXTERN __declspec(dllimport)
 #  define APPKIT_DECLARE __declspec(dllimport)
 #endif
 
 #else /* GNUSTEP_WITH[OUT]_DLL */
 
-#  define APPKIT_EXPORT APPKIT_EXTERN 
+#  define APPKIT_EXPORT_CLASS
+#  define APPKIT_EXPORT APPKIT_EXTERN
+#  define APPKIT_IMPORT
 #  define APPKIT_DECLARE
 
 #endif

--- a/Headers/AppKit/AppKitExceptions.h
+++ b/Headers/AppKit/AppKitExceptions.h
@@ -27,8 +27,6 @@
 
 #ifndef __AppKit_AppKitExceptions_h__
 #define __AppKit_AppKitExceptions_h__
-#import <GNUstepBase/GSVersionMacros.h>
-
 #import <AppKit/AppKitDefines.h>
 
 @class NSString;

--- a/Headers/AppKit/DPSOperators.h
+++ b/Headers/AppKit/DPSOperators.h
@@ -26,7 +26,7 @@
 
 #ifndef _DPSOperators_h_INCLUDE
 #define _DPSOperators_h_INCLUDE
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSGraphicsContext.h>
 

--- a/Headers/AppKit/NSAccessibilityCustomAction.h
+++ b/Headers/AppKit/NSAccessibilityCustomAction.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSAccessibilityCustomAction_h_GNUSTEP_GUI_INCLUDE
 #define _NSAccessibilityCustomAction_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -35,6 +36,7 @@ extern "C" {
 
 DEFINE_BLOCK_TYPE(GSAccessibilityCustomActionHandler, void, BOOL);
   
+APPKIT_EXPORT_CLASS
 @interface NSAccessibilityCustomAction : NSObject
 {
   NSString *_name;

--- a/Headers/AppKit/NSAccessibilityCustomRotor.h
+++ b/Headers/AppKit/NSAccessibilityCustomRotor.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSAccessibilityCustomRotor_h_GNUSTEP_GUI_INCLUDE
 #define _NSAccessibilityCustomRotor_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSRange.h>
@@ -80,6 +81,7 @@ enum
 typedef NSInteger NSAccessibilityCustomRotorType;
 
 // Rotor...
+APPKIT_EXPORT_CLASS
 @interface NSAccessibilityCustomRotor : NSObject
   
 - (instancetype) initWithLabel: (NSString *)label
@@ -103,6 +105,7 @@ typedef NSInteger NSAccessibilityCustomRotorType;
 @end
 
 // Results...
+APPKIT_EXPORT_CLASS
 @interface NSAccessibilityCustomRotorItemResult : NSObject
 
 - (instancetype)initWithTargetElement:(id<NSAccessibilityElement>)targetElement;

--- a/Headers/AppKit/NSAccessibilityElement.h
+++ b/Headers/AppKit/NSAccessibilityElement.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSAccessibilityElement_h_GNUSTEP_GUI_INCLUDE
 #define _NSAccessibilityElement_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -33,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSAccessibilityElement : NSObject
 
 @end

--- a/Headers/AppKit/NSActionCell.h
+++ b/Headers/AppKit/NSActionCell.h
@@ -29,10 +29,11 @@
 
 #ifndef _GNUstep_H_NSActionCell
 #define _GNUstep_H_NSActionCell
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSCell.h>
 
+APPKIT_EXPORT_CLASS
 @interface NSActionCell : NSCell
 {
   // Attributes

--- a/Headers/AppKit/NSAffineTransform.h
+++ b/Headers/AppKit/NSAffineTransform.h
@@ -28,7 +28,7 @@
 
 #ifndef _GNUstep_H_NSAffineTransform
 #define _GNUstep_H_NSAffineTransform
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSAffineTransform.h>
 

--- a/Headers/AppKit/NSAlert.h
+++ b/Headers/AppKit/NSAlert.h
@@ -28,7 +28,7 @@
 
 #ifndef _GNUstep_H_NSAlert
 #define _GNUstep_H_NSAlert
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -55,6 +55,7 @@ enum {
   NSAlertThirdButtonReturn = 1002
 };
 
+APPKIT_EXPORT_CLASS
 @interface NSAlert : NSObject 
 {
   @private

--- a/Headers/AppKit/NSAnimation.h
+++ b/Headers/AppKit/NSAnimation.h
@@ -28,13 +28,11 @@
 
 #ifndef _GNUstep_H_NSAnimation_
 #define _GNUstep_H_NSAnimation_
-
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_4, GS_API_LATEST)
 
 #import <Foundation/NSObject.h>
-#import <AppKit/AppKitDefines.h>
 #import <GNUstepGUI/GSAnimator.h>
 
 @class NSString;
@@ -109,6 +107,7 @@ APPKIT_EXPORT NSString *NSAnimationTriggerOrderOut;
  * It does not provide any drawing support for animation and does not directly
  * deal with views, targets, or actions.
  */
+APPKIT_EXPORT_CLASS
 @interface NSAnimation : NSObject < NSCopying, NSCoding, GSAnimation >
 {
 // FIXME ... all these ivars should be hidden inside a pointer to an
@@ -309,6 +308,7 @@ APPKIT_EXPORT NSString *NSViewAnimationFadeOutEffect;
  * The animation effects you can achieve are limited to changes in
  * frame location and size, and to fade-in and fade-out effects.
  */
+APPKIT_EXPORT_CLASS
 @interface NSViewAnimation : NSAnimation
 {
   NSArray *_viewAnimations;

--- a/Headers/AppKit/NSAnimationContext.h
+++ b/Headers/AppKit/NSAnimationContext.h
@@ -28,6 +28,7 @@
 
 #ifndef _GNUstep_H_NSAnimationContext_
 #define _GNUstep_H_NSAnimationContext_
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSDate.h>
@@ -37,6 +38,7 @@
 DEFINE_BLOCK_TYPE_NO_ARGS(GSAnimationContextCompletionHandler, void);
 DEFINE_BLOCK_TYPE(GSAnimationContextChanges, void, NSAnimationContext*);
 
+APPKIT_EXPORT_CLASS
 @interface NSAnimationContext : NSObject
 {
   NSTimeInterval _duration;

--- a/Headers/AppKit/NSAppearance.h
+++ b/Headers/AppKit/NSAppearance.h
@@ -37,6 +37,7 @@ extern "C" {
 
 typedef NSString* NSAppearanceName;
 
+APPKIT_EXPORT_CLASS
 @interface NSAppearance : NSObject <NSCoding>
 {
   NSString *_name;

--- a/Headers/AppKit/NSApplication.h
+++ b/Headers/AppKit/NSApplication.h
@@ -37,7 +37,7 @@
 
 #ifndef _GNUstep_H_NSApplication
 #define _GNUstep_H_NSApplication
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSResponder.h>
 #import <AppKit/NSUserInterfaceValidation.h>
@@ -200,6 +200,7 @@ typedef enum _NSApplicationPresentationOptions
 APPKIT_EXPORT NSString	*NSModalPanelRunLoopMode;
 APPKIT_EXPORT NSString	*NSEventTrackingRunLoopMode;
 
+APPKIT_EXPORT_CLASS
 @interface NSApplication : NSResponder <NSCoding,NSUserInterfaceValidations>
 {
   NSGraphicsContext	*_default_context;

--- a/Headers/AppKit/NSArrayController.h
+++ b/Headers/AppKit/NSArrayController.h
@@ -38,6 +38,7 @@
 @class NSIndexSet;
 @class NSPredicate;
 
+APPKIT_EXPORT_CLASS
 @interface NSArrayController : NSObjectController
 {
   NSArray *_arranged_objects;

--- a/Headers/AppKit/NSAttributedString.h
+++ b/Headers/AppKit/NSAttributedString.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSAttributedString
 #define _GNUstep_H_NSAttributedString
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 
@@ -39,7 +39,6 @@
 // for NSWritingDirection
 #import <AppKit/NSParagraphStyle.h>
 #import <AppKit/NSText.h>
-#import <AppKit/AppKitDefines.h>
 
 @class NSTextAttachment;
 @class NSFileWrapper;

--- a/Headers/AppKit/NSBezierPath.h
+++ b/Headers/AppKit/NSBezierPath.h
@@ -27,7 +27,7 @@
 
 #ifndef BEZIERPATH_H
 #define BEZIERPATH_H
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSGeometry.h>
 #import <Foundation/NSObject.h>
@@ -95,6 +95,7 @@ typedef enum {
   #endif
 } NSBezierPathElement;
 
+APPKIT_EXPORT_CLASS
 @interface NSBezierPath : NSObject <NSCopying, NSCoding>
 {
 @private

--- a/Headers/AppKit/NSBitmapImageRep.h
+++ b/Headers/AppKit/NSBitmapImageRep.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSBitmapImageRep
 #define _GNUstep_H_NSBitmapImageRep
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSImageRep.h>
 
@@ -139,6 +139,7 @@ APPKIT_EXPORT NSString *NSImageEXIFData; // No GNUstep support yet; for reading 
 
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSBitmapImageRep : NSImageRep
 {
   // Attributes

--- a/Headers/AppKit/NSBox.h
+++ b/Headers/AppKit/NSBox.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSBox
 #define _GNUstep_H_NSBox
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSView.h>
 
@@ -71,6 +71,7 @@ typedef enum _NSBoxType
 } NSBoxType;
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSBox : NSView <NSCoding>
 {
   // Attributes

--- a/Headers/AppKit/NSBrowser.h
+++ b/Headers/AppKit/NSBrowser.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSBrowser
 #define _GNUstep_H_NSBrowser
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSControl.h>
 
@@ -54,6 +54,7 @@ enum _NSBrowserColumnResizingType
 typedef NSUInteger NSBrowserColumnResizingType;
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSBrowser : NSControl <NSCoding>
 {
   // Attributes

--- a/Headers/AppKit/NSBrowserCell.h
+++ b/Headers/AppKit/NSBrowserCell.h
@@ -29,12 +29,13 @@
 
 #ifndef _GNUstep_H_NSBrowserCell
 #define _GNUstep_H_NSBrowserCell
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSCell.h>
 
 @class NSImage;
 
+APPKIT_EXPORT_CLASS
 @interface NSBrowserCell : NSCell
 {
   // Attributes

--- a/Headers/AppKit/NSButton.h
+++ b/Headers/AppKit/NSButton.h
@@ -30,7 +30,7 @@
 
 #ifndef _GNUstep_H_NSButton
 #define _GNUstep_H_NSButton
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSControl.h>
 #import <AppKit/NSButtonCell.h>
@@ -39,6 +39,7 @@
 @class NSString;
 @class NSEvent;
 
+APPKIT_EXPORT_CLASS
 @interface NSButton : NSControl
 {
   // Attributes

--- a/Headers/AppKit/NSButtonCell.h
+++ b/Headers/AppKit/NSButtonCell.h
@@ -30,7 +30,7 @@
 
 #ifndef _GNUstep_H_NSButtonCell
 #define _GNUstep_H_NSButtonCell
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSActionCell.h>
 
@@ -119,6 +119,7 @@ typedef enum _NSGradientType {
 } NSGradientType;
 
 
+APPKIT_EXPORT_CLASS
 @interface NSButtonCell : NSActionCell
 {
   // Attributes

--- a/Headers/AppKit/NSButtonTouchBarItem.h
+++ b/Headers/AppKit/NSButtonTouchBarItem.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSButtonTouchBarItem : NSTouchBarItem
 
 @end

--- a/Headers/AppKit/NSCIImageRep.h
+++ b/Headers/AppKit/NSCIImageRep.h
@@ -33,6 +33,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSCIImageRep : NSImageRep
 
 @end

--- a/Headers/AppKit/NSCachedImageRep.h
+++ b/Headers/AppKit/NSCachedImageRep.h
@@ -29,13 +29,14 @@
 
 #ifndef _GNUstep_H_NSCachedImageRep
 #define _GNUstep_H_NSCachedImageRep
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSImageRep.h>
 #import <AppKit/NSGraphics.h>
 
 @class NSWindow;
 
+APPKIT_EXPORT_CLASS
 @interface NSCachedImageRep : NSImageRep
 {
   // Attributes

--- a/Headers/AppKit/NSCandidateListTouchBarItem.h
+++ b/Headers/AppKit/NSCandidateListTouchBarItem.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSCandidateListTouchBarItem : NSTouchBarItem
 
 @end

--- a/Headers/AppKit/NSCell.h
+++ b/Headers/AppKit/NSCell.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSCell
 #define _GNUstep_H_NSCell
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSGeometry.h>
 
@@ -186,6 +186,7 @@ enum __NSControlSize {
 };
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSCell : NSObject <NSCopying, NSCoding>
 {
   // Attributes

--- a/Headers/AppKit/NSClickGestureRecognizer.h
+++ b/Headers/AppKit/NSClickGestureRecognizer.h
@@ -25,6 +25,7 @@
 
 #ifndef _NSClickGestureRecognizer_h_GNUSTEP_GUI_INCLUDE
 #define _NSClickGestureRecognizer_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSGestureRecognizer.h>
 
@@ -34,6 +35,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSClickGestureRecognizer : NSGestureRecognizer
 
 @end

--- a/Headers/AppKit/NSClipView.h
+++ b/Headers/AppKit/NSClipView.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSClipView
 #define _GNUstep_H_NSClipView
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSView.h>
 
@@ -37,6 +37,7 @@
 @class NSCursor;
 @class NSColor;
 
+APPKIT_EXPORT_CLASS
 @interface NSClipView : NSView
 {
   NSView* _documentView;

--- a/Headers/AppKit/NSCollectionView.h
+++ b/Headers/AppKit/NSCollectionView.h
@@ -28,8 +28,7 @@
 
 #ifndef _GNUstep_H_NSCollectionView
 #define _GNUstep_H_NSCollectionView
-
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSDragging.h>
 #import <AppKit/NSNibDeclarations.h>
@@ -72,6 +71,7 @@ namesOfPromisedFilesDroppedAtDestination:(NSURL *)dropURL
 @end
 
 
+APPKIT_EXPORT_CLASS
 @interface NSCollectionView : NSView //<NSDraggingDestination, NSDraggingSource>
 {
   NSArray *_content;

--- a/Headers/AppKit/NSCollectionViewItem.h
+++ b/Headers/AppKit/NSCollectionViewItem.h
@@ -28,8 +28,8 @@
 
 #ifndef _GNUstep_H_NSCollectionViewItem
 #define _GNUstep_H_NSCollectionViewItem
+#import <AppKit/AppKitDefines.h>
 
-#import <GNUstepBase/GSVersionMacros.h>
 #import <Foundation/NSArray.h>
 
 #import <AppKit/NSCollectionView.h>
@@ -41,6 +41,7 @@
 #import <AppKit/NSViewController.h>
 
 
+APPKIT_EXPORT_CLASS
 @interface NSCollectionViewItem : NSViewController
 {
   IBOutlet NSTextField *textField;

--- a/Headers/AppKit/NSColor.h
+++ b/Headers/AppKit/NSColor.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSColor
 #define _GNUstep_H_NSColor
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSCoder.h>
 #import <Foundation/NSObject.h>
@@ -86,6 +86,7 @@ typedef NSInteger NSColorSystemEffect;
  * used as synonyms to NSDeviceWhiteColorSpace and NSCalibratedWhiteColorSpace.
  */
 
+APPKIT_EXPORT_CLASS
 @interface NSColor : NSObject <NSCoding, NSCopying>
 {
 }

--- a/Headers/AppKit/NSColorList.h
+++ b/Headers/AppKit/NSColorList.h
@@ -31,10 +31,9 @@
 
 #ifndef _GNUstep_H_NSColorList
 #define _GNUstep_H_NSColorList
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
-#import <AppKit/AppKitDefines.h>
 
 @class NSString;
 @class NSArray;
@@ -44,6 +43,7 @@
 
 @class NSColor;
 
+APPKIT_EXPORT_CLASS
 @interface NSColorList : NSObject <NSCoding>
 
 {

--- a/Headers/AppKit/NSColorPanel.h
+++ b/Headers/AppKit/NSColorPanel.h
@@ -29,9 +29,8 @@
 
 #ifndef _GNUstep_H_NSColorPanel
 #define _GNUstep_H_NSColorPanel
-#import <GNUstepBase/GSVersionMacros.h>
-
 #import <AppKit/AppKitDefines.h>
+
 #import <AppKit/NSApplication.h>
 #import <AppKit/NSColorPicking.h>
 #import <AppKit/NSColorWell.h>
@@ -74,6 +73,7 @@ enum {
 - (void) orderFrontColorPanel: (id)sender;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSColorPanel : NSPanel
 {
   // Attributes

--- a/Headers/AppKit/NSColorPicker.h
+++ b/Headers/AppKit/NSColorPicker.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSColorPicker
 #define _GNUstep_H_NSColorPicker
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <AppKit/NSColorPicking.h>
@@ -39,6 +39,7 @@
 @class NSImage;
 @class NSButtonCell;
 
+APPKIT_EXPORT_CLASS
 @interface NSColorPicker : NSObject <NSColorPickingDefault>
 {
   // Attributes

--- a/Headers/AppKit/NSColorPickerTouchBarItem.h
+++ b/Headers/AppKit/NSColorPickerTouchBarItem.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSColorPickerTouchBarItem : NSTouchBarItem
 
 @end

--- a/Headers/AppKit/NSColorPicking.h
+++ b/Headers/AppKit/NSColorPicking.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSColorPicking
 #define _GNUstep_H_NSColorPicking
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 @class NSColor;
 @class NSColorPanel;

--- a/Headers/AppKit/NSColorSampler.h
+++ b/Headers/AppKit/NSColorSampler.h
@@ -37,6 +37,7 @@ extern "C" {
   
 DEFINE_BLOCK_TYPE(GSColorSampleHandler, void, NSColor*);
 
+APPKIT_EXPORT_CLASS
 @interface NSColorSampler : NSObject
 
 - (void) showSamplerWithSelectionHandler: (GSColorSampleHandler)selectionHandler;

--- a/Headers/AppKit/NSColorSpace.h
+++ b/Headers/AppKit/NSColorSpace.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSColorSpace
 #define _GNUstep_H_NSColorSpace
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_4, GS_API_LATEST)
 #import <Foundation/NSObject.h>
@@ -47,6 +47,7 @@ typedef enum _NSColorSpaceModel
   NSDeviceNColorSpaceModel
 } NSColorSpaceModel;
 
+APPKIT_EXPORT_CLASS
 @interface NSColorSpace : NSObject <NSCoding>
 {
   NSColorSpaceModel _colorSpaceModel;

--- a/Headers/AppKit/NSColorWell.h
+++ b/Headers/AppKit/NSColorWell.h
@@ -29,12 +29,13 @@
 
 #ifndef _GNUstep_H_NSColorWell
 #define _GNUstep_H_NSColorWell
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSControl.h>
 
 @class NSColor;
 
+APPKIT_EXPORT_CLASS
 @interface NSColorWell : NSControl <NSCoding>
 
 {

--- a/Headers/AppKit/NSComboBox.h
+++ b/Headers/AppKit/NSComboBox.h
@@ -27,7 +27,7 @@
 
 #ifndef _GNUstep_H_NSComboBox
 #define _GNUstep_H_NSComboBox
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSTextField.h>
 
@@ -35,6 +35,7 @@
 @class NSString;
 @class NSNotification;
 
+APPKIT_EXPORT_CLASS
 @interface NSComboBox : NSTextField
 {
 }

--- a/Headers/AppKit/NSComboBoxCell.h
+++ b/Headers/AppKit/NSComboBoxCell.h
@@ -27,7 +27,7 @@
 
 #ifndef _GNUstep_H_NSComboBoxCell
 #define _GNUstep_H_NSComboBoxCell
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSGeometry.h>
 #import <AppKit/NSTextFieldCell.h>
@@ -37,6 +37,7 @@
 @class NSArray;
 @class NSString;
 
+APPKIT_EXPORT_CLASS
 @interface NSComboBoxCell : NSTextFieldCell
 {
    id			_dataSource;

--- a/Headers/AppKit/NSControl.h
+++ b/Headers/AppKit/NSControl.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSControl
 #define _GNUstep_H_NSControl
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 // for NSWritingDirection
 #import <AppKit/NSParagraphStyle.h>
@@ -44,6 +44,7 @@
 @class NSEvent;
 @class NSTextView;
 
+APPKIT_EXPORT_CLASS
 @interface NSControl : NSView
 {
   // Attributes

--- a/Headers/AppKit/NSController.h
+++ b/Headers/AppKit/NSController.h
@@ -27,6 +27,7 @@
 
 #ifndef _GNUstep_H_NSController
 #define _GNUstep_H_NSController
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -34,6 +35,7 @@
 
 @class NSMutableArray;
 
+APPKIT_EXPORT_CLASS
 @interface NSController : NSObject <NSCoding>
 {
   NSMutableArray *_editors;

--- a/Headers/AppKit/NSCursor.h
+++ b/Headers/AppKit/NSCursor.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSCursor
 #define _GNUstep_H_NSCursor
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSGeometry.h>
 #import <Foundation/NSObject.h>
@@ -38,6 +38,7 @@
 @class NSEvent;
 @class NSColor;
 
+APPKIT_EXPORT_CLASS
 @interface NSCursor : NSObject <NSCoding>
 {
   NSImage	*_cursor_image;

--- a/Headers/AppKit/NSCustomImageRep.h
+++ b/Headers/AppKit/NSCustomImageRep.h
@@ -29,10 +29,11 @@
 
 #ifndef _GNUstep_H_NSCustomImageRep
 #define _GNUstep_H_NSCustomImageRep
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSImageRep.h>
 
+APPKIT_EXPORT_CLASS
 @interface NSCustomImageRep : NSImageRep
 {
   // Attributes

--- a/Headers/AppKit/NSCustomTouchBarItem.h
+++ b/Headers/AppKit/NSCustomTouchBarItem.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSCustomTouchBarItem : NSTouchBarItem
 
 @end

--- a/Headers/AppKit/NSDataAsset.h
+++ b/Headers/AppKit/NSDataAsset.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSDataAsset_h_GNUSTEP_GUI_INCLUDE
 #define _NSDataAsset_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -37,6 +38,7 @@ extern "C" {
   
 typedef NSString* NSDataAssetName;
   
+APPKIT_EXPORT_CLASS
 @interface NSDataAsset : NSObject <NSCopying>
 {
   NSDataAssetName _name;

--- a/Headers/AppKit/NSDataLink.h
+++ b/Headers/AppKit/NSDataLink.h
@@ -29,10 +29,9 @@
 
 #ifndef _GNUstep_H_NSDataLink
 #define _GNUstep_H_NSDataLink
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
-#import <AppKit/AppKitDefines.h>
 
 @class NSString;
 @class NSArray;
@@ -59,6 +58,7 @@ typedef enum _NSDataLinkUpdateMode {
 
 APPKIT_EXPORT NSString *NSDataLinkFileNameExtension;
 
+APPKIT_EXPORT_CLASS
 @interface NSDataLink : NSObject <NSCoding>
 {
   // Attributes

--- a/Headers/AppKit/NSDataLinkManager.h
+++ b/Headers/AppKit/NSDataLinkManager.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSDataLinkManager
 #define _GNUstep_H_NSDataLinkManager
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -41,6 +41,7 @@
 @class NSPasteboard;
 @class NSWindow;
 
+APPKIT_EXPORT_CLASS
 @interface NSDataLinkManager : NSObject <NSCoding>
 {
   // Attributes

--- a/Headers/AppKit/NSDataLinkPanel.h
+++ b/Headers/AppKit/NSDataLinkPanel.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSDataLinkPanel
 #define _GNUstep_H_NSDataLinkPanel
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSApplication.h>
 #import <AppKit/NSPanel.h>
@@ -42,6 +42,7 @@
 - (void) orderFrontDataLinkPanel: (id)sender;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSDataLinkPanel : NSPanel
 {
   // Outlets

--- a/Headers/AppKit/NSDatePicker.h
+++ b/Headers/AppKit/NSDatePicker.h
@@ -41,6 +41,7 @@
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_4, GS_API_LATEST)
 
+APPKIT_EXPORT_CLASS
 @interface NSDatePicker : NSControl
 
 - (NSColor *) backgroundColor;

--- a/Headers/AppKit/NSDatePickerCell.h
+++ b/Headers/AppKit/NSDatePickerCell.h
@@ -62,6 +62,7 @@ typedef NSUInteger NSDatePickerElementFlags;
 
 @class NSColor, NSDate, NSCalendar, NSLocale, NSTimeZone;
 
+APPKIT_EXPORT_CLASS
 @interface NSDatePickerCell : NSActionCell
 {
   NSColor *_backgroundColor;

--- a/Headers/AppKit/NSDockTile.h
+++ b/Headers/AppKit/NSDockTile.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSDockTile_h_GNUSTEP_GUI_INCLUDE
 #define _NSDockTile_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSGeometry.h>
@@ -36,6 +37,7 @@ extern "C" {
 
 @class NSView, NSString;
 
+APPKIT_EXPORT_CLASS
 @interface NSDockTile : NSObject
 {
   NSView   *_contentView;

--- a/Headers/AppKit/NSDocument.h
+++ b/Headers/AppKit/NSDocument.h
@@ -32,7 +32,7 @@
 
 #ifndef _GNUstep_H_NSDocument
 #define _GNUstep_H_NSDocument
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <AppKit/NSNibDeclarations.h>
@@ -84,6 +84,7 @@ typedef enum _NSSaveOperationType {
 #endif
 } NSSaveOperationType;
 
+APPKIT_EXPORT_CLASS
 @interface NSDocument : NSObject
 {
   @private

--- a/Headers/AppKit/NSDocumentController.h
+++ b/Headers/AppKit/NSDocumentController.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSDocumentController
 #define _GNUstep_H_NSDocumentController
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST) 
 
@@ -49,6 +49,7 @@
 @class NSOpenPanel;
 @class NSWindow;
 
+APPKIT_EXPORT_CLASS
 @interface NSDocumentController : NSObject <NSCoding>
 {
   @private

--- a/Headers/AppKit/NSDragging.h
+++ b/Headers/AppKit/NSDragging.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSDragging
 #define _GNUstep_H_NSDragging
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSGeometry.h>
 

--- a/Headers/AppKit/NSDrawer.h
+++ b/Headers/AppKit/NSDrawer.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSDrawer
 #define _GNUstep_H_NSDrawer
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSGeometry.h>
 #import <AppKit/NSResponder.h>
@@ -45,6 +45,7 @@ enum {
   NSDrawerClosingState = 3
 };
 
+APPKIT_EXPORT_CLASS
 @interface NSDrawer : NSResponder
 {
   // Attributes

--- a/Headers/AppKit/NSEPSImageRep.h
+++ b/Headers/AppKit/NSEPSImageRep.h
@@ -29,13 +29,14 @@
 
 #ifndef _GNUstep_H_NSEPSImageRep
 #define _GNUstep_H_NSEPSImageRep
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSGeometry.h>
 #import <AppKit/NSImageRep.h>
 
 @class NSData;
 
+APPKIT_EXPORT_CLASS
 @interface NSEPSImageRep : NSImageRep
 {
   // Attributes

--- a/Headers/AppKit/NSEvent.h
+++ b/Headers/AppKit/NSEvent.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSEvent
 #define _GNUstep_H_NSEvent
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSGeometry.h>
@@ -256,6 +256,7 @@ typedef NSUInteger NSEventSwipeTrackingOptions;
 
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSEvent : NSObject <NSCoding, NSCopying>
 {
   NSEventType	event_type;

--- a/Headers/AppKit/NSFileWrapperExtensions.h
+++ b/Headers/AppKit/NSFileWrapperExtensions.h
@@ -29,6 +29,7 @@
 
 #ifndef _GNUstep_H_NSFileWrapper_Extensions
 #define _GNUstep_H_NSFileWrapper_Extensions
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSFileWrapper.h>
 

--- a/Headers/AppKit/NSFont.h
+++ b/Headers/AppKit/NSFont.h
@@ -30,11 +30,10 @@
 
 #ifndef _GNUstep_H_NSFont
 #define _GNUstep_H_NSFont
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSGeometry.h>
-#import <AppKit/AppKitDefines.h>
 // For NSControlSize
 #import <AppKit/NSColor.h>
 
@@ -77,6 +76,7 @@ typedef enum _NSFontRenderingMode
 
 APPKIT_EXPORT const CGFloat *NSFontIdentityMatrix;
 
+APPKIT_EXPORT_CLASS
 @interface NSFont : NSObject <NSCoding, NSCopying>
 {
   NSString *fontName;

--- a/Headers/AppKit/NSFontAssetRequest.h
+++ b/Headers/AppKit/NSFontAssetRequest.h
@@ -45,8 +45,6 @@ enum {
 };
 typedef NSUInteger NSFontAssetRequestOptions;
 
-DEFINE_BLOCK_TYPE(GSFontAssetCompletionHandler, BOOL, NSError*);
-
 APPKIT_EXPORT_CLASS
 @interface NSFontAssetRequest : NSObject // <NSProgressReporting>
 

--- a/Headers/AppKit/NSFontAssetRequest.h
+++ b/Headers/AppKit/NSFontAssetRequest.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSFontAssetRequest_h_GNUSTEP_GUI_INCLUDE
 #define _NSFontAssetRequest_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSError.h>
@@ -44,6 +45,9 @@ enum {
 };
 typedef NSUInteger NSFontAssetRequestOptions;
 
+DEFINE_BLOCK_TYPE(GSFontAssetCompletionHandler, BOOL, NSError*);
+
+APPKIT_EXPORT_CLASS
 @interface NSFontAssetRequest : NSObject // <NSProgressReporting>
 
 - (instancetype) initWithFontDescriptors: (NSArray *)fontDescriptors

--- a/Headers/AppKit/NSFontCollection.h
+++ b/Headers/AppKit/NSFontCollection.h
@@ -51,6 +51,7 @@ APPKIT_EXPORT NSFontCollectionMatchingOptionKey const NSFontCollectionDisallowAu
 
 typedef NSString* NSFontCollectionName;
 
+APPKIT_EXPORT_CLASS
 @interface NSFontCollection : NSObject <NSCopying, NSMutableCopying, NSCoding>
 {
   NSMutableDictionary *_fontCollectionDictionary;
@@ -97,6 +98,7 @@ typedef NSString* NSFontCollectionName;
 @end
  
 
+APPKIT_EXPORT_CLASS
 @interface NSMutableFontCollection : NSFontCollection
 
 + (NSMutableFontCollection *) fontCollectionWithDescriptors: (NSArray *)queryDescriptors;

--- a/Headers/AppKit/NSFontDescriptor.h
+++ b/Headers/AppKit/NSFontDescriptor.h
@@ -30,10 +30,9 @@
 
 #ifndef _GNUstep_H_NSFontDescriptor
 #define _GNUstep_H_NSFontDescriptor
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
-#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_3, GS_API_LATEST)
 
@@ -103,6 +102,7 @@ APPKIT_EXPORT NSString *NSFontVariationAxisMaximumValueKey;
 APPKIT_EXPORT NSString *NSFontVariationAxisDefaultValueKey;
 APPKIT_EXPORT NSString *NSFontVariationAxisNameKey;
 
+APPKIT_EXPORT_CLASS
 @interface NSFontDescriptor : NSObject <NSCoding, NSCopying>
 {
   NSDictionary *_attributes;

--- a/Headers/AppKit/NSFontManager.h
+++ b/Headers/AppKit/NSFontManager.h
@@ -32,7 +32,7 @@
 
 #ifndef _GNUstep_H_NSFontManager
 #define _GNUstep_H_NSFontManager
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -81,6 +81,7 @@ typedef enum {
   NSLighterFontAction,
 } NSFontTag;
 
+APPKIT_EXPORT_CLASS
 @interface NSFontManager : NSObject
 {
   // Attributes

--- a/Headers/AppKit/NSFontPanel.h
+++ b/Headers/AppKit/NSFontPanel.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSFontPanel
 #define _GNUstep_H_NSFontPanel
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSPanel.h>
 #import <AppKit/NSFontManager.h>
@@ -56,6 +56,7 @@ enum {
   NSFPSizeBrowser
 };
 
+APPKIT_EXPORT_CLASS
 @interface NSFontPanel : NSPanel <NSTextFieldDelegate>
 {
   // Attributes

--- a/Headers/AppKit/NSForm.h
+++ b/Headers/AppKit/NSForm.h
@@ -29,13 +29,14 @@
 
 #ifndef _GNUstep_H_NSForm
 #define _GNUstep_H_NSForm
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSMatrix.h>
 
 @class NSFormCell;
 @class NSFont;
 
+APPKIT_EXPORT_CLASS
 @interface NSForm : NSMatrix
 {
   BOOL _title_width_needs_update;

--- a/Headers/AppKit/NSFormCell.h
+++ b/Headers/AppKit/NSFormCell.h
@@ -29,10 +29,11 @@
 
 #ifndef _GNUstep_H_NSFormCell
 #define _GNUstep_H_NSFormCell
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSActionCell.h>
 
+APPKIT_EXPORT_CLASS
 @interface NSFormCell : NSActionCell <NSCoding>
 {
   // NB: this is the titleWidth which is effectively used -- takes in

--- a/Headers/AppKit/NSGestureRecognizer.h
+++ b/Headers/AppKit/NSGestureRecognizer.h
@@ -31,6 +31,7 @@
 
 #ifndef _GNUstep_H_NSGestureRecognizer
 #define _GNUstep_H_NSGestureRecognizer
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSGeometry.h>
@@ -43,6 +44,7 @@ extern "C" {
 
 @class NSView, NSEvent;
 
+APPKIT_EXPORT_CLASS
 @interface NSGestureRecognizer : NSObject
 - (NSPoint)locationInView:(NSView *)view;
 @end

--- a/Headers/AppKit/NSGlyphGenerator.h
+++ b/Headers/AppKit/NSGlyphGenerator.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSGlyphGenerator
 #define _GNUstep_H_NSGlyphGenerator
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 // define NSGlyph
@@ -61,6 +61,7 @@ forStartingGlyphAtIndex: (NSUInteger)glyph
 @end
 
 
+APPKIT_EXPORT_CLASS
 @interface NSGlyphGenerator : NSObject
 
 + (id) sharedGlyphGenerator;

--- a/Headers/AppKit/NSGlyphInfo.h
+++ b/Headers/AppKit/NSGlyphInfo.h
@@ -25,7 +25,7 @@
 #ifndef _NSGlyphInfo_h_GNUSTEP_GUI_INCLUDE
 #define _NSGlyphInfo_h_GNUSTEP_GUI_INCLUDE
 
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 #import <Foundation/NSObject.h>
 #import <AppKit/NSFont.h>
 

--- a/Headers/AppKit/NSGradient.h
+++ b/Headers/AppKit/NSGradient.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSGradient
 #define _GNUstep_H_NSGradient
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
 #import <Foundation/NSGeometry.h>
@@ -47,6 +47,7 @@ enum {
   NSGradientDrawsAfterEndingLocation = 2
 };
 
+APPKIT_EXPORT_CLASS
 @interface NSGradient : NSObject <NSCopying, NSCoding>
 {
   NSColorSpace *_colorSpace;

--- a/Headers/AppKit/NSGraphics.h
+++ b/Headers/AppKit/NSGraphics.h
@@ -27,7 +27,7 @@
 
 #ifndef __NSGraphics_h__
 #define __NSGraphics_h__
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSGeometry.h>

--- a/Headers/AppKit/NSGraphicsContext.h
+++ b/Headers/AppKit/NSGraphicsContext.h
@@ -30,7 +30,7 @@
 
 #ifndef _NSGraphicsContext_h_INCLUDE
 #define _NSGraphicsContext_h_INCLUDE
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSMapTable.h>
@@ -168,6 +168,7 @@ typedef enum _GSColorSpace
   GSICC
 } GSColorSpace;
 
+APPKIT_EXPORT_CLASS
 @interface NSGraphicsContext : NSObject
 {
   /* Make the one public instance variable first in the object so that, if we

--- a/Headers/AppKit/NSGridView.h
+++ b/Headers/AppKit/NSGridView.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSGridView_h_GNUSTEP_GUI_INCLUDE
 #define _NSGridView_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSView.h>
 
@@ -57,6 +58,7 @@ APPKIT_EXPORT const CGFloat NSGridViewSizeForContent;
 
 @class NSGridColumn, NSGridRow, NSGridCell, NSArray, NSMutableArray;
   
+APPKIT_EXPORT_CLASS
 @interface NSGridView : NSView
 {
   NSGridRowAlignment _rowAlignment;
@@ -109,6 +111,7 @@ APPKIT_EXPORT const CGFloat NSGridViewSizeForContent;
 @end
 
 /// Cell
+APPKIT_EXPORT_CLASS
 @interface NSGridCell : NSObject <NSCoding>
 {
   NSView *_contentView;
@@ -144,6 +147,7 @@ APPKIT_EXPORT const CGFloat NSGridViewSizeForContent;
 @end
 
 /// Column
+APPKIT_EXPORT_CLASS
 @interface NSGridColumn : NSObject <NSCoding>
 {
   NSGridView *_gridView;
@@ -174,6 +178,7 @@ APPKIT_EXPORT const CGFloat NSGridViewSizeForContent;
 @end
 
 /// Row
+APPKIT_EXPORT_CLASS
 @interface NSGridRow : NSObject <NSCoding>
 {
   NSGridView *_gridView;

--- a/Headers/AppKit/NSGroupTouchBarItem.h
+++ b/Headers/AppKit/NSGroupTouchBarItem.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSGroupTouchBarItem : NSTouchBarItem
 
 @end

--- a/Headers/AppKit/NSHelpManager.h
+++ b/Headers/AppKit/NSHelpManager.h
@@ -29,7 +29,7 @@
 
 #ifndef __GNUstep_H_NSHelpManager
 #define __GNUstep_H_NSHelpManager
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSBundle.h>
 #import <Foundation/NSGeometry.h>

--- a/Headers/AppKit/NSHelpPanel.h
+++ b/Headers/AppKit/NSHelpPanel.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSHelpPanel
 #define _GNUstep_H_NSHelpPanel
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(GS_API_OPENSTEP,GS_API_MACOSX) || GS_API_VERSION(GS_API_NONE, GS_API_LATEST)
 
@@ -42,6 +42,7 @@
 - (void) orderFrontHelpPanel: (id)sender;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSHelpPanel : NSPanel
 {
   // Attributes

--- a/Headers/AppKit/NSImage.h
+++ b/Headers/AppKit/NSImage.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSImage
 #define _GNUstep_H_NSImage
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSGraphicsContext.h>
 #import <Foundation/NSBundle.h>
@@ -123,6 +123,7 @@ APPKIT_EXTERN NSString *const NSImageNameNetwork;
 APPKIT_EXTERN NSString *const NSImageNameFolder;
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSImage : NSObject <NSCoding, NSCopying>
 {
   // Attributes

--- a/Headers/AppKit/NSImageCell.h
+++ b/Headers/AppKit/NSImageCell.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSImageCell
 #define _GNUstep_H_NSImageCell
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSCell.h>
 
@@ -85,6 +85,7 @@ typedef enum {
  *  <p>The -setImageFrameStyle: method can be used to control if the
  *  cell should display a frame border, and which one.</p>
  */
+APPKIT_EXPORT_CLASS
 @interface NSImageCell : NSCell
 {
   NSImageAlignment _imageAlignment;

--- a/Headers/AppKit/NSImageRep.h
+++ b/Headers/AppKit/NSImageRep.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSImageRep
 #define _GNUstep_H_NSImageRep
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSGeometry.h>
 #import <Foundation/NSObject.h>
@@ -46,6 +46,7 @@ enum {
   NSImageRepMatchesDevice
 };
 
+APPKIT_EXPORT_CLASS
 @interface NSImageRep : NSObject <NSCoding, NSCopying>
 {
   // Attributes

--- a/Headers/AppKit/NSImageView.h
+++ b/Headers/AppKit/NSImageView.h
@@ -27,11 +27,12 @@
 
 #ifndef _GNUstep_H_NSImageView
 #define _GNUstep_H_NSImageView
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSControl.h>
 #import <AppKit/NSImageCell.h>
 
+APPKIT_EXPORT_CLASS
 @interface NSImageView : NSControl
 {
   id _target;

--- a/Headers/AppKit/NSInputManager.h
+++ b/Headers/AppKit/NSInputManager.h
@@ -27,7 +27,7 @@
 
 #ifndef _GNUstep_H_NSInputManager
 #define _GNUstep_H_NSInputManager
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSGeometry.h>
 #import <Foundation/NSObject.h>

--- a/Headers/AppKit/NSInputServer.h
+++ b/Headers/AppKit/NSInputServer.h
@@ -27,7 +27,7 @@
 
 #ifndef _GNUstep_H_NSInputServer
 #define _GNUstep_H_NSInputServer
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSGeometry.h>
 #import <Foundation/NSObject.h>

--- a/Headers/AppKit/NSInterfaceStyle.h
+++ b/Headers/AppKit/NSInterfaceStyle.h
@@ -27,7 +27,7 @@
 
 #ifndef _GNUstep_H_NSInterfaceStyle
 #define _GNUstep_H_NSInterfaceStyle
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if defined(__cplusplus)
 extern "C" {

--- a/Headers/AppKit/NSKeyValueBinding.h
+++ b/Headers/AppKit/NSKeyValueBinding.h
@@ -29,7 +29,7 @@
 #ifndef _GNUstep_H_NSKeyValueBinding
 #define _GNUstep_H_NSKeyValueBinding
 
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 #import <Foundation/NSObject.h>
 #import <AppKit/AppKitDefines.h>
 

--- a/Headers/AppKit/NSLayoutAnchor.h
+++ b/Headers/AppKit/NSLayoutAnchor.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSLayoutAnchor_h_GNUSTEP_GUI_INCLUDE
 #define _NSLayoutAnchor_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -35,6 +36,7 @@ extern "C" {
 
 @class NSLayoutConstraint, NSString, NSArray;
   
+APPKIT_EXPORT_CLASS
 @interface NSLayoutAnchor : NSObject <NSCoding, NSCopying>
 {
   NSString *_name;
@@ -61,6 +63,7 @@ extern "C" {
   
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSLayoutDimension : NSLayoutAnchor
 {
 }
@@ -79,12 +82,14 @@ extern "C" {
   
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSLayoutXAxisAnchor : NSLayoutAnchor
 
 - (NSLayoutDimension *) anchorWithOffsetToAnchor: (NSLayoutXAxisAnchor *)anchor;
   
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSLayoutYAxisAnchor : NSLayoutAnchor
 
 - (NSLayoutDimension *) anchorWithOffsetToAnchor: (NSLayoutYAxisAnchor *)anchor;

--- a/Headers/AppKit/NSLayoutConstraint.h
+++ b/Headers/AppKit/NSLayoutConstraint.h
@@ -103,6 +103,7 @@ enum {
 };
 typedef NSUInteger NSLayoutFormatOptions;
 
+APPKIT_EXPORT_CLASS
 @interface NSLayoutConstraint : NSObject <NSCoding, NSCopying>
 {
   NSLayoutAnchor *_firstAnchor;

--- a/Headers/AppKit/NSLayoutGuide.h
+++ b/Headers/AppKit/NSLayoutGuide.h
@@ -38,6 +38,7 @@ extern "C" {
 
 @class NSView, NSLayoutXAxisAnchor, NSLayoutYAxisAnchor, NSLayoutDimension;
   
+APPKIT_EXPORT_CLASS
 @interface NSLayoutGuide : NSObject <NSCoding, NSUserInterfaceItemIdentification>
 {
   NSRect _frame;

--- a/Headers/AppKit/NSLayoutManager.h
+++ b/Headers/AppKit/NSLayoutManager.h
@@ -27,7 +27,7 @@
 
 #ifndef _GNUstep_H_NSLayoutManager
 #define _GNUstep_H_NSLayoutManager
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSGeometry.h>
 #import <GNUstepGUI/GSLayoutManager.h>
@@ -47,6 +47,7 @@ typedef enum {
 } GSInsertionPointMovementDirection;
 
 
+APPKIT_EXPORT_CLASS
 @interface NSLayoutManager : GSLayoutManager
 {
   /* Public for use only in the associated NSTextViews.  Don't access

--- a/Headers/AppKit/NSLevelIndicator.h
+++ b/Headers/AppKit/NSLevelIndicator.h
@@ -36,6 +36,7 @@
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_4, GS_API_LATEST)
 
+APPKIT_EXPORT_CLASS
 @interface NSLevelIndicator : NSControl
 {
 }

--- a/Headers/AppKit/NSLevelIndicatorCell.h
+++ b/Headers/AppKit/NSLevelIndicatorCell.h
@@ -44,6 +44,7 @@ typedef enum _NSLevelIndicatorStyle
   NSRatingLevelIndicatorStyle
 } NSLevelIndicatorStyle;
 
+APPKIT_EXPORT_CLASS
 @interface NSLevelIndicatorCell : NSActionCell
 {
   double _minValue;

--- a/Headers/AppKit/NSMagnificationGestureRecognizer.h
+++ b/Headers/AppKit/NSMagnificationGestureRecognizer.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSMagnificationGestureRecognizer : NSGestureRecognizer
 
 @end

--- a/Headers/AppKit/NSMatrix.h
+++ b/Headers/AppKit/NSMatrix.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSMatrix
 #define _GNUstep_H_NSMatrix
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSControl.h>
 
@@ -52,6 +52,7 @@ typedef enum _NSMatrixMode {
 @protocol NSMatrixDelegate <NSControlTextEditingDelegate>
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSMatrix : NSControl <NSCoding>
 {
   __strong id		**_cells;

--- a/Headers/AppKit/NSMediaLibraryBrowserController.h
+++ b/Headers/AppKit/NSMediaLibraryBrowserController.h
@@ -42,6 +42,7 @@ enum {
 };
 typedef NSUInteger NSMediaLibrary;  
 
+APPKIT_EXPORT_CLASS
 @interface NSMediaLibraryBrowserController : NSObject
 
 + (NSMediaLibraryBrowserController *) sharedMediaLibraryBrowserController;

--- a/Headers/AppKit/NSMenu.h
+++ b/Headers/AppKit/NSMenu.h
@@ -28,7 +28,7 @@
 
 #ifndef _GNUstep_H_NSMenu
 #define _GNUstep_H_NSMenu
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSGeometry.h>
@@ -386,6 +386,7 @@
  *  </enum>
  *
  */
+APPKIT_EXPORT_CLASS
 @interface NSMenu : NSObject <NSCoding, NSCopying>
 {
   NSString *_title;

--- a/Headers/AppKit/NSMenuItem.h
+++ b/Headers/AppKit/NSMenuItem.h
@@ -32,7 +32,7 @@
 
 #ifndef _GNUstep_H_NSMenuItem
 #define _GNUstep_H_NSMenuItem
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <AppKit/NSUserInterfaceValidation.h>
@@ -368,6 +368,7 @@
 
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSMenuItem : NSObject <NSMenuItem, NSValidatedUserInterfaceItem>
 {
   NSMenu *_menu;

--- a/Headers/AppKit/NSMenuItemCell.h
+++ b/Headers/AppKit/NSMenuItemCell.h
@@ -27,7 +27,7 @@
 
 #ifndef _GNUstep_H_NSMenuItemCell
 #define _GNUstep_H_NSMenuItemCell
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSButtonCell.h>
 #import <AppKit/NSMenuItem.h>
@@ -36,6 +36,7 @@
 
 typedef void (*DrawingIMP)(id, SEL, NSRect, NSView*);
 
+APPKIT_EXPORT_CLASS
 @interface NSMenuItemCell : NSButtonCell <NSCopying, NSCoding>
 {
   NSMenuItem *_menuItem;

--- a/Headers/AppKit/NSMenuView.h
+++ b/Headers/AppKit/NSMenuView.h
@@ -27,7 +27,7 @@
 
 #ifndef _GNUstep_H_NSMenuView
 #define _GNUstep_H_NSMenuView
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSMenu.h>
 #import <AppKit/NSMenuItem.h>
@@ -78,6 +78,7 @@
    </item>
    </list>
 */
+APPKIT_EXPORT_CLASS
 @interface NSMenuView : NSView <NSCoding, NSMenuView>
 {
   NSMutableArray *_itemCells;

--- a/Headers/AppKit/NSMovie.h
+++ b/Headers/AppKit/NSMovie.h
@@ -28,7 +28,7 @@
 
 #ifndef _GNUstep_H_NSMovie
 #define _GNUstep_H_NSMovie
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -37,6 +37,7 @@
 @class NSURL;
 @class NSPasteboard;
 
+APPKIT_EXPORT_CLASS
 @interface NSMovie : NSObject <NSCopying, NSCoding> 
 {
   @private

--- a/Headers/AppKit/NSMovieView.h
+++ b/Headers/AppKit/NSMovieView.h
@@ -28,7 +28,7 @@
 
 #ifndef _GNUstep_H_NSMovieView
 #define _GNUstep_H_NSMovieView
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSView.h>
 
@@ -40,6 +40,7 @@ typedef enum {
   NSQTMovieLoopingBackAndForthPlayback
 } NSQTMovieLoopMode;
 
+APPKIT_EXPORT_CLASS
 @interface NSMovieView : NSView
 {
   @protected

--- a/Headers/AppKit/NSNib.h
+++ b/Headers/AppKit/NSNib.h
@@ -41,7 +41,7 @@
 
 #ifndef _GNUstep_H_NSNib
 #define _GNUstep_H_NSNib
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSZone.h>
@@ -62,6 +62,7 @@ APPKIT_EXPORT NSString *NSNibOwner;
 
 typedef NSString *NSNibName;
 
+APPKIT_EXPORT_CLASS
 @interface NSNib : NSObject <NSCoding>
 {
   NSData *_nibData;

--- a/Headers/AppKit/NSNibConnector.h
+++ b/Headers/AppKit/NSNibConnector.h
@@ -27,12 +27,13 @@
 
 #ifndef _GNUstep_H_NSNibConnector
 #define _GNUstep_H_NSNibConnector
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
 @class NSString;
 
+APPKIT_EXPORT_CLASS
 @interface NSNibConnector : NSObject <NSCoding>
 {
   id		_src;

--- a/Headers/AppKit/NSNibControlConnector.h
+++ b/Headers/AppKit/NSNibControlConnector.h
@@ -30,6 +30,7 @@
 
 #import <AppKit/NSNibConnector.h>
 
+APPKIT_EXPORT_CLASS
 @interface NSNibControlConnector : NSNibConnector
 - (void) establishConnection;
 @end

--- a/Headers/AppKit/NSNibDeclarations.h
+++ b/Headers/AppKit/NSNibDeclarations.h
@@ -30,7 +30,7 @@
 
 #ifndef _NSNibDeclarations_H_
 #define _NSNibDeclarations_H_
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 /* IBOutlet and IBAction are now built-in macros in recent Clang */

--- a/Headers/AppKit/NSNibLoading.h
+++ b/Headers/AppKit/NSNibLoading.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSNibLoading
 #define _GNUstep_H_NSNibLoading
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSBundle.h>

--- a/Headers/AppKit/NSNibOutletConnector.h
+++ b/Headers/AppKit/NSNibOutletConnector.h
@@ -30,6 +30,7 @@
 
 #import <AppKit/NSNibConnector.h>
 
+APPKIT_EXPORT_CLASS
 @interface NSNibOutletConnector : NSNibConnector
 - (void) establishConnection;
 @end

--- a/Headers/AppKit/NSObjectController.h
+++ b/Headers/AppKit/NSObjectController.h
@@ -28,7 +28,7 @@
 
 #ifndef _GNUstep_H_NSObjectController
 #define _GNUstep_H_NSObjectController
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSController.h>
 #import <AppKit/NSMenuItem.h>
@@ -43,6 +43,7 @@
 @class NSFetchRequest;
 @class NSManagedObjectContext;
 
+APPKIT_EXPORT_CLASS
 @interface NSObjectController : NSController
 {
   @protected

--- a/Headers/AppKit/NSOpenGL.h
+++ b/Headers/AppKit/NSOpenGL.h
@@ -25,7 +25,7 @@
 
 #ifndef _NSOpenGL_h_INCLUDE
 #define _NSOpenGL_h_INCLUDE
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -86,6 +86,7 @@ typedef enum {
   NSOpenGLGOResetLibrary = 504
 } NSOpenGLGlobalOption;
 
+APPKIT_EXPORT_CLASS
 @interface NSOpenGLPixelFormat : NSObject <NSCoding>
 {
 }
@@ -96,6 +97,7 @@ typedef enum {
 - (int)numberOfVirtualScreens;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSOpenGLContext : NSObject
 {
 }

--- a/Headers/AppKit/NSOpenGLView.h
+++ b/Headers/AppKit/NSOpenGLView.h
@@ -25,13 +25,14 @@
 
 #ifndef _NSOpenGLView_h
 #define _NSOpenGLView_h
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSView.h>
 
 @class NSOpenGLContext;
 @class NSOpenGLPixelFormat;
 
+APPKIT_EXPORT_CLASS
 @interface NSOpenGLView : NSView
 {
   NSOpenGLContext 	*glcontext;

--- a/Headers/AppKit/NSOpenPanel.h
+++ b/Headers/AppKit/NSOpenPanel.h
@@ -36,13 +36,14 @@
 
 #ifndef _GNUstep_H_NSOpenPanel
 #define _GNUstep_H_NSOpenPanel
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSSavePanel.h>
 
 @class NSString;
 @class NSArray;
 
+APPKIT_EXPORT_CLASS
 @interface NSOpenPanel : NSSavePanel
 {
   BOOL _canChooseDirectories;

--- a/Headers/AppKit/NSOutlineView.h
+++ b/Headers/AppKit/NSOutlineView.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSOutlineView
 #define _GNUstep_H_NSOutlineView
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSTableView.h>
 
@@ -38,6 +38,7 @@
 @class NSString;
 @class NSURL;
 
+APPKIT_EXPORT_CLASS
 @interface NSOutlineView : NSTableView
 {
   NSMapTable *_itemDict;

--- a/Headers/AppKit/NSPDFImageRep.h
+++ b/Headers/AppKit/NSPDFImageRep.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSPDFImageRep_h_GNUSTEP_GUI_INCLUDE
 #define _NSPDFImageRep_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSImageRep.h>
 
@@ -33,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSPDFImageRep : NSImageRep
 {
   NSArray *_pageReps;

--- a/Headers/AppKit/NSPDFInfo.h
+++ b/Headers/AppKit/NSPDFInfo.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSPDFInfo_h_GNUSTEP_GUI_INCLUDE
 #define _NSPDFInfo_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSGeometry.h>
@@ -37,6 +38,7 @@ extern "C" {
 
 @class NSURL, NSArray, NSMutableDictionary;
   
+APPKIT_EXPORT_CLASS
 @interface NSPDFInfo : NSObject <NSCoding, NSCopying>
 {
   NSURL *_url;

--- a/Headers/AppKit/NSPDFPanel.h
+++ b/Headers/AppKit/NSPDFPanel.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSPDFPanel_h_GNUSTEP_GUI_INCLUDE
 #define _NSPDFPanel_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -44,6 +45,7 @@ typedef NSUInteger NSPDFPanelOptions;
 
 DEFINE_BLOCK_TYPE(GSPDFPanelCompletionHandler, void, NSInteger);
   
+APPKIT_EXPORT_CLASS
 @interface NSPDFPanel : NSObject
 {
   NSViewController *_accessoryController;

--- a/Headers/AppKit/NSPICTImageRep.h
+++ b/Headers/AppKit/NSPICTImageRep.h
@@ -36,6 +36,7 @@ extern "C" {
 
 @class NSData;
   
+APPKIT_EXPORT_CLASS
 @interface NSPICTImageRep : NSImageRep
 {
   NSBitmapImageRep *_pageRep;

--- a/Headers/AppKit/NSPageController.h
+++ b/Headers/AppKit/NSPageController.h
@@ -47,6 +47,7 @@ enum
 };
 typedef NSUInteger NSPageControllerTransitionStyle;
 
+APPKIT_EXPORT_CLASS
 @interface NSPageController : NSViewController 
 {
   NSPageControllerTransitionStyle _transitionStyle;

--- a/Headers/AppKit/NSPageLayout.h
+++ b/Headers/AppKit/NSPageLayout.h
@@ -30,7 +30,7 @@
 
 #ifndef _GNUstep_H_NSPageLayout
 #define _GNUstep_H_NSPageLayout
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSApplication.h>
 #import <AppKit/NSPanel.h>
@@ -65,6 +65,7 @@ enum {
 - (void) runPageLayout: (id)sender;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSPageLayout : NSPanel
 {
   id _controller; 

--- a/Headers/AppKit/NSPanGestureRecognizer.h
+++ b/Headers/AppKit/NSPanGestureRecognizer.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSPanGestureRecognizer : NSGestureRecognizer
 
 @end

--- a/Headers/AppKit/NSPanel.h
+++ b/Headers/AppKit/NSPanel.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSPanel
 #define _GNUstep_H_NSPanel
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSWindow.h>
 
@@ -70,6 +70,7 @@ enum {
 #define	NS_ALERTERROR		NSAlertErrorReturn
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSPanel : NSWindow
 {
   // Think of the following as BOOL ivars

--- a/Headers/AppKit/NSParagraphStyle.h
+++ b/Headers/AppKit/NSParagraphStyle.h
@@ -31,7 +31,7 @@
 
 #ifndef _GNUstep_H_NSParagraphStyle
 #define _GNUstep_H_NSParagraphStyle
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <AppKit/NSText.h>
@@ -67,6 +67,7 @@ typedef NSInteger NSWritingDirection;
 APPKIT_EXPORT NSString *NSTabColumnTerminatorsAttributeName; 
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSTextTab : NSObject <NSCopying, NSCoding>
 {
   NSTextTabType	_tabStopType;
@@ -89,6 +90,7 @@ APPKIT_EXPORT NSString *NSTabColumnTerminatorsAttributeName;
 
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSParagraphStyle : NSObject <NSCopying, NSMutableCopying, NSCoding>
 {
   NSMutableArray *_tabStops;
@@ -192,6 +194,7 @@ APPKIT_EXPORT NSString *NSTabColumnTerminatorsAttributeName;
 
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSMutableParagraphStyle : NSParagraphStyle
 {
 }

--- a/Headers/AppKit/NSPasteboard.h
+++ b/Headers/AppKit/NSPasteboard.h
@@ -30,7 +30,7 @@
 
 #ifndef _GNUstep_H_NSPasteboard
 #define _GNUstep_H_NSPasteboard
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <AppKit/AppKitDefines.h>
@@ -196,6 +196,7 @@ APPKIT_EXPORT NSString *const NSPasteboardTypeTextFinderOptions;
 #endif
 
 
+APPKIT_EXPORT_CLASS
 @interface NSPasteboard : NSObject
 {
   NSString	*name;		// The name of this pasteboard.

--- a/Headers/AppKit/NSPasteboardItem.h
+++ b/Headers/AppKit/NSPasteboardItem.h
@@ -27,7 +27,7 @@
 
 #ifndef _GNUstep_H_NSPasteboardItem
 #define _GNUstep_H_NSPasteboardItem 
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <AppKit/AppKitDefines.h>
@@ -43,6 +43,7 @@
 
 @protocol NSPasteboardItemDataProvider;
 
+APPKIT_EXPORT_CLASS
 @interface NSPasteboardItem : NSObject <NSPasteboardWriting, NSPasteboardReading> {
   NSMutableDictionary *_providerMap;
   NSMutableDictionary *_dataMap;

--- a/Headers/AppKit/NSPathCell.h
+++ b/Headers/AppKit/NSPathCell.h
@@ -44,6 +44,7 @@ typedef NSUInteger NSPathStyle;
 
 @class NSEvent, NSView, NSArray, NSString, NSAttributeString, NSColor, NSPathComponentCell, NSOpenPanel, NSURL;    
   
+APPKIT_EXPORT_CLASS
 @interface NSPathCell : NSActionCell
 {
   NSPathStyle _pathStyle;

--- a/Headers/AppKit/NSPathComponentCell.h
+++ b/Headers/AppKit/NSPathComponentCell.h
@@ -35,6 +35,7 @@ extern "C" {
 
 @class NSImage, NSURL;
   
+APPKIT_EXPORT_CLASS
 @interface NSPathComponentCell : NSTextFieldCell
 {
   NSImage *_image;

--- a/Headers/AppKit/NSPathControl.h
+++ b/Headers/AppKit/NSPathControl.h
@@ -40,6 +40,7 @@ extern "C" {
 @class NSColor, NSPathComponentCell, NSArray, NSURL, NSAttributedString, NSString,
   NSMenu, NSPasteboard, NSOpenPanel, NSPathControlItem;
   
+APPKIT_EXPORT_CLASS
 @interface NSPathControl : NSControl
 {
   NSArray *_pathItems;

--- a/Headers/AppKit/NSPathControlItem.h
+++ b/Headers/AppKit/NSPathControlItem.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSPathControlItem_h_GNUSTEP_GUI_INCLUDE
 #define _NSPathControlItem_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -35,6 +36,7 @@ extern "C" {
 
 @class NSURL, NSAttributedString, NSImage, NSString;
 
+APPKIT_EXPORT_CLASS
 @interface NSPathControlItem : NSObject
 {
   NSURL *_url;

--- a/Headers/AppKit/NSPersistentDocument.h
+++ b/Headers/AppKit/NSPersistentDocument.h
@@ -41,6 +41,7 @@ extern "C" {
 @class NSDictionary;
 @class NSUndoManager;
 
+APPKIT_EXPORT_CLASS
 @interface NSPersistentDocument : NSDocument
 {
   NSManagedObjectContext *_managedObjectContext;

--- a/Headers/AppKit/NSPickerTouchBarItem.h
+++ b/Headers/AppKit/NSPickerTouchBarItem.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSPickerTouchBarItem : NSTouchBarItem
 
 @end

--- a/Headers/AppKit/NSPopUpButton.h
+++ b/Headers/AppKit/NSPopUpButton.h
@@ -42,6 +42,7 @@
 @class NSArray;
 
 
+APPKIT_EXPORT_CLASS
 @interface NSPopUpButton : NSButton
 {
 }

--- a/Headers/AppKit/NSPopUpButtonCell.h
+++ b/Headers/AppKit/NSPopUpButtonCell.h
@@ -46,6 +46,7 @@ typedef enum {
   NSPopUpArrowAtBottom = 2
 } NSPopUpArrowPosition;
 
+APPKIT_EXPORT_CLASS
 @interface NSPopUpButtonCell : NSMenuItemCell
 {
   id <NSMenuItem> _selectedItem;

--- a/Headers/AppKit/NSPopover.h
+++ b/Headers/AppKit/NSPopover.h
@@ -64,6 +64,7 @@ typedef NSInteger NSPopoverBehavior;
 @protocol NSPopoverDelegate;
 
 /* Class */
+APPKIT_EXPORT_CLASS
 @interface NSPopover : NSResponder
 {
   BOOL _animates;

--- a/Headers/AppKit/NSPopoverTouchBarItem.h
+++ b/Headers/AppKit/NSPopoverTouchBarItem.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSPopoverTouchBarItem : NSTouchBarItem
 
 @end

--- a/Headers/AppKit/NSPredicateEditor.h
+++ b/Headers/AppKit/NSPredicateEditor.h
@@ -35,6 +35,7 @@
 
 @class NSArray;
 
+APPKIT_EXPORT_CLASS
 @interface NSPredicateEditor : NSRuleEditor {
   NSArray *_rowTemplates;
 }

--- a/Headers/AppKit/NSPredicateEditorRowTemplate.h
+++ b/Headers/AppKit/NSPredicateEditorRowTemplate.h
@@ -28,6 +28,7 @@
 
 #ifndef _GNUstep_H_NSPredicateEditorRowTemplate
 #define _GNUstep_H_NSPredicateEditorRowTemplate
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/Foundation.h>
 
@@ -53,6 +54,7 @@ enum {
 };
 typedef NSUInteger NSAttributeType;
 
+APPKIT_EXPORT_CLASS
 @interface NSPredicateEditorRowTemplate : NSObject {
 
 }

--- a/Headers/AppKit/NSPressGestureRecognizer.h
+++ b/Headers/AppKit/NSPressGestureRecognizer.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSPressGestureRecognizer : NSGestureRecognizer
 
 @end

--- a/Headers/AppKit/NSPrintInfo.h
+++ b/Headers/AppKit/NSPrintInfo.h
@@ -60,6 +60,7 @@ typedef enum _NSPrintingPaginationMode {
   NSClipPagination
 } NSPrintingPaginationMode;
 
+APPKIT_EXPORT_CLASS
 @interface NSPrintInfo : NSObject <NSCoding, NSCopying>
 {
   NSMutableDictionary *_info;

--- a/Headers/AppKit/NSPrintOperation.h
+++ b/Headers/AppKit/NSPrintOperation.h
@@ -36,7 +36,7 @@
 
 #ifndef _GNUstep_H_NSPrintOperation
 #define _GNUstep_H_NSPrintOperation
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSGeometry.h>
@@ -58,6 +58,7 @@ typedef enum _NSPrintingPageOrder {
   NSUnknownPageOrder
 } NSPrintingPageOrder;
 
+APPKIT_EXPORT_CLASS
 @interface NSPrintOperation : NSObject
 {
   // Attributes

--- a/Headers/AppKit/NSPrintPanel.h
+++ b/Headers/AppKit/NSPrintPanel.h
@@ -94,6 +94,7 @@ APPKIT_EXPORT NSString *NSPrintPanelAccessorySummaryItemDescriptionKey;
 APPKIT_EXPORT NSString *NSPrintPhotoJobStyleHint;
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSPrintPanel : NSPanel
 {
   id _panel;

--- a/Headers/AppKit/NSPrinter.h
+++ b/Headers/AppKit/NSPrinter.h
@@ -32,6 +32,7 @@
 
 #ifndef _GNUstep_H_NSPrinter
 #define _GNUstep_H_NSPrinter
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSGeometry.h>
@@ -47,6 +48,7 @@ typedef enum _NSPrinterTableStatus {
   NSPrinterTableError
 } NSPrinterTableStatus;
 
+APPKIT_EXPORT_CLASS
 @interface NSPrinter : NSObject <NSCoding>
 {
   NSString *_printerHost;

--- a/Headers/AppKit/NSProgressIndicator.h
+++ b/Headers/AppKit/NSProgressIndicator.h
@@ -27,7 +27,7 @@
 
 #ifndef _GNUstep_H_NSProgressIndicator
 #define _GNUstep_H_NSProgressIndicator
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSView.h>
 
@@ -54,6 +54,7 @@ typedef enum _NSProgressIndicatorStyle
   NSProgressIndicatorSpinningStyle = 1
 } NSProgressIndicatorStyle;
 
+APPKIT_EXPORT_CLASS
 @interface NSProgressIndicator : NSView
 {
   double _doubleValue;

--- a/Headers/AppKit/NSResponder.h
+++ b/Headers/AppKit/NSResponder.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSResponder
 #define _GNUstep_H_NSResponder
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <AppKit/NSInterfaceStyle.h>
@@ -44,6 +44,7 @@
 @class NSUndoManager;
 @class NSWindow;
 
+APPKIT_EXPORT_CLASS
 @interface NSResponder : NSObject <NSCoding>
 {
 PACKAGE_SCOPE

--- a/Headers/AppKit/NSRotationGestureRecognizer.h
+++ b/Headers/AppKit/NSRotationGestureRecognizer.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSRotationGestureRecognizer : NSGestureRecognizer
 
 @end

--- a/Headers/AppKit/NSRuleEditor.h
+++ b/Headers/AppKit/NSRuleEditor.h
@@ -28,6 +28,7 @@
 
 #ifndef _GNUstep_H_NSRuleEditor
 #define _GNUstep_H_NSRuleEditor
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSControl.h>
 
@@ -57,6 +58,7 @@ extern NSString * const NSRuleEditorPredicateCompoundType;
 
 extern NSString *NSRuleEditorRowsDidChangeNotification;
 
+APPKIT_EXPORT_CLASS
 @interface NSRuleEditor : NSControl {
   id _target;
   SEL _action;

--- a/Headers/AppKit/NSRulerMarker.h
+++ b/Headers/AppKit/NSRulerMarker.h
@@ -31,6 +31,7 @@
 
 #ifndef _GNUstep_H_NSRulerMarker
 #define _GNUstep_H_NSRulerMarker
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSGeometry.h>
@@ -39,6 +40,7 @@
 @class NSImage;
 @class NSEvent;
 
+APPKIT_EXPORT_CLASS
 @interface NSRulerMarker : NSObject <NSCopying, NSCoding>
 {
   NSRulerView *_rulerView;

--- a/Headers/AppKit/NSRulerView.h
+++ b/Headers/AppKit/NSRulerView.h
@@ -52,6 +52,7 @@ typedef enum {
 
 @class GSRulerUnit;
 
+APPKIT_EXPORT_CLASS
 @interface NSRulerView : NSView
 {
   GSRulerUnit *_unit;

--- a/Headers/AppKit/NSRunningApplication.h
+++ b/Headers/AppKit/NSRunningApplication.h
@@ -32,7 +32,7 @@
 
 #import <Foundation/Foundation.h>
 #import <AppKit/NSWorkspace.h>
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
 
@@ -49,6 +49,7 @@ enum {
   NSApplicationActivationPolicyProhibited
 };
 
+APPKIT_EXPORT_CLASS
 @interface NSRunningApplication : NSObject
 #if GS_HAS_DECLARED_PROPERTIES
 @property (readonly, getter=isTerminated) BOOL terminated;

--- a/Headers/AppKit/NSSavePanel.h
+++ b/Headers/AppKit/NSSavePanel.h
@@ -33,7 +33,7 @@
 
 #ifndef _GNUstep_H_NSSavePanel
 #define _GNUstep_H_NSSavePanel
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 #import <GNUstepBase/GSBlocks.h>
 
 #import <AppKit/NSPanel.h>
@@ -84,6 +84,7 @@ enum {
 
 DEFINE_BLOCK_TYPE(GSSavePanelCompletionHandler, void, NSInteger);
 
+APPKIT_EXPORT_CLASS
 @interface NSSavePanel : NSPanel
 {
   NSView *_accessoryView;

--- a/Headers/AppKit/NSScreen.h
+++ b/Headers/AppKit/NSScreen.h
@@ -33,7 +33,7 @@
 
 #ifndef _GNUstep_H_NSScreen
 #define _GNUstep_H_NSScreen
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <AppKit/NSGraphics.h>
@@ -41,6 +41,7 @@
 @class NSArray;
 @class NSDictionary;
 
+APPKIT_EXPORT_CLASS
 @interface NSScreen : NSObject
 {
 @private

--- a/Headers/AppKit/NSScrollView.h
+++ b/Headers/AppKit/NSScrollView.h
@@ -30,7 +30,7 @@
 
 #ifndef _GNUstep_H_NSScrollView
 #define _GNUstep_H_NSScrollView
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSView.h>
 
@@ -49,6 +49,7 @@ typedef NSInteger NSScrollElasticity;
 @class NSCursor;
 @class NSScroller;
 
+APPKIT_EXPORT_CLASS
 @interface NSScrollView : NSView
 {
   NSClipView *_contentView;

--- a/Headers/AppKit/NSScroller.h
+++ b/Headers/AppKit/NSScroller.h
@@ -30,7 +30,7 @@
 
 #ifndef _GNUstep_H_NSScroller
 #define _GNUstep_H_NSScroller
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSControl.h>
 #import <AppKit/NSCell.h>
@@ -86,6 +86,7 @@ enum _NSScrollerArrow {
 };
 typedef NSUInteger NSScrollerArrow;
 
+APPKIT_EXPORT_CLASS
 @interface NSScroller : NSControl <NSCoding>
 {
   double _doubleValue;

--- a/Headers/AppKit/NSScrubber.h
+++ b/Headers/AppKit/NSScrubber.h
@@ -33,6 +33,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSScrubber : NSView
 
 @end

--- a/Headers/AppKit/NSScrubberItemView.h
+++ b/Headers/AppKit/NSScrubberItemView.h
@@ -33,10 +33,12 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSScrubberArrangedView : NSView
 
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSScrubberItemView : NSScrubberArrangedView
 
 @end

--- a/Headers/AppKit/NSScrubberLayout.h
+++ b/Headers/AppKit/NSScrubberLayout.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSScrubberLayout_h_GNUSTEP_GUI_INCLUDE
 #define _NSScrubberLayout_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSCoder.h>
@@ -37,6 +38,7 @@ extern "C" {
 
 @class NSScrubber; 
   
+APPKIT_EXPORT_CLASS
 @interface NSScrubberLayoutAttributes : NSObject <NSCopying>
 
 + (NSScrubberLayoutAttributes *) layoutAttributesForItemAtIndex: (NSInteger)index;
@@ -49,6 +51,7 @@ extern "C" {
 
 @end
   
+APPKIT_EXPORT_CLASS
 @interface NSScrubberLayout : NSObject <NSCoding>
 
 // Configuring

--- a/Headers/AppKit/NSSearchField.h
+++ b/Headers/AppKit/NSSearchField.h
@@ -32,6 +32,7 @@
 
 #import <AppKit/NSTextField.h>
 
+APPKIT_EXPORT_CLASS
 @interface NSSearchField : NSTextField
 
 - (NSArray *) recentSearches;

--- a/Headers/AppKit/NSSearchFieldCell.h
+++ b/Headers/AppKit/NSSearchFieldCell.h
@@ -45,6 +45,7 @@ enum
     NSSearchFieldNoRecentsMenuItemTag = 1003
 };
 
+APPKIT_EXPORT_CLASS
 @interface NSSearchFieldCell : NSTextFieldCell
 {
     NSMutableArray *_recent_searches;

--- a/Headers/AppKit/NSSecureTextField.h
+++ b/Headers/AppKit/NSSecureTextField.h
@@ -33,12 +33,14 @@
 #import <AppKit/NSTextField.h>
 #import <AppKit/NSTextFieldCell.h>
 
+APPKIT_EXPORT_CLASS
 @interface NSSecureTextField : NSTextField
 {}
 - (void) setEchosBullets:(BOOL)flag;
 - (BOOL) echosBullets;
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSSecureTextFieldCell : NSTextFieldCell
 {
   BOOL _echosBullets;

--- a/Headers/AppKit/NSSegmentedCell.h
+++ b/Headers/AppKit/NSSegmentedCell.h
@@ -43,6 +43,7 @@ typedef enum {
 @class NSMenu;
 @class NSView;
 
+APPKIT_EXPORT_CLASS
 @interface NSSegmentedCell : NSActionCell
 {
   @private

--- a/Headers/AppKit/NSSegmentedControl.h
+++ b/Headers/AppKit/NSSegmentedControl.h
@@ -40,6 +40,7 @@ typedef enum _NSSegmentStyle {
 } NSSegmentStyle;
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSSegmentedControl : NSControl
 
 // Specifying number of segments...

--- a/Headers/AppKit/NSSelection.h
+++ b/Headers/AppKit/NSSelection.h
@@ -29,12 +29,14 @@
 
 #ifndef _GNUstep_H_NSSelection
 #define _GNUstep_H_NSSelection
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
 @class NSData;
 @class NSPasteboard;
 
+APPKIT_EXPORT_CLASS
 @interface NSSelection : NSObject <NSCoding>
 {
   // Attributes

--- a/Headers/AppKit/NSShadow.h
+++ b/Headers/AppKit/NSShadow.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSShadow
 #define _GNUstep_H_NSShadow
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_3, GS_API_LATEST)
 #import <Foundation/NSGeometry.h>
@@ -37,6 +37,7 @@
 
 @class NSColor;
 
+APPKIT_EXPORT_CLASS
 @interface NSShadow : NSObject <NSCopying, NSCoding>
 {
     NSSize _offset;

--- a/Headers/AppKit/NSSharingService.h
+++ b/Headers/AppKit/NSSharingService.h
@@ -27,15 +27,18 @@
 */
 #ifndef __GNUstep_NSSharingService
 #define __GNUstep_NSSharingService
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
+APPKIT_EXPORT_CLASS
 @interface NSSharingService : NSObject
 @end
 
 @protocol NSSharingServiceDelegate <NSObject>
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSSharingServicePicker : NSObject 
 @end
 

--- a/Headers/AppKit/NSSharingServicePickerToolbarItem.h
+++ b/Headers/AppKit/NSSharingServicePickerToolbarItem.h
@@ -35,6 +35,7 @@ extern "C" {
 
 @protocol NSSharingServicePickerToolbarItemDelegate;
   
+APPKIT_EXPORT_CLASS
 @interface NSSharingServicePickerToolbarItem : NSToolbarItem
 
 - (id) activityItemsConfiguration;

--- a/Headers/AppKit/NSSharingServicePickerTouchBarItem.h
+++ b/Headers/AppKit/NSSharingServicePickerTouchBarItem.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSSharingServicePickerTouchBarItem : NSTouchBarItem
 
 @end

--- a/Headers/AppKit/NSSlider.h
+++ b/Headers/AppKit/NSSlider.h
@@ -38,6 +38,7 @@
 @class NSColor;
 @class NSEvent;
 
+APPKIT_EXPORT_CLASS
 @interface NSSlider : NSControl
 // appearance 
 - (double) altIncrementValue;

--- a/Headers/AppKit/NSSliderAccessory.h
+++ b/Headers/AppKit/NSSliderAccessory.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSSliderAccessory_h_GNUSTEP_GUI_INCLUDE
 #define _NSSliderAccessory_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -36,6 +37,7 @@ extern "C" {
 @class NSSliderAccessoryBehavior;
 @class NSImage;
   
+APPKIT_EXPORT_CLASS
 @interface NSSliderAccessory : NSObject <NSCopying, NSCoding>
 {
   NSImage *_image;
@@ -56,6 +58,7 @@ extern "C" {
 // Behavior...
 DEFINE_BLOCK_TYPE(GSSliderAccessoryBehaviorHandler, void, NSSliderAccessory*);
   
+APPKIT_EXPORT_CLASS
 @interface NSSliderAccessoryBehavior : NSObject <NSCopying, NSCoding>
 
 // Initializers

--- a/Headers/AppKit/NSSliderCell.h
+++ b/Headers/AppKit/NSSliderCell.h
@@ -49,6 +49,7 @@ typedef enum _NSSliderType
     NSCircularSlider
 } NSSliderType;
 
+APPKIT_EXPORT_CLASS
 @interface NSSliderCell : NSActionCell <NSCoding>
 {
   double	_value;

--- a/Headers/AppKit/NSSliderTouchBarItem.h
+++ b/Headers/AppKit/NSSliderTouchBarItem.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSSliderTouchBarItem : NSTouchBarItem
 
 @end

--- a/Headers/AppKit/NSSound.h
+++ b/Headers/AppKit/NSSound.h
@@ -54,6 +54,7 @@
  */
 NSArray *PlaybackDeviceIdentifiers (void);
 
+APPKIT_EXPORT_CLASS
 @interface NSSound : NSObject <NSCoding, NSCopying>
 {		
   NSString *_name;

--- a/Headers/AppKit/NSSpeechRecognizer.h
+++ b/Headers/AppKit/NSSpeechRecognizer.h
@@ -38,6 +38,7 @@ extern "C" {
 
 @class NSArray, NSString, NSUUID;
   
+APPKIT_EXPORT_CLASS
 @interface NSSpeechRecognizer : NSObject
 {
   id<NSSpeechRecognizerDelegate> _delegate;

--- a/Headers/AppKit/NSSpeechSynthesizer.h
+++ b/Headers/AppKit/NSSpeechSynthesizer.h
@@ -100,6 +100,7 @@ extern NSString *NSSpeechDictionaryEntrySpelling;
 extern NSString *NSSpeechDictionaryEntryPhonemes;
 
 // class declaration...
+APPKIT_EXPORT_CLASS
 @interface NSSpeechSynthesizer : NSObject
 
 // init...

--- a/Headers/AppKit/NSSpellChecker.h
+++ b/Headers/AppKit/NSSpellChecker.h
@@ -52,6 +52,7 @@ enum
   NSCorrectionIndicatorTypeGuesses
 };
 
+APPKIT_EXPORT_CLASS
 @interface NSSpellChecker : NSObject
 {
 @private

--- a/Headers/AppKit/NSSplitView.h
+++ b/Headers/AppKit/NSSplitView.h
@@ -45,6 +45,7 @@ enum {
 typedef NSInteger NSSplitViewDividerStyle;
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSSplitView : NSView
 {
   id	      _delegate;

--- a/Headers/AppKit/NSSplitViewController.h
+++ b/Headers/AppKit/NSSplitViewController.h
@@ -37,6 +37,7 @@ extern "C" {
 
 @class NSSplitView, NSSplitViewItem, NSArray, NSMutableArray;
   
+APPKIT_EXPORT_CLASS
 @interface NSSplitViewController : NSViewController
 {
   CGFloat _minimumThicknessForInlineSidebars;

--- a/Headers/AppKit/NSSplitViewItem.h
+++ b/Headers/AppKit/NSSplitViewItem.h
@@ -62,6 +62,7 @@ typedef NSInteger NSTitlebarSeparatorStyle;
 
 @class NSViewController;
   
+APPKIT_EXPORT_CLASS
 @interface NSSplitViewItem : NSObject <NSCoding>
 {
   CGFloat _automaticMaximumThickness;

--- a/Headers/AppKit/NSStackView.h
+++ b/Headers/AppKit/NSStackView.h
@@ -64,6 +64,7 @@ static const CGFloat NSStackViewSpacingUseDefault = FLT_MAX;
 
 @protocol NSStackViewDelegate;
   
+APPKIT_EXPORT_CLASS
 @interface NSStackView : NSView
 {
   id<NSStackViewDelegate> _delegate;

--- a/Headers/AppKit/NSStatusBar.h
+++ b/Headers/AppKit/NSStatusBar.h
@@ -28,11 +28,13 @@
 */
 #ifndef _GNUstep_H_NSStatusBar
 #define _GNUstep_H_NSStatusBar
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/Foundation.h>
 
 @class NSStatusItem;
 
+APPKIT_EXPORT_CLASS
 @interface NSStatusBar : NSObject
 {
   @private

--- a/Headers/AppKit/NSStatusBarButton.h
+++ b/Headers/AppKit/NSStatusBarButton.h
@@ -33,6 +33,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSStatusBarButton : NSButton
 {
   BOOL _appearsDisabled;

--- a/Headers/AppKit/NSStatusItem.h
+++ b/Headers/AppKit/NSStatusItem.h
@@ -33,7 +33,7 @@
 
 #ifndef _GNUstep_H_NSStatusItem
 #define _GNUstep_H_NSStatusItem
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 #import <Foundation/NSObject.h>
 #import <Foundation/NSGeometry.h>
 
@@ -45,6 +45,7 @@
 @class NSMenu;
 @class NSMenuItem;
 
+APPKIT_EXPORT_CLASS
 @interface NSStatusItem : NSObject
 {
   @private

--- a/Headers/AppKit/NSStepper.h
+++ b/Headers/AppKit/NSStepper.h
@@ -32,6 +32,7 @@
 
 #import <AppKit/NSControl.h>
 
+APPKIT_EXPORT_CLASS
 @interface NSStepper : NSControl
 {
   // Attributes

--- a/Headers/AppKit/NSStepperCell.h
+++ b/Headers/AppKit/NSStepperCell.h
@@ -30,6 +30,7 @@
 
 #import <AppKit/NSActionCell.h>
 
+APPKIT_EXPORT_CLASS
 @interface NSStepperCell : NSActionCell
 {
   // Think of the following ones as of two BOOL ivars

--- a/Headers/AppKit/NSStepperTouchBarItem.h
+++ b/Headers/AppKit/NSStepperTouchBarItem.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSStepperTouchBarItem : NSTouchBarItem
 
 @end

--- a/Headers/AppKit/NSStoryboard.h
+++ b/Headers/AppKit/NSStoryboard.h
@@ -40,6 +40,7 @@ typedef NSString *NSStoryboardSceneIdentifier;
 
 DEFINE_BLOCK_TYPE(NSStoryboardControllerCreator, NSCoder*, id);
 
+APPKIT_EXPORT_CLASS
 @interface NSStoryboard : NSObject
 {
   id _transform;

--- a/Headers/AppKit/NSStoryboardSegue.h
+++ b/Headers/AppKit/NSStoryboardSegue.h
@@ -39,6 +39,7 @@ typedef NSString *NSStoryboardSegueIdentifier;
 
 DEFINE_BLOCK_TYPE_NO_ARGS(GSStoryboardSeguePerformHandler, void);
   
+APPKIT_EXPORT_CLASS
 @interface NSStoryboardSegue : NSObject
 {
   id _sourceController;

--- a/Headers/AppKit/NSStringDrawing.h
+++ b/Headers/AppKit/NSStringDrawing.h
@@ -32,7 +32,7 @@
 
 #ifndef _GNUstep_H_NSStringDrawing
 #define _GNUstep_H_NSStringDrawing
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 

--- a/Headers/AppKit/NSSwitch.h
+++ b/Headers/AppKit/NSSwitch.h
@@ -35,6 +35,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSSwitch : NSControl <NSAccessibilitySwitch>
 {
   NSControlStateValue _state;

--- a/Headers/AppKit/NSTabView.h
+++ b/Headers/AppKit/NSTabView.h
@@ -45,6 +45,7 @@ typedef enum {
 @class NSFont;
 @class NSTabViewItem;
 
+APPKIT_EXPORT_CLASS
 @interface NSTabView : NSView <NSCoding>
 {
   NSMutableArray *_items;

--- a/Headers/AppKit/NSTabViewController.h
+++ b/Headers/AppKit/NSTabViewController.h
@@ -45,6 +45,7 @@ enum
 };
 typedef NSUInteger NSTabViewControllerTabStyle;
   
+APPKIT_EXPORT_CLASS
 @interface NSTabViewController : NSViewController
 {
   NSTabViewControllerTabStyle _tabStyle;

--- a/Headers/AppKit/NSTabViewItem.h
+++ b/Headers/AppKit/NSTabViewItem.h
@@ -43,6 +43,7 @@ typedef enum {
 @class NSView;
 @class NSViewController;
 
+APPKIT_EXPORT_CLASS
 @interface NSTabViewItem : NSObject <NSCoding>
 {
   id _ident;

--- a/Headers/AppKit/NSTableColumn.h
+++ b/Headers/AppKit/NSTableColumn.h
@@ -30,9 +30,9 @@
 
 #ifndef _GNUstep_H_NSTableColumn
 #define _GNUstep_H_NSTableColumn
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
-#import <AppKit/AppKitDefines.h>
 
 @class NSSortDescriptor;
 @class NSCell;
@@ -56,6 +56,7 @@ enum {
   /** Allow the user to resize the column manually. */
 };
 
+APPKIT_EXPORT_CLASS
 @interface NSTableColumn : NSObject <NSCoding>
 {
   id _identifier;

--- a/Headers/AppKit/NSTableHeaderCell.h
+++ b/Headers/AppKit/NSTableHeaderCell.h
@@ -27,10 +27,11 @@
 
 #ifndef _GNUstep_H_NSTableHeaderCell
 #define _GNUstep_H_NSTableHeaderCell
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSTextFieldCell.h>
 
+APPKIT_EXPORT_CLASS
 @interface NSTableHeaderCell : NSTextFieldCell
 {
 }

--- a/Headers/AppKit/NSTableHeaderView.h
+++ b/Headers/AppKit/NSTableHeaderView.h
@@ -36,6 +36,7 @@
 
 @class NSTableView;
 
+APPKIT_EXPORT_CLASS
 @interface NSTableHeaderView : NSView
 {
   NSTableView *_tableView;

--- a/Headers/AppKit/NSTableView.h
+++ b/Headers/AppKit/NSTableView.h
@@ -91,6 +91,7 @@ typedef enum _NSTableViewAnimationOptions
 #endif
 
 
+APPKIT_EXPORT_CLASS
 @interface NSTableView : NSControl <NSUserInterfaceValidations>
 {
   /*

--- a/Headers/AppKit/NSText.h
+++ b/Headers/AppKit/NSText.h
@@ -128,6 +128,7 @@ enum {
   NSBacktabKey        = 25
 };
 
+APPKIT_EXPORT_CLASS
 @interface NSText : NSView <NSChangeSpelling, NSIgnoreMisspelledWords>
 {
 }

--- a/Headers/AppKit/NSTextAlternatives.h
+++ b/Headers/AppKit/NSTextAlternatives.h
@@ -29,13 +29,13 @@
 
 #ifndef _GNUstep_H_NSTextAlternatives 
 #define _GNUstep_H_NSTextAlternatives 
-
 #import <AppKit/AppKitDefines.h>
+
 #import <Foundation/NSString.h>
-#import <GNUstepBase/GSVersionMacros.h>
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_8, GS_API_LATEST)
 
+APPKIT_EXPORT_CLASS
 @interface NSTextAlternatives : NSObject {
   NSString *_primaryString;
   NSArray *_alternativeStrings;

--- a/Headers/AppKit/NSTextAttachment.h
+++ b/Headers/AppKit/NSTextAttachment.h
@@ -43,8 +43,7 @@ the NSTextAttachment protocol.
 
 #ifndef _GNUstep_H_NSTextAttachment
 #define _GNUstep_H_NSTextAttachment
-
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 
@@ -144,12 +143,14 @@ The class uses -cellSize and -cellBaselineOffset to return a rect.
    By default this class causes NSTextView to send out delegate 
    messages when the attachment is clicked on or dragged.
  */
+APPKIT_EXPORT_CLASS
 @interface NSTextAttachmentCell : NSCell <NSTextAttachmentCell> {
     NSTextAttachment *_attachment;
 }
 @end
 
 
+APPKIT_EXPORT_CLASS
 @interface NSTextAttachment : NSObject <NSCoding> {
     NSFileWrapper *_fileWrapper;
     id <NSTextAttachmentCell>_cell;

--- a/Headers/AppKit/NSTextCheckingController.h
+++ b/Headers/AppKit/NSTextCheckingController.h
@@ -38,6 +38,7 @@ extern "C" {
 
 @class NSArray, NSDictionary, NSMenu;
 
+APPKIT_EXPORT_CLASS
 @interface NSTextCheckingController : NSObject
 {
   id<NSTextCheckingClient> _client;

--- a/Headers/AppKit/NSTextContainer.h
+++ b/Headers/AppKit/NSTextContainer.h
@@ -64,7 +64,7 @@ whenever this happens.
 
 #ifndef _GNUstep_H_NSTextContainer
 #define _GNUstep_H_NSTextContainer
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if GS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)
 
@@ -91,6 +91,7 @@ enum {
 };
 typedef NSUInteger NSLineMovementDirection;
 
+APPKIT_EXPORT_CLASS
 @interface NSTextContainer : NSObject
 {
   id _layoutManager;

--- a/Headers/AppKit/NSTextField.h
+++ b/Headers/AppKit/NSTextField.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSTextField
 #define _GNUstep_H_NSTextField
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSControl.h>
 // For NSTextFieldBezelStyle
@@ -43,6 +43,7 @@
 @protocol NSTextFieldDelegate <NSControlTextEditingDelegate>
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSTextField : NSControl
 {
   // Attributes

--- a/Headers/AppKit/NSTextFieldCell.h
+++ b/Headers/AppKit/NSTextFieldCell.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSTextFieldCell
 #define _GNUstep_H_NSTextFieldCell
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSActionCell.h>
 
@@ -43,6 +43,7 @@ typedef enum _NSTextFieldBezelStyle
 } NSTextFieldBezelStyle;
 #endif 
 
+APPKIT_EXPORT_CLASS
 @interface NSTextFieldCell : NSActionCell <NSCoding>
 {
   // Attributes

--- a/Headers/AppKit/NSTextFinder.h
+++ b/Headers/AppKit/NSTextFinder.h
@@ -73,6 +73,7 @@ typedef NSString* NSPasteboardTypeTextFinderOptionKey;
 APPKIT_EXPORT NSPasteboardTypeTextFinderOptionKey const NSTextFinderCaseInsensitiveKey;
 APPKIT_EXPORT NSPasteboardTypeTextFinderOptionKey const NSTextFinderMatchingTypeKey;
 
+APPKIT_EXPORT_CLASS
 @interface NSTextFinder : NSObject <NSCoding>
 {
   IBOutlet id<NSTextFinderClient> _client;

--- a/Headers/AppKit/NSTextInputContext.h
+++ b/Headers/AppKit/NSTextInputContext.h
@@ -38,6 +38,7 @@ extern "C" {
   
 typedef NSString* NSTextInputSourceIdentifier;
   
+APPKIT_EXPORT_CLASS
 @interface NSTextInputContext : NSObject
 {
   id<NSTextInputClient> _client;

--- a/Headers/AppKit/NSTextList.h
+++ b/Headers/AppKit/NSTextList.h
@@ -27,7 +27,7 @@
 
 #ifndef _GNUstep_H_NSTextList
 #define _GNUstep_H_NSTextList
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_4, GS_API_LATEST)
 #import <Foundation/NSObject.h>
@@ -38,6 +38,7 @@ enum {
 	NSTextListPrependEnclosingMarker = 1
 };
 
+APPKIT_EXPORT_CLASS
 @interface NSTextList : NSObject <NSCopying, NSCoding>
 {
 	NSString *_markerFormat;

--- a/Headers/AppKit/NSTextStorage.h
+++ b/Headers/AppKit/NSTextStorage.h
@@ -64,6 +64,7 @@ typedef NSUInteger NSTextStorageEditedOptions;
 /* 
  * The NSTextStorage 
  */
+APPKIT_EXPORT_CLASS
 @interface NSTextStorage : NSMutableAttributedString
 {
   NSRange		_editedRange;

--- a/Headers/AppKit/NSTextTable.h
+++ b/Headers/AppKit/NSTextTable.h
@@ -27,7 +27,7 @@
 
 #ifndef _GNUstep_H_NSTextTable
 #define _GNUstep_H_NSTextTable
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_4, GS_API_LATEST)
 #import <Foundation/NSObject.h>
@@ -70,6 +70,7 @@ typedef enum _NSTextBlockVerticalAlignment
 	NSTextBlockBaselineAlignment
 } NSTextBlockVerticalAlignment;
 
+APPKIT_EXPORT_CLASS
 @interface NSTextBlock : NSObject <NSCoding, NSCopying>
 {
   NSColor *_backgroundColor;
@@ -127,6 +128,7 @@ typedef enum _NSTextTableLayoutAlgorithm {
 	NSTextTableFixedLayoutAlgorithm
 } NSTextTableLayoutAlgorithm;
 
+APPKIT_EXPORT_CLASS
 @interface NSTextTable : NSTextBlock
 {
   NSTextTableLayoutAlgorithm _layoutAlgorithm;
@@ -161,6 +163,7 @@ typedef enum _NSTextTableLayoutAlgorithm {
 
 @end
 
+APPKIT_EXPORT_CLASS
 @interface NSTextTableBlock : NSTextBlock
 {
   NSTextTable *_table;

--- a/Headers/AppKit/NSTextView.h
+++ b/Headers/AppKit/NSTextView.h
@@ -31,7 +31,7 @@
 
 #ifndef _GNUstep_H_NSTextView
 #define _GNUstep_H_NSTextView
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSText.h>
 #import <AppKit/NSTextFinder.h>
@@ -93,6 +93,7 @@ be stored in the NSTextView. Non-persistant attributes don't, and should
 therefore be stored in the NSLayoutManager to avoid problems.
 */
 
+APPKIT_EXPORT_CLASS
 @interface NSTextView : NSText <NSTextInput, NSUserInterfaceValidations, NSTextFinderClient>
 {
   /* These attributes are shared by all text views attached to a layout

--- a/Headers/AppKit/NSTitlebarAccessoryViewController.h
+++ b/Headers/AppKit/NSTitlebarAccessoryViewController.h
@@ -33,6 +33,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSTitlebarAccessoryViewController : NSViewController
 
 @end

--- a/Headers/AppKit/NSTokenField.h
+++ b/Headers/AppKit/NSTokenField.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSTokenField
 #define _GNUstep_H_NSTokenField
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSDate.h>
 #import <AppKit/NSTextField.h>
@@ -37,6 +37,7 @@
 
 @class NSCharacterSet;
 
+APPKIT_EXPORT_CLASS
 @interface NSTokenField : NSTextField
 // Style...
 - (NSTokenStyle)tokenStyle;

--- a/Headers/AppKit/NSTokenFieldCell.h
+++ b/Headers/AppKit/NSTokenFieldCell.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSTokenFieldCell
 #define _GNUstep_H_NSTokenFieldCell
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSDate.h>
 #import <AppKit/NSTextFieldCell.h>
@@ -44,6 +44,7 @@ typedef enum _NSTokenStyle
 } NSTokenStyle;
 
 
+APPKIT_EXPORT_CLASS
 @interface NSTokenFieldCell : NSTextFieldCell <NSCoding>
 {
   NSTokenStyle tokenStyle;

--- a/Headers/AppKit/NSToolbar.h
+++ b/Headers/AppKit/NSToolbar.h
@@ -33,10 +33,9 @@
 
 #ifndef _GNUstep_H_NSToolbar
 #define _GNUstep_H_NSToolbar
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
-#import <AppKit/AppKitDefines.h>
 
 @class NSArray;
 @class NSString;
@@ -74,6 +73,7 @@ APPKIT_EXPORT NSString *NSToolbarWillAddItemNotification;
 
 typedef NSString* NSToolbarItemIdentifier;
 
+APPKIT_EXPORT_CLASS
 @interface NSToolbar : NSObject
 {
   NSDictionary *_configurationDictionary;

--- a/Headers/AppKit/NSToolbarItem.h
+++ b/Headers/AppKit/NSToolbarItem.h
@@ -31,7 +31,7 @@
 
 #ifndef _GNUstep_H_NSToolbarItem
 #define _GNUstep_H_NSToolbarItem
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSGeometry.h>
@@ -67,6 +67,7 @@ enum _NSToolbarItemVisibilityPriority {
 };
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSToolbarItem : NSObject <NSCopying, NSValidatedUserInterfaceItem>
 {
   // externally visible variables

--- a/Headers/AppKit/NSToolbarItemGroup.h
+++ b/Headers/AppKit/NSToolbarItemGroup.h
@@ -29,7 +29,7 @@
 
 #ifndef _GNUstep_H_NSToolbarItemGroup
 #define _GNUstep_H_NSToolbarItemGroup
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSToolbarItem.h>
 
@@ -37,6 +37,7 @@
 
 @class NSArray;
 
+APPKIT_EXPORT_CLASS
 @interface NSToolbarItemGroup : NSToolbarItem
 {
 	NSArray *_subitems;

--- a/Headers/AppKit/NSTouch.h
+++ b/Headers/AppKit/NSTouch.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSTouch_h_GNUSTEP_GUI_INCLUDE
 #define _NSTouch_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -33,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSTouch : NSObject
 
 @end

--- a/Headers/AppKit/NSTouchBar.h
+++ b/Headers/AppKit/NSTouchBar.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSTouchBar_h_GNUSTEP_GUI_INCLUDE
 #define _NSTouchBar_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -33,6 +34,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSTouchBar : NSObject
 
 @end

--- a/Headers/AppKit/NSTouchBarItem.h
+++ b/Headers/AppKit/NSTouchBarItem.h
@@ -25,6 +25,7 @@
 
 #ifndef _NSTouchBarItem_h_GNUSTEP_GUI_INCLUDE
 #define _NSTouchBarItem_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -34,6 +35,7 @@
 extern "C" {
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSTouchBarItem : NSObject
 
 @end

--- a/Headers/AppKit/NSTrackingArea.h
+++ b/Headers/AppKit/NSTrackingArea.h
@@ -29,6 +29,7 @@
 
 #ifndef _GNUstep_H_NSTrackingArea
 #define _GNUstep_H_NSTrackingArea
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSCoder.h>
@@ -53,6 +54,7 @@ typedef NSUInteger NSTrackingAreaOptions;
 @class NSDictionary;
 @class GSTrackingRect;
 
+APPKIT_EXPORT_CLASS
 @interface NSTrackingArea : NSObject <NSCoding, NSCopying>
 {
     NSDictionary *_userInfo;

--- a/Headers/AppKit/NSTreeController.h
+++ b/Headers/AppKit/NSTreeController.h
@@ -30,7 +30,7 @@
 #ifndef _GNUstep_H_NSTreeController
 #define _GNUstep_H_NSTreeController
 
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_4, GS_API_LATEST)
 #import <AppKit/NSObjectController.h>
@@ -40,6 +40,7 @@
 @class NSIndexPath;
 @class NSTreeNode;
 
+APPKIT_EXPORT_CLASS
 @interface NSTreeController : NSObjectController <NSCoding, NSCopying>
 {
   NSString *_childrenKeyPath;

--- a/Headers/AppKit/NSTreeNode.h
+++ b/Headers/AppKit/NSTreeNode.h
@@ -29,7 +29,7 @@
 #ifndef _GNUstep_H_NSTreeNode
 #define _GNUstep_H_NSTreeNode
 
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 #import <Foundation/NSObject.h>
 
 @class NSArray;
@@ -37,6 +37,7 @@
 @class NSMutableArray;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
+APPKIT_EXPORT_CLASS
 @interface NSTreeNode : NSObject
 {
   id _representedObject;

--- a/Headers/AppKit/NSUserDefaultsController.h
+++ b/Headers/AppKit/NSUserDefaultsController.h
@@ -28,7 +28,7 @@
 
 #ifndef _GNUstep_H_NSUserDefaultsController
 #define _GNUstep_H_NSUserDefaultsController
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSController.h>
 
@@ -38,6 +38,7 @@
 @class NSDictionary;
 @class NSMutableDictionary;
 
+APPKIT_EXPORT_CLASS
 @interface NSUserDefaultsController : NSController
 {
   NSUserDefaults* _defaults;

--- a/Headers/AppKit/NSUserInterfaceCompression.h
+++ b/Headers/AppKit/NSUserInterfaceCompression.h
@@ -24,6 +24,7 @@
 
 #ifndef _NSUserInterfaceCompression_h_GNUSTEP_GUI_INCLUDE
 #define _NSUserInterfaceCompression_h_GNUSTEP_GUI_INCLUDE
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 
@@ -35,6 +36,7 @@ extern "C" {
 
 @class NSSet, NSString, NSArray;
 
+APPKIT_EXPORT_CLASS
 @interface NSUserInterfaceCompressionOptions : NSObject <NSCopying, NSCoding>
 
 - (instancetype) initWithIdentifier: (NSString *)identifier;

--- a/Headers/AppKit/NSView.h
+++ b/Headers/AppKit/NSView.h
@@ -32,7 +32,7 @@
 
 #ifndef _GNUstep_H_NSView
 #define _GNUstep_H_NSView
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSGraphicsContext.h>
 #import <AppKit/NSResponder.h>
@@ -122,6 +122,7 @@ typedef enum _NSFocusRingType {
   NSFocusRingTypeExterior = 2
 } NSFocusRingType;
 
+APPKIT_EXPORT_CLASS
 @interface NSView : NSResponder
 {
   NSRect _frame;

--- a/Headers/AppKit/NSViewController.h
+++ b/Headers/AppKit/NSViewController.h
@@ -24,7 +24,7 @@ Boston, MA 02110-1301, USA.
 
 #ifndef _GNUstep_H_NSViewController
 #define _GNUstep_H_NSViewController
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSNibDeclarations.h>
 #import <AppKit/NSResponder.h>
@@ -50,6 +50,7 @@ enum
 typedef NSUInteger NSViewControllerTransitionOptions;
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSViewController : NSResponder <NSSeguePerforming>
 {
 @private

--- a/Headers/AppKit/NSVisualEffectView.h
+++ b/Headers/AppKit/NSVisualEffectView.h
@@ -28,7 +28,7 @@
 */
 
 #import <AppKit/NSView.h>
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
 
@@ -59,6 +59,7 @@ enum {
   NSVisualEffectStateInactive,
 };
 
+APPKIT_EXPORT_CLASS
 @interface NSVisualEffectView : NSView {
 }
 

--- a/Headers/AppKit/NSWindow.h
+++ b/Headers/AppKit/NSWindow.h
@@ -35,7 +35,7 @@
 
 #ifndef _GNUstep_H_NSWindow
 #define _GNUstep_H_NSWindow
-#import <GNUstepBase/GSVersionMacros.h>
+#import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSGraphicsContext.h>
 #import <AppKit/NSResponder.h>
@@ -227,6 +227,7 @@ APPKIT_EXPORT NSSize NSTokenSize;
  * -convertBaseToScreen: and -convertScreenToBase: methods.
  * </p>
  */
+APPKIT_EXPORT_CLASS
 @interface NSWindow : NSResponder <NSCoding>
 {
   NSRect        _frame;

--- a/Headers/AppKit/NSWindowController.h
+++ b/Headers/AppKit/NSWindowController.h
@@ -38,6 +38,7 @@
 @class NSMapTable;
 @class NSStoryboard;
 
+APPKIT_EXPORT_CLASS
 @interface NSWindowController : NSResponder <NSCoding, NSSeguePerforming>
 {
   @private

--- a/Headers/AppKit/NSWorkspace.h
+++ b/Headers/AppKit/NSWorkspace.h
@@ -76,6 +76,7 @@ enum {
 typedef NSUInteger NSWorkspaceIconCreationOptions;
 #endif
 
+APPKIT_EXPORT_CLASS
 @interface NSWorkspace : NSObject
 {
   NSMutableDictionary	*_iconMap;

--- a/Source/NSAttributedString.m
+++ b/Source/NSAttributedString.m
@@ -60,6 +60,11 @@
 #import "GNUstepGUI/GSTextConverter.h"
 #import "GSGuiPrivate.h"
 
+/* Redefine unavailable function when using the MSVC ABI on Windows. */
+#ifdef _MSC_VER
+#  define strncasecmp _strnicmp
+#endif
+
 /* Cache class pointers to avoid the expensive lookup by string. */ 
 static Class dictionaryClass = nil;
 static Class stringClass = nil;

--- a/Source/NSWorkspace.m
+++ b/Source/NSWorkspace.m
@@ -32,7 +32,10 @@
 
 #import "config.h"
 
+#if defined(HAVE_UNISTD_H)
 #include <unistd.h>
+#endif
+
 #include <sys/types.h>
 
 #if defined(HAVE_GETMNTINFO)

--- a/Source/externs.m
+++ b/Source/externs.m
@@ -38,420 +38,376 @@
 #import "AppKit/NSTextFinder.h"
 
 // Global strings
-NSString *NSModalPanelRunLoopMode = @"NSModalPanelRunLoopMode";
-NSString *NSEventTrackingRunLoopMode = @"NSEventTrackingRunLoopMode";
+APPKIT_DECLARE APPKIT_DECLARE NSString *NSModalPanelRunLoopMode = @"NSModalPanelRunLoopMode";
+APPKIT_DECLARE APPKIT_DECLARE NSString *NSEventTrackingRunLoopMode = @"NSEventTrackingRunLoopMode";
 
-const double NSAppKitVersionNumber = NSAppKitVersionNumber10_4;
+APPKIT_DECLARE const double NSAppKitVersionNumber = NSAppKitVersionNumber10_4;
 
 //
 // Global Exception Strings
 //
-NSExceptionName NSAbortModalException = @"NSAbortModalException";
-NSExceptionName NSAbortPrintingException = @"NSAbortPrintingException";
-NSExceptionName NSAppKitIgnoredException = @"NSAppKitIgnoredException";
-NSExceptionName NSAppKitVirtualMemoryException = @"NSAppKitVirtualMemoryException";
-NSExceptionName NSBadBitmapParametersException = @"NSBadBitmapParametersException";
-NSExceptionName NSBadComparisonException = @"NSBadComparisonException";
-NSExceptionName NSBadRTFColorTableException = @"NSBadRTFColorTableException";
-NSExceptionName NSBadRTFDirectiveException = @"NSBadRTFDirectiveException";
-NSExceptionName NSBadRTFFontTableException = @"NSBadRTFFontTableException";
-NSExceptionName NSBadRTFStyleSheetException = @"NSBadRTFStyleSheetException";
-NSExceptionName NSBrowserIllegalDelegateException = @"NSBrowserIllegalDelegateException";
-NSExceptionName NSColorListIOException = @"NSColorListIOException";
-NSExceptionName NSColorListNotEditableException = @"NSColorListNotEditableException";
-NSExceptionName NSDraggingException = @"NSDraggingException";
-NSExceptionName NSFontUnavailableException = @"NSFontUnavailableException";
-NSExceptionName NSIllegalSelectorException = @"NSIllegalSelectorException";
-NSExceptionName NSImageCacheException = @"NSImageCacheException";
-NSExceptionName NSNibLoadingException = @"NSNibLoadingException";
-NSExceptionName NSPPDIncludeNotFoundException = @"NSPPDIncludeNotFoundException";
-NSExceptionName NSPPDIncludeStackOverflowException = @"NSPPDIncludeStackOverflowException";
-NSExceptionName NSPPDIncludeStackUnderflowException = @"NSPPDIncludeStackUnderflowException";
-NSExceptionName NSPPDParseException = @"NSPPDParseException";
-NSExceptionName NSPrintOperationExistsException = @"NSPrintOperationExistsException";
-NSExceptionName NSPrintPackageException = @"NSPrintPackageException";
-NSExceptionName NSPrintingCommunicationException = @"NSPrintingCommunicationException";
-NSExceptionName NSRTFPropertyStackOverflowException = @"NSRTFPropertyStackOverflowException";
-NSExceptionName NSTIFFException = @"NSTIFFException";
-NSExceptionName NSTextLineTooLongException = @"NSTextLineTooLongException";
-NSExceptionName NSTextNoSelectionException = @"NSTextNoSelectionException";
-NSExceptionName NSTextReadException = @"NSTextReadException";
-NSExceptionName NSTextWriteException = @"NSTextWriteException";
-NSExceptionName NSTypedStreamVersionException = @"NSTypedStreamVersionException";
-NSExceptionName NSWindowServerCommunicationException = @"NSWindowServerCommunicationException";
-NSExceptionName NSWordTablesReadException = @"NSWordTablesReadException";
-NSExceptionName NSWordTablesWriteException = @"NSWordTablesWriteException";
+APPKIT_DECLARE NSExceptionName NSAbortModalException = @"NSAbortModalException";
+APPKIT_DECLARE NSExceptionName NSAbortPrintingException = @"NSAbortPrintingException";
+APPKIT_DECLARE NSExceptionName NSAppKitIgnoredException = @"NSAppKitIgnoredException";
+APPKIT_DECLARE NSExceptionName NSAppKitVirtualMemoryException = @"NSAppKitVirtualMemoryException";
+APPKIT_DECLARE NSExceptionName NSBadBitmapParametersException = @"NSBadBitmapParametersException";
+APPKIT_DECLARE NSExceptionName NSBadComparisonException = @"NSBadComparisonException";
+APPKIT_DECLARE NSExceptionName NSBadRTFColorTableException = @"NSBadRTFColorTableException";
+APPKIT_DECLARE NSExceptionName NSBadRTFDirectiveException = @"NSBadRTFDirectiveException";
+APPKIT_DECLARE NSExceptionName NSBadRTFFontTableException = @"NSBadRTFFontTableException";
+APPKIT_DECLARE NSExceptionName NSBadRTFStyleSheetException = @"NSBadRTFStyleSheetException";
+APPKIT_DECLARE NSExceptionName NSBrowserIllegalDelegateException = @"NSBrowserIllegalDelegateException";
+APPKIT_DECLARE NSExceptionName NSColorListIOException = @"NSColorListIOException";
+APPKIT_DECLARE NSExceptionName NSColorListNotEditableException = @"NSColorListNotEditableException";
+APPKIT_DECLARE NSExceptionName NSDraggingException = @"NSDraggingException";
+APPKIT_DECLARE NSExceptionName NSFontUnavailableException = @"NSFontUnavailableException";
+APPKIT_DECLARE NSExceptionName NSIllegalSelectorException = @"NSIllegalSelectorException";
+APPKIT_DECLARE NSExceptionName NSImageCacheException = @"NSImageCacheException";
+APPKIT_DECLARE NSExceptionName NSNibLoadingException = @"NSNibLoadingException";
+APPKIT_DECLARE NSExceptionName NSPPDIncludeNotFoundException = @"NSPPDIncludeNotFoundException";
+APPKIT_DECLARE NSExceptionName NSPPDIncludeStackOverflowException = @"NSPPDIncludeStackOverflowException";
+APPKIT_DECLARE NSExceptionName NSPPDIncludeStackUnderflowException = @"NSPPDIncludeStackUnderflowException";
+APPKIT_DECLARE NSExceptionName NSPPDParseException = @"NSPPDParseException";
+APPKIT_DECLARE NSExceptionName NSPrintOperationExistsException = @"NSPrintOperationExistsException";
+APPKIT_DECLARE NSExceptionName NSPrintPackageException = @"NSPrintPackageException";
+APPKIT_DECLARE NSExceptionName NSPrintingCommunicationException = @"NSPrintingCommunicationException";
+APPKIT_DECLARE NSExceptionName NSRTFPropertyStackOverflowException = @"NSRTFPropertyStackOverflowException";
+APPKIT_DECLARE NSExceptionName NSTIFFException = @"NSTIFFException";
+APPKIT_DECLARE NSExceptionName NSTextLineTooLongException = @"NSTextLineTooLongException";
+APPKIT_DECLARE NSExceptionName NSTextNoSelectionException = @"NSTextNoSelectionException";
+APPKIT_DECLARE NSExceptionName NSTextReadException = @"NSTextReadException";
+APPKIT_DECLARE NSExceptionName NSTextWriteException = @"NSTextWriteException";
+APPKIT_DECLARE NSExceptionName NSTypedStreamVersionException = @"NSTypedStreamVersionException";
+APPKIT_DECLARE NSExceptionName NSWindowServerCommunicationException = @"NSWindowServerCommunicationException";
+APPKIT_DECLARE NSExceptionName NSWordTablesReadException = @"NSWordTablesReadException";
+APPKIT_DECLARE NSExceptionName NSWordTablesWriteException = @"NSWordTablesWriteException";
 
-NSExceptionName GSWindowServerInternalException = @"WindowServerInternal";
+APPKIT_DECLARE NSExceptionName GSWindowServerInternalException = @"WindowServerInternal";
 
 // NSAnimation
-NSString* NSAnimationProgressMarkNotification
-= @"NSAnimationProgressMarkNotification";
-NSString *NSAnimationProgressMark = @"NSAnimationProgressMark";
-NSString *NSAnimationTriggerOrderIn = @"NSAnimationTriggerOrderIn"; 
-NSString *NSAnimationTriggerOrderOut = @"NSAnimationTriggerOrderOut"; 
+APPKIT_DECLARE NSString *NSAnimationProgressMarkNotification = @"NSAnimationProgressMarkNotification";
+APPKIT_DECLARE NSString *NSAnimationProgressMark = @"NSAnimationProgressMark";
+APPKIT_DECLARE NSString *NSAnimationTriggerOrderIn = @"NSAnimationTriggerOrderIn"; 
+APPKIT_DECLARE NSString *NSAnimationTriggerOrderOut = @"NSAnimationTriggerOrderOut"; 
 
 // Application notifications
-NSString *NSApplicationDidBecomeActiveNotification
-              = @"NSApplicationDidBecomeActiveNotification";
-NSString *NSApplicationDidChangeScreenParametersNotification 
-              = @"NSApplicationDidChangeScreenParametersNotification";
-NSString *NSApplicationDidFinishLaunchingNotification
-              = @"NSApplicationDidFinishLaunchingNotification";
-NSString *NSApplicationDidHideNotification = @"NSApplicationDidHideNotification";
-NSString *NSApplicationDidResignActiveNotification
-              = @"NSApplicationDidResignActiveNotification";
-NSString *NSApplicationDidUnhideNotification = @"NSApplicationDidUnhideNotification";
-NSString *NSApplicationDidUpdateNotification = @"NSApplicationDidUpdateNotification";
-NSString *NSApplicationWillBecomeActiveNotification
-              = @"NSApplicationWillBecomeActiveNotification";
-NSString *NSApplicationWillFinishLaunchingNotification
-              = @"NSApplicationWillFinishLaunchingNotification";
-NSString *NSApplicationWillTerminateNotification = @"NSApplicationWillTerminateNotification";
-NSString *NSApplicationWillHideNotification = @"NSApplicationWillHideNotification";
-NSString *NSApplicationWillResignActiveNotification
-              = @"NSApplicationWillResignActiveNotification";
-NSString *NSApplicationWillUnhideNotification = @"NSApplicationWillUnhideNotification";
-NSString *NSApplicationWillUpdateNotification = @"NSApplicationWillUpdateNotification";
+APPKIT_DECLARE NSString *NSApplicationDidBecomeActiveNotification = @"NSApplicationDidBecomeActiveNotification";
+APPKIT_DECLARE NSString *NSApplicationDidChangeScreenParametersNotification = @"NSApplicationDidChangeScreenParametersNotification";
+APPKIT_DECLARE NSString *NSApplicationDidFinishLaunchingNotification = @"NSApplicationDidFinishLaunchingNotification";
+APPKIT_DECLARE NSString *NSApplicationDidHideNotification = @"NSApplicationDidHideNotification";
+APPKIT_DECLARE NSString *NSApplicationDidResignActiveNotification = @"NSApplicationDidResignActiveNotification";
+APPKIT_DECLARE NSString *NSApplicationDidUnhideNotification = @"NSApplicationDidUnhideNotification";
+APPKIT_DECLARE NSString *NSApplicationDidUpdateNotification = @"NSApplicationDidUpdateNotification";
+APPKIT_DECLARE NSString *NSApplicationWillBecomeActiveNotification = @"NSApplicationWillBecomeActiveNotification";
+APPKIT_DECLARE NSString *NSApplicationWillFinishLaunchingNotification = @"NSApplicationWillFinishLaunchingNotification";
+APPKIT_DECLARE NSString *NSApplicationWillTerminateNotification = @"NSApplicationWillTerminateNotification";
+APPKIT_DECLARE NSString *NSApplicationWillHideNotification = @"NSApplicationWillHideNotification";
+APPKIT_DECLARE NSString *NSApplicationWillResignActiveNotification = @"NSApplicationWillResignActiveNotification";
+APPKIT_DECLARE NSString *NSApplicationWillUnhideNotification = @"NSApplicationWillUnhideNotification";
+APPKIT_DECLARE NSString *NSApplicationWillUpdateNotification = @"NSApplicationWillUpdateNotification";
 
 // NSBitmapImageRep Global strings
-NSString *NSImageCompressionMethod = @"NSImageCompressionMethod";
-NSString *NSImageCompressionFactor = @"NSImageCompressionFactor";
-NSString *NSImageDitherTransparency = @"NSImageDitherTransparency";
-NSString *NSImageRGBColorTable = @"NSImageRGBColorTable";
-NSString *NSImageInterlaced = @"NSImageInterlaced";
-NSString *NSImageColorSyncProfileData = @"NSImageColorSyncProfileData";  // Mac OS X only
-//NSString *GSImageICCProfileData = @"GSImageICCProfileData";  // if & when GNUstep supports color management
-NSString *NSImageFrameCount = @"NSImageFrameCount";
-NSString *NSImageCurrentFrame = @"NSImageCurrentFrame";
-NSString *NSImageCurrentFrameDuration = @"NSImageCurrentFrameDuration";
-NSString *NSImageLoopCount = @"NSImageLoopCount";
-NSString *NSImageGamma = @"NSImageGamma";
-NSString *NSImageProgressive = @"NSImageProgressive";
-NSString *NSImageEXIFData = @"NSImageEXIFData";  // No support yet in GNUstep
+APPKIT_DECLARE NSString *NSImageCompressionMethod = @"NSImageCompressionMethod";
+APPKIT_DECLARE NSString *NSImageCompressionFactor = @"NSImageCompressionFactor";
+APPKIT_DECLARE NSString *NSImageDitherTransparency = @"NSImageDitherTransparency";
+APPKIT_DECLARE NSString *NSImageRGBColorTable = @"NSImageRGBColorTable";
+APPKIT_DECLARE NSString *NSImageInterlaced = @"NSImageInterlaced";
+APPKIT_DECLARE NSString *NSImageColorSyncProfileData = @"NSImageColorSyncProfileData";  // Mac OS X only
+//APPKIT_DECLARE NSString *GSImageICCProfileData = @"GSImageICCProfileData";  // if & when GNUstep supports color management
+APPKIT_DECLARE NSString *NSImageFrameCount = @"NSImageFrameCount";
+APPKIT_DECLARE NSString *NSImageCurrentFrame = @"NSImageCurrentFrame";
+APPKIT_DECLARE NSString *NSImageCurrentFrameDuration = @"NSImageCurrentFrameDuration";
+APPKIT_DECLARE NSString *NSImageLoopCount = @"NSImageLoopCount";
+APPKIT_DECLARE NSString *NSImageGamma = @"NSImageGamma";
+APPKIT_DECLARE NSString *NSImageProgressive = @"NSImageProgressive";
+APPKIT_DECLARE NSString *NSImageEXIFData = @"NSImageEXIFData";  // No support yet in GNUstep
 
 // NSBrowser notification
-NSString *NSBrowserColumnConfigurationDidChangeNotification = @"NSBrowserColumnConfigurationDidChange";
+APPKIT_DECLARE NSString *NSBrowserColumnConfigurationDidChangeNotification = @"NSBrowserColumnConfigurationDidChange";
 
 // NSColor Global strings
-NSString *NSCalibratedWhiteColorSpace = @"NSCalibratedWhiteColorSpace";
-NSString *NSCalibratedBlackColorSpace = @"NSCalibratedBlackColorSpace";
-NSString *NSCalibratedRGBColorSpace = @"NSCalibratedRGBColorSpace";
-NSString *NSDeviceWhiteColorSpace = @"NSDeviceWhiteColorSpace";
-NSString *NSDeviceBlackColorSpace = @"NSDeviceBlackColorSpace";
-NSString *NSDeviceRGBColorSpace = @"NSDeviceRGBColorSpace";
-NSString *NSDeviceCMYKColorSpace = @"NSDeviceCMYKColorSpace";
-NSString *NSNamedColorSpace = @"NSNamedColorSpace";
-NSString *NSPatternColorSpace = @"NSPatternColorSpace";
-NSString *NSCustomColorSpace = @"NSCustomColorSpace";
+APPKIT_DECLARE NSString *NSCalibratedWhiteColorSpace = @"NSCalibratedWhiteColorSpace";
+APPKIT_DECLARE NSString *NSCalibratedBlackColorSpace = @"NSCalibratedBlackColorSpace";
+APPKIT_DECLARE NSString *NSCalibratedRGBColorSpace = @"NSCalibratedRGBColorSpace";
+APPKIT_DECLARE NSString *NSDeviceWhiteColorSpace = @"NSDeviceWhiteColorSpace";
+APPKIT_DECLARE NSString *NSDeviceBlackColorSpace = @"NSDeviceBlackColorSpace";
+APPKIT_DECLARE NSString *NSDeviceRGBColorSpace = @"NSDeviceRGBColorSpace";
+APPKIT_DECLARE NSString *NSDeviceCMYKColorSpace = @"NSDeviceCMYKColorSpace";
+APPKIT_DECLARE NSString *NSNamedColorSpace = @"NSNamedColorSpace";
+APPKIT_DECLARE NSString *NSPatternColorSpace = @"NSPatternColorSpace";
+APPKIT_DECLARE NSString *NSCustomColorSpace = @"NSCustomColorSpace";
 
 // NSColor Global gray values
-const CGFloat NSBlack = 0;
-const CGFloat NSDarkGray = .333;
-const CGFloat NSGray = 0.5;
-const CGFloat NSLightGray = .667;
-const CGFloat NSWhite = 1;
+APPKIT_DECLARE const CGFloat NSBlack = 0;
+APPKIT_DECLARE const CGFloat NSDarkGray = .333;
+APPKIT_DECLARE const CGFloat NSGray = 0.5;
+APPKIT_DECLARE const CGFloat NSLightGray = .667;
+APPKIT_DECLARE const CGFloat NSWhite = 1;
 
-const CGFloat NSFontWeightUltraLight = -0.8;
-const CGFloat NSFontWeightThin = -0.6;
-const CGFloat NSFontWeightLight = -0.4;
-const CGFloat NSFontWeightRegular = 0;
-const CGFloat NSFontWeightMedium = 0.23;
-const CGFloat NSFontWeightSemibold = 0.3;
-const CGFloat NSFontWeightBold = 0.4;
-const CGFloat NSFontWeightHeavy = 0.56;
-const CGFloat NSFontWeightBlack = 0.62;
+APPKIT_DECLARE const CGFloat NSFontWeightUltraLight = -0.8;
+APPKIT_DECLARE const CGFloat NSFontWeightThin = -0.6;
+APPKIT_DECLARE const CGFloat NSFontWeightLight = -0.4;
+APPKIT_DECLARE const CGFloat NSFontWeightRegular = 0;
+APPKIT_DECLARE const CGFloat NSFontWeightMedium = 0.23;
+APPKIT_DECLARE const CGFloat NSFontWeightSemibold = 0.3;
+APPKIT_DECLARE const CGFloat NSFontWeightBold = 0.4;
+APPKIT_DECLARE const CGFloat NSFontWeightHeavy = 0.56;
+APPKIT_DECLARE const CGFloat NSFontWeightBlack = 0.62;
 
 // NSColor notification
-NSString *NSSystemColorsDidChangeNotification =
-            @"NSSystemColorsDidChangeNotification";
+APPKIT_DECLARE NSString *NSSystemColorsDidChangeNotification = @"NSSystemColorsDidChangeNotification";
 
 // NSColorList notifications
-NSString *NSColorListDidChangeNotification = @"NSColorListDidChangeNotification";
+APPKIT_DECLARE NSString *NSColorListDidChangeNotification = @"NSColorListDidChangeNotification";
 
 // NSColorPanel notifications
-NSString *NSColorPanelColorDidChangeNotification =
-  @"NSColorPanelColorDidChangeNotification";
+APPKIT_DECLARE NSString *NSColorPanelColorDidChangeNotification = @"NSColorPanelColorDidChangeNotification";
 
 // NSComboBox notifications
-NSString *NSComboBoxWillPopUpNotification = 
-@"NSComboBoxWillPopUpNotification";
-NSString *NSComboBoxWillDismissNotification = 
-@"NSComboBoxWillDismissNotification";
-NSString *NSComboBoxSelectionDidChangeNotification = 
-@"NSComboBoxSelectionDidChangeNotification";
-NSString *NSComboBoxSelectionIsChangingNotification = 
-@"NSComboBoxSelectionIsChangingNotification";
+APPKIT_DECLARE NSString *NSComboBoxWillPopUpNotification = @"NSComboBoxWillPopUpNotification";
+APPKIT_DECLARE NSString *NSComboBoxWillDismissNotification = @"NSComboBoxWillDismissNotification";
+APPKIT_DECLARE NSString *NSComboBoxSelectionDidChangeNotification = @"NSComboBoxSelectionDidChangeNotification";
+APPKIT_DECLARE NSString *NSComboBoxSelectionIsChangingNotification = @"NSComboBoxSelectionIsChangingNotification";
 
 // NSControl notifications
-NSString *NSControlTextDidBeginEditingNotification =
-@"NSControlTextDidBeginEditingNotification";
-NSString *NSControlTextDidEndEditingNotification =
-@"NSControlTextDidEndEditingNotification";
-NSString *NSControlTextDidChangeNotification =
-@"NSControlTextDidChangeNotification";
+APPKIT_DECLARE NSString *NSControlTextDidBeginEditingNotification = @"NSControlTextDidBeginEditingNotification";
+APPKIT_DECLARE NSString *NSControlTextDidEndEditingNotification = @"NSControlTextDidEndEditingNotification";
+APPKIT_DECLARE NSString *NSControlTextDidChangeNotification = @"NSControlTextDidChangeNotification";
 
 // NSDataLink global strings
-NSString *NSDataLinkFilenameExtension = @"dlf";
+APPKIT_DECLARE NSString *NSDataLinkFilenameExtension = @"dlf";
 
 // NSDrawer notifications
-NSString *NSDrawerDidCloseNotification =
-@"NSDrawerDidCloseNotification";
-NSString *NSDrawerDidOpenNotification =
-@"NSDrawerDidOpenNotification";
-NSString *NSDrawerWillCloseNotification =
-@"NSDrawerWillCloseNotification";
-NSString *NSDrawerWillOpenNotification =
-@"NSDrawerWillOpenNotification";
+APPKIT_DECLARE NSString *NSDrawerDidCloseNotification = @"NSDrawerDidCloseNotification";
+APPKIT_DECLARE NSString *NSDrawerDidOpenNotification = @"NSDrawerDidOpenNotification";
+APPKIT_DECLARE NSString *NSDrawerWillCloseNotification = @"NSDrawerWillCloseNotification";
+APPKIT_DECLARE NSString *NSDrawerWillOpenNotification = @"NSDrawerWillOpenNotification";
 
 // NSForm private notification
-NSString *_NSFormCellDidChangeTitleWidthNotification 
+APPKIT_DECLARE NSString *_NSFormCellDidChangeTitleWidthNotification 
 = @"_NSFormCellDidChangeTitleWidthNotification";
 
 // NSGraphicContext constants
-NSString *NSGraphicsContextDestinationAttributeName = 
-@"NSGraphicsContextDestinationAttributeName";
-NSString *NSGraphicsContextPDFFormat = 
-@"NSGraphicsContextPDFFormat";
-NSString *NSGraphicsContextPSFormat = 
-@"NSGraphicsContextPSFormat";
-NSString *NSGraphicsContextRepresentationFormatAttributeName = 
-@"NSGraphicsContextRepresentationFormatAttributeName";
+APPKIT_DECLARE NSString *NSGraphicsContextDestinationAttributeName = @"NSGraphicsContextDestinationAttributeName";
+APPKIT_DECLARE NSString *NSGraphicsContextPDFFormat = @"NSGraphicsContextPDFFormat";
+APPKIT_DECLARE NSString *NSGraphicsContextPSFormat = @"NSGraphicsContextPSFormat";
+APPKIT_DECLARE NSString *NSGraphicsContextRepresentationFormatAttributeName = @"NSGraphicsContextRepresentationFormatAttributeName";
 
 // NSHelpManager notifications;
-NSString *NSContextHelpModeDidActivateNotification =
-@"NSContextHelpModeDidActivateNotification";
-NSString *NSContextHelpModeDidDeactivateNotification =
-@"NSContextHelpModeDidDeactivateNotification";
+APPKIT_DECLARE NSString *NSContextHelpModeDidActivateNotification = @"NSContextHelpModeDidActivateNotification";
+APPKIT_DECLARE NSString *NSContextHelpModeDidDeactivateNotification = @"NSContextHelpModeDidDeactivateNotification";
 
 // NSFont Global Strings
-NSString *NSAFMAscender = @"Ascender";
-NSString *NSAFMCapHeight = @"CapHeight";
-NSString *NSAFMCharacterSet = @"CharacterSet";
-NSString *NSAFMDescender = @"Descender";
-NSString *NSAFMEncodingScheme = @"EncodingScheme";
-NSString *NSAFMFamilyName = @"FamilyName";
-NSString *NSAFMFontName = @"FontName";
-NSString *NSAFMFormatVersion = @"FormatVersion";
-NSString *NSAFMFullName = @"FullName";
-NSString *NSAFMItalicAngle = @"ItalicAngle";
-NSString *NSAFMMappingScheme = @"MappingScheme";
-NSString *NSAFMNotice = @"Notice";
-NSString *NSAFMUnderlinePosition = @"UnderlinePosition";
-NSString *NSAFMUnderlineThickness = @"UnderlineThickness";
-NSString *NSAFMVersion = @"Version";
-NSString *NSAFMWeight = @"Weight";
-NSString *NSAFMXHeight = @"XHeight";
+APPKIT_DECLARE NSString *NSAFMAscender = @"Ascender";
+APPKIT_DECLARE NSString *NSAFMCapHeight = @"CapHeight";
+APPKIT_DECLARE NSString *NSAFMCharacterSet = @"CharacterSet";
+APPKIT_DECLARE NSString *NSAFMDescender = @"Descender";
+APPKIT_DECLARE NSString *NSAFMEncodingScheme = @"EncodingScheme";
+APPKIT_DECLARE NSString *NSAFMFamilyName = @"FamilyName";
+APPKIT_DECLARE NSString *NSAFMFontName = @"FontName";
+APPKIT_DECLARE NSString *NSAFMFormatVersion = @"FormatVersion";
+APPKIT_DECLARE NSString *NSAFMFullName = @"FullName";
+APPKIT_DECLARE NSString *NSAFMItalicAngle = @"ItalicAngle";
+APPKIT_DECLARE NSString *NSAFMMappingScheme = @"MappingScheme";
+APPKIT_DECLARE NSString *NSAFMNotice = @"Notice";
+APPKIT_DECLARE NSString *NSAFMUnderlinePosition = @"UnderlinePosition";
+APPKIT_DECLARE NSString *NSAFMUnderlineThickness = @"UnderlineThickness";
+APPKIT_DECLARE NSString *NSAFMVersion = @"Version";
+APPKIT_DECLARE NSString *NSAFMWeight = @"Weight";
+APPKIT_DECLARE NSString *NSAFMXHeight = @"XHeight";
 
 // NSFontDescriptor global strings
-NSString *NSFontFamilyAttribute = @"NSFontFamilyAttribute";
-NSString *NSFontNameAttribute = @"NSFontNameAttribute";
-NSString *NSFontFaceAttribute = @"NSFontFaceAttribute";
-NSString *NSFontSizeAttribute = @"NSFontSizeAttribute"; 
-NSString *NSFontVisibleNameAttribute = @"NSFontVisibleNameAttribute"; 
-NSString *NSFontColorAttribute = @"NSFontColorAttribute";
-NSString *NSFontMatrixAttribute = @"NSFontMatrixAttribute";
-NSString *NSFontVariationAttribute = @"NSCTFontVariationAttribute";
-NSString *NSFontCharacterSetAttribute = @"NSCTFontCharacterSetAttribute";
-NSString *NSFontCascadeListAttribute = @"NSCTFontCascadeListAttribute";
-NSString *NSFontTraitsAttribute = @"NSCTFontTraitsAttribute";
-NSString *NSFontFixedAdvanceAttribute = @"NSCTFontFixedAdvanceAttribute";
+APPKIT_DECLARE NSString *NSFontFamilyAttribute = @"NSFontFamilyAttribute";
+APPKIT_DECLARE NSString *NSFontNameAttribute = @"NSFontNameAttribute";
+APPKIT_DECLARE NSString *NSFontFaceAttribute = @"NSFontFaceAttribute";
+APPKIT_DECLARE NSString *NSFontSizeAttribute = @"NSFontSizeAttribute"; 
+APPKIT_DECLARE NSString *NSFontVisibleNameAttribute = @"NSFontVisibleNameAttribute"; 
+APPKIT_DECLARE NSString *NSFontColorAttribute = @"NSFontColorAttribute";
+APPKIT_DECLARE NSString *NSFontMatrixAttribute = @"NSFontMatrixAttribute";
+APPKIT_DECLARE NSString *NSFontVariationAttribute = @"NSCTFontVariationAttribute";
+APPKIT_DECLARE NSString *NSFontCharacterSetAttribute = @"NSCTFontCharacterSetAttribute";
+APPKIT_DECLARE NSString *NSFontCascadeListAttribute = @"NSCTFontCascadeListAttribute";
+APPKIT_DECLARE NSString *NSFontTraitsAttribute = @"NSCTFontTraitsAttribute";
+APPKIT_DECLARE NSString *NSFontFixedAdvanceAttribute = @"NSCTFontFixedAdvanceAttribute";
 
-NSString *NSFontSymbolicTrait = @"NSCTFontSymbolicTrait";
-NSString *NSFontWeightTrait = @"NSCTFontWeightTrait";
-NSString *NSFontWidthTrait = @"NSCTFontProportionTrait";
-NSString *NSFontSlantTrait = @"NSCTFontSlantTrait";
+APPKIT_DECLARE NSString *NSFontSymbolicTrait = @"NSCTFontSymbolicTrait";
+APPKIT_DECLARE NSString *NSFontWeightTrait = @"NSCTFontWeightTrait";
+APPKIT_DECLARE NSString *NSFontWidthTrait = @"NSCTFontProportionTrait";
+APPKIT_DECLARE NSString *NSFontSlantTrait = @"NSCTFontSlantTrait";
 
-NSString *NSFontVariationAxisIdentifierKey = @"NSCTFontVariationAxisIdentifier";
-NSString *NSFontVariationAxisMinimumValueKey = @"NSCTFontVariationAxisMinimumValue";
-NSString *NSFontVariationAxisMaximumValueKey = @"NSCTFontVariationAxisMaximumValue";
-NSString *NSFontVariationAxisDefaultValueKey = @"NSCTFontVariationAxisDefaultValue";
-NSString *NSFontVariationAxisNameKey = @"NSCTFontVariationAxisName";
+APPKIT_DECLARE NSString *NSFontVariationAxisIdentifierKey = @"NSCTFontVariationAxisIdentifier";
+APPKIT_DECLARE NSString *NSFontVariationAxisMinimumValueKey = @"NSCTFontVariationAxisMinimumValue";
+APPKIT_DECLARE NSString *NSFontVariationAxisMaximumValueKey = @"NSCTFontVariationAxisMaximumValue";
+APPKIT_DECLARE NSString *NSFontVariationAxisDefaultValueKey = @"NSCTFontVariationAxisDefaultValue";
+APPKIT_DECLARE NSString *NSFontVariationAxisNameKey = @"NSCTFontVariationAxisName";
 
 // NSScreen Global device dictionary key strings
-NSString *NSDeviceResolution = @"NSDeviceResolution";
-NSString *NSDeviceColorSpaceName = @"NSDeviceColorSpaceName";
-NSString *NSDeviceBitsPerSample = @"NSDeviceBitsPerSample";
-NSString *NSDeviceIsScreen = @"NSDeviceIsScreen";
-NSString *NSDeviceIsPrinter = @"NSDeviceIsPrinter";
-NSString *NSDeviceSize = @"NSDeviceSize";
+APPKIT_DECLARE NSString *NSDeviceResolution = @"NSDeviceResolution";
+APPKIT_DECLARE NSString *NSDeviceColorSpaceName = @"NSDeviceColorSpaceName";
+APPKIT_DECLARE NSString *NSDeviceBitsPerSample = @"NSDeviceBitsPerSample";
+APPKIT_DECLARE NSString *NSDeviceIsScreen = @"NSDeviceIsScreen";
+APPKIT_DECLARE NSString *NSDeviceIsPrinter = @"NSDeviceIsPrinter";
+APPKIT_DECLARE NSString *NSDeviceSize = @"NSDeviceSize";
 
 // NSImageRep notifications
-NSString *NSImageRepRegistryChangedNotification =
-@"NSImageRepRegistryChangedNotification";
+APPKIT_DECLARE NSString *NSImageRepRegistryChangedNotification = @"NSImageRepRegistryChangedNotification";
 
 // Pasteboard Type Globals
-NSString *const NSPasteboardTypeString = @"NSStringPboardType";
-NSString *const NSStringPboardType = @"NSStringPboardType";
+APPKIT_DECLARE NSString *const NSPasteboardTypeString = @"NSStringPboardType";
+APPKIT_DECLARE NSString *const NSStringPboardType = @"NSStringPboardType";
 
-NSString *const NSPasteboardTypeColor = @"NSColorPboardType";
-NSString *const NSColorPboardType = @"NSColorPboardType";
+APPKIT_DECLARE NSString *const NSPasteboardTypeColor = @"NSColorPboardType";
+APPKIT_DECLARE NSString *const NSColorPboardType = @"NSColorPboardType";
 
-NSString *const NSPasteboardTypeFont = @"NSFontPboardType";
-NSString *const NSFontPboardType = @"NSFontPboardType";
+APPKIT_DECLARE NSString *const NSPasteboardTypeFont = @"NSFontPboardType";
+APPKIT_DECLARE NSString *const NSFontPboardType = @"NSFontPboardType";
 
-NSString *const NSPasteboardTypeRuler = @"NSRulerPboardType";
-NSString *const NSRulerPboardType = @"NSRulerPboardType";
+APPKIT_DECLARE NSString *const NSPasteboardTypeRuler = @"NSRulerPboardType";
+APPKIT_DECLARE NSString *const NSRulerPboardType = @"NSRulerPboardType";
 
-NSString *const NSPasteboardTypeTabularText = @"NSTabularTextPboardType";
-NSString *const NSTabularTextPboardType = @"NSTabularTextPboardType";
+APPKIT_DECLARE NSString *const NSPasteboardTypeTabularText = @"NSTabularTextPboardType";
+APPKIT_DECLARE NSString *const NSTabularTextPboardType = @"NSTabularTextPboardType";
 
-NSString *const NSPasteboardTypeRTF = @"NSRTFPboardType";
-NSString *const NSRTFPboardType = @"NSRTFPboardType";
+APPKIT_DECLARE NSString *const NSPasteboardTypeRTF = @"NSRTFPboardType";
+APPKIT_DECLARE NSString *const NSRTFPboardType = @"NSRTFPboardType";
 
-NSString *const NSPasteboardTypeRTFD = @"NSRTFDPboardType";
-NSString *const NSRTFDPboardType = @"NSRTFDPboardType";
+APPKIT_DECLARE NSString *const NSPasteboardTypeRTFD = @"NSRTFDPboardType";
+APPKIT_DECLARE NSString *const NSRTFDPboardType = @"NSRTFDPboardType";
 
-NSString *const NSPasteboardTypeTIFF = @"NSTIFFPboardType";
-NSString *const NSTIFFPboardType = @"NSTIFFPboardType";
+APPKIT_DECLARE NSString *const NSPasteboardTypeTIFF = @"NSTIFFPboardType";
+APPKIT_DECLARE NSString *const NSTIFFPboardType = @"NSTIFFPboardType";
 
-NSString *const NSPasteboardTypePDF = @"NSPDFPboardType";
-NSString *const NSPDFPboardType = @"NSPDFPboardType";
+APPKIT_DECLARE NSString *const NSPasteboardTypePDF = @"NSPDFPboardType";
+APPKIT_DECLARE NSString *const NSPDFPboardType = @"NSPDFPboardType";
 
-NSString *const NSPasteboardTypeHTML = @"NSHTMLPboardType";
-NSString *const NSHTMLPboardType = @"NSHTMLPboardType";
+APPKIT_DECLARE NSString *const NSPasteboardTypeHTML = @"NSHTMLPboardType";
+APPKIT_DECLARE NSString *const NSHTMLPboardType = @"NSHTMLPboardType";
 
-NSString *NSPasteboardTypePNG = @"NSPasteboardTypePNG";
-NSString *NSPasteboardTypeSound = @"NSPasteboardTypeSound";
-NSString *NSPasteboardTypeMultipleTextSelection =
-  @"NSPasteboardTypeMultipleTextSelection";
-NSString *NSPasteboardTypeTextFinderOptions =
-  @"NSPasteboardTypeTextFinderOptions";
+APPKIT_DECLARE NSString *NSPasteboardTypePNG = @"NSPasteboardTypePNG";
+APPKIT_DECLARE NSString *NSPasteboardTypeSound = @"NSPasteboardTypeSound";
+APPKIT_DECLARE NSString *NSPasteboardTypeMultipleTextSelection = @"NSPasteboardTypeMultipleTextSelection";
+APPKIT_DECLARE NSString *NSPasteboardTypeTextFinderOptions = @"NSPasteboardTypeTextFinderOptions";
 
-NSString *NSFileContentsPboardType = @"NSFileContentsPboardType";
-NSString *NSFilenamesPboardType = @"NSFilenamesPboardType";
-NSString *NSPostScriptPboardType = @"NSPostScriptPboardType";
-NSString *NSDataLinkPboardType = @"NSDataLinkPboardType";
-NSString *NSGeneralPboardType = @"NSGeneralPboardType";
-NSString *NSPICTPboardType = @"NSPICTPboardType";
-NSString *NSURLPboardType = @"NSURLPboardType";
-NSString *NSVCardPboardType = @"NSVCardPboardType";
-NSString *NSFilesPromisePboardType = @"NSFilesPromisePboardType";
+APPKIT_DECLARE NSString *NSFileContentsPboardType = @"NSFileContentsPboardType";
+APPKIT_DECLARE NSString *NSFilenamesPboardType = @"NSFilenamesPboardType";
+APPKIT_DECLARE NSString *NSPostScriptPboardType = @"NSPostScriptPboardType";
+APPKIT_DECLARE NSString *NSDataLinkPboardType = @"NSDataLinkPboardType";
+APPKIT_DECLARE NSString *NSGeneralPboardType = @"NSGeneralPboardType";
+APPKIT_DECLARE NSString *NSPICTPboardType = @"NSPICTPboardType";
+APPKIT_DECLARE NSString *NSURLPboardType = @"NSURLPboardType";
+APPKIT_DECLARE NSString *NSVCardPboardType = @"NSVCardPboardType";
+APPKIT_DECLARE NSString *NSFilesPromisePboardType = @"NSFilesPromisePboardType";
 
 // Pasteboard Name Globals
-NSString *NSDragPboard = @"NSDragPboard";
-NSString *NSFindPboard = @"NSFindPboard";
-NSString *NSFontPboard = @"NSFontPboard";
-NSString *NSGeneralPboard = @"NSGeneralPboard";
-NSString *NSRulerPboard = @"NSRulerPboard";
+APPKIT_DECLARE NSString *NSDragPboard = @"NSDragPboard";
+APPKIT_DECLARE NSString *NSFindPboard = @"NSFindPboard";
+APPKIT_DECLARE NSString *NSFontPboard = @"NSFontPboard";
+APPKIT_DECLARE NSString *NSGeneralPboard = @"NSGeneralPboard";
+APPKIT_DECLARE NSString *NSRulerPboard = @"NSRulerPboard";
 
 //
 // Pasteboard Exceptions
 //
-NSString *NSPasteboardCommunicationException
-= @"NSPasteboardCommunicationException";
+APPKIT_DECLARE NSString *NSPasteboardCommunicationException = @"NSPasteboardCommunicationException";
 
-NSString *_NXSmartPaste = @"NeXT smart paste pasteboard type";
+APPKIT_DECLARE NSString *_NXSmartPaste = @"NeXT smart paste pasteboard type";
 
 // Printing Information Dictionary Keys
-NSString *NSPrintAllPages = @"NSPrintAllPages";
-NSString *NSPrintBottomMargin = @"NSBottomMargin";
-NSString *NSPrintCopies = @"NSCopies";
-NSString *NSPrintFaxCoverSheetName = @"NSPrintFaxCoverSheetName";
-NSString *NSPrintFaxHighResolution = @"NSPrintFaxHighResolution";
-NSString *NSPrintFaxModem = @"NSPrintFaxModem";
-NSString *NSPrintFaxReceiverNames = @"NSPrintFaxReceiverNames";
-NSString *NSPrintFaxReceiverNumbers = @"NSPrintFaxReceiverNumbers";
-NSString *NSPrintFaxReturnReceipt = @"NSPrintFaxReturnReceipt";
-NSString *NSPrintFaxSendTime = @"NSPrintFaxSendTime";
-NSString *NSPrintFaxTrimPageEnds = @"NSPrintFaxTrimPageEnds";
-NSString *NSPrintFaxUseCoverSheet = @"NSPrintFaxUseCoverSheet";
-NSString *NSPrintFirstPage = @"NSFirstPage";
-NSString *NSPrintHorizontalPagination = @"NSHorizontalPagination";
-NSString *NSPrintHorizontallyCentered = @"NSHorizontallyCentered";
-NSString *NSPrintJobDisposition = @"NSJobDisposition";
-NSString *NSPrintJobFeatures = @"NSJobFeatures";
-NSString *NSPrintLastPage = @"NSLastPage";
-NSString *NSPrintLeftMargin = @"NSLeftMargin";
-NSString *NSPrintManualFeed = @"NSPrintManualFeed";
-NSString *NSPrintMustCollate = @"NSMustCollate";
-NSString *NSPrintOrientation = @"NSOrientation";
-NSString *NSPrintPagesPerSheet = @"NSPagesPerSheet";
-NSString *NSPrintPaperFeed = @"NSPaperFeed";
-NSString *NSPrintPaperName = @"NSPaperName";
-NSString *NSPrintPaperSize = @"NSPaperSize";
-NSString *NSPrintPrinter = @"NSPrinter";
-NSString *NSPrintReversePageOrder = @"NSReversePageOrder";
-NSString *NSPrintRightMargin = @"NSRightMargin";
-NSString *NSPrintSavePath = @"NSSavePath";
-NSString *NSPrintScalingFactor = @"NSScalingFactor";
-NSString *NSPrintTopMargin = @"NSTopMargin";
-NSString *NSPrintVerticalPagination = @"NSVerticalPagination";
-NSString *NSPrintVerticallyCentered = @"NSVerticallyCentered";
-NSString *NSPrintPagesAcross = @"NSPagesAcross";
-NSString *NSPrintPagesDown = @"NSPagesDown";
-NSString *NSPrintTime = @"NSPrintTime";
-NSString *NSPrintDetailedErrorReporting = @"NSDetailedErrorReporting";
-NSString *NSPrintFaxNumber = @"NSFaxNumber";
-NSString *NSPrintPrinterName = @"NSPrinterName";
-NSString *NSPrintHeaderAndFooter = @"NSPrintHeaderAndFooter";
+APPKIT_DECLARE NSString *NSPrintAllPages = @"NSPrintAllPages";
+APPKIT_DECLARE NSString *NSPrintBottomMargin = @"NSBottomMargin";
+APPKIT_DECLARE NSString *NSPrintCopies = @"NSCopies";
+APPKIT_DECLARE NSString *NSPrintFaxCoverSheetName = @"NSPrintFaxCoverSheetName";
+APPKIT_DECLARE NSString *NSPrintFaxHighResolution = @"NSPrintFaxHighResolution";
+APPKIT_DECLARE NSString *NSPrintFaxModem = @"NSPrintFaxModem";
+APPKIT_DECLARE NSString *NSPrintFaxReceiverNames = @"NSPrintFaxReceiverNames";
+APPKIT_DECLARE NSString *NSPrintFaxReceiverNumbers = @"NSPrintFaxReceiverNumbers";
+APPKIT_DECLARE NSString *NSPrintFaxReturnReceipt = @"NSPrintFaxReturnReceipt";
+APPKIT_DECLARE NSString *NSPrintFaxSendTime = @"NSPrintFaxSendTime";
+APPKIT_DECLARE NSString *NSPrintFaxTrimPageEnds = @"NSPrintFaxTrimPageEnds";
+APPKIT_DECLARE NSString *NSPrintFaxUseCoverSheet = @"NSPrintFaxUseCoverSheet";
+APPKIT_DECLARE NSString *NSPrintFirstPage = @"NSFirstPage";
+APPKIT_DECLARE NSString *NSPrintHorizontalPagination = @"NSHorizontalPagination";
+APPKIT_DECLARE NSString *NSPrintHorizontallyCentered = @"NSHorizontallyCentered";
+APPKIT_DECLARE NSString *NSPrintJobDisposition = @"NSJobDisposition";
+APPKIT_DECLARE NSString *NSPrintJobFeatures = @"NSJobFeatures";
+APPKIT_DECLARE NSString *NSPrintLastPage = @"NSLastPage";
+APPKIT_DECLARE NSString *NSPrintLeftMargin = @"NSLeftMargin";
+APPKIT_DECLARE NSString *NSPrintManualFeed = @"NSPrintManualFeed";
+APPKIT_DECLARE NSString *NSPrintMustCollate = @"NSMustCollate";
+APPKIT_DECLARE NSString *NSPrintOrientation = @"NSOrientation";
+APPKIT_DECLARE NSString *NSPrintPagesPerSheet = @"NSPagesPerSheet";
+APPKIT_DECLARE NSString *NSPrintPaperFeed = @"NSPaperFeed";
+APPKIT_DECLARE NSString *NSPrintPaperName = @"NSPaperName";
+APPKIT_DECLARE NSString *NSPrintPaperSize = @"NSPaperSize";
+APPKIT_DECLARE NSString *NSPrintPrinter = @"NSPrinter";
+APPKIT_DECLARE NSString *NSPrintReversePageOrder = @"NSReversePageOrder";
+APPKIT_DECLARE NSString *NSPrintRightMargin = @"NSRightMargin";
+APPKIT_DECLARE NSString *NSPrintSavePath = @"NSSavePath";
+APPKIT_DECLARE NSString *NSPrintScalingFactor = @"NSScalingFactor";
+APPKIT_DECLARE NSString *NSPrintTopMargin = @"NSTopMargin";
+APPKIT_DECLARE NSString *NSPrintVerticalPagination = @"NSVerticalPagination";
+APPKIT_DECLARE NSString *NSPrintVerticallyCentered = @"NSVerticallyCentered";
+APPKIT_DECLARE NSString *NSPrintPagesAcross = @"NSPagesAcross";
+APPKIT_DECLARE NSString *NSPrintPagesDown = @"NSPagesDown";
+APPKIT_DECLARE NSString *NSPrintTime = @"NSPrintTime";
+APPKIT_DECLARE NSString *NSPrintDetailedErrorReporting = @"NSDetailedErrorReporting";
+APPKIT_DECLARE NSString *NSPrintFaxNumber = @"NSFaxNumber";
+APPKIT_DECLARE NSString *NSPrintPrinterName = @"NSPrinterName";
+APPKIT_DECLARE NSString *NSPrintHeaderAndFooter = @"NSPrintHeaderAndFooter";
 
-NSString *NSPrintPageDirection = @"NSPrintPageDirection";
+APPKIT_DECLARE NSString *NSPrintPageDirection = @"NSPrintPageDirection";
 
 // Print Job Disposition Values
-NSString  *NSPrintCancelJob = @"NSPrintCancelJob";
-NSString  *NSPrintFaxJob = @"NSPrintFaxJob";
-NSString  *NSPrintPreviewJob = @"NSPrintPreviewJob";
-NSString  *NSPrintSaveJob = @"NSPrintSaveJob";
-NSString  *NSPrintSpoolJob = @"NSPrintSpoolJob";
+APPKIT_DECLARE NSString  *NSPrintCancelJob = @"NSPrintCancelJob";
+APPKIT_DECLARE NSString  *NSPrintFaxJob = @"NSPrintFaxJob";
+APPKIT_DECLARE NSString  *NSPrintPreviewJob = @"NSPrintPreviewJob";
+APPKIT_DECLARE NSString  *NSPrintSaveJob = @"NSPrintSaveJob";
+APPKIT_DECLARE NSString  *NSPrintSpoolJob = @"NSPrintSpoolJob";
 
 // Print Panel
-NSString *NSPrintPanelAccessorySummaryItemNameKey = @"name";
-NSString *NSPrintPanelAccessorySummaryItemDescriptionKey = @"description";
-NSString *NSPrintPhotoJobStyleHint = @"Photo";
+APPKIT_DECLARE NSString *NSPrintPanelAccessorySummaryItemNameKey = @"name";
+APPKIT_DECLARE NSString *NSPrintPanelAccessorySummaryItemDescriptionKey = @"description";
+APPKIT_DECLARE NSString *NSPrintPhotoJobStyleHint = @"Photo";
 
 // NSSplitView notifications
-NSString *NSSplitViewDidResizeSubviewsNotification =
+APPKIT_DECLARE NSString *NSSplitViewDidResizeSubviewsNotification =
 @"NSSplitViewDidResizeSubviewsNotification";
-NSString *NSSplitViewWillResizeSubviewsNotification =
+APPKIT_DECLARE NSString *NSSplitViewWillResizeSubviewsNotification =
 @"NSSplitViewWillResizeSubviewsNotification";
 
 // NSTableView notifications
-NSString *NSTableViewColumnDidMove = @"NSTableViewColumnDidMoveNotification";
-NSString *NSTableViewColumnDidResize 
-= @"NSTableViewColumnDidResizeNotification";
-NSString *NSTableViewSelectionDidChange 
-= @"NSTableViewSelectionDidChangeNotification";
-NSString *NSTableViewSelectionIsChanging 
-= @"NSTableViewSelectionIsChangingNotification";
+APPKIT_DECLARE NSString *NSTableViewColumnDidMove = @"NSTableViewColumnDidMoveNotification";
+APPKIT_DECLARE NSString *NSTableViewColumnDidResize = @"NSTableViewColumnDidResizeNotification";
+APPKIT_DECLARE NSString *NSTableViewSelectionDidChange = @"NSTableViewSelectionDidChangeNotification";
+APPKIT_DECLARE NSString *NSTableViewSelectionIsChanging = @"NSTableViewSelectionIsChangingNotification";
 
 // NSText notifications
-NSString *NSTextDidBeginEditingNotification =
-@"NSTextDidBeginEditingNotification";
-NSString *NSTextDidEndEditingNotification = @"NSTextDidEndEditingNotification";
-NSString *NSTextDidChangeNotification = @"NSTextDidChangeNotification";
+APPKIT_DECLARE NSString *NSTextDidBeginEditingNotification = @"NSTextDidBeginEditingNotification";
+APPKIT_DECLARE NSString *NSTextDidEndEditingNotification = @"NSTextDidEndEditingNotification";
+APPKIT_DECLARE NSString *NSTextDidChangeNotification = @"NSTextDidChangeNotification";
 
 // NSTextStorage Notifications
-NSString *NSTextStorageWillProcessEditingNotification =
-  @"NSTextStorageWillProcessEditingNotification";
-NSString *NSTextStorageDidProcessEditingNotification =
-  @"NSTextStorageDidProcessEditingNotification";
+APPKIT_DECLARE NSString *NSTextStorageWillProcessEditingNotification = @"NSTextStorageWillProcessEditingNotification";
+APPKIT_DECLARE NSString *NSTextStorageDidProcessEditingNotification = @"NSTextStorageDidProcessEditingNotification";
 
 // NSTextView notifications
-NSString *NSTextViewDidChangeSelectionNotification =
-@"NSTextViewDidChangeSelectionNotification";
-NSString *NSTextViewWillChangeNotifyingTextViewNotification =
-@"NSTextViewWillChangeNotifyingTextViewNotification";
-NSString *NSTextViewDidChangeTypingAttributesNotification =
-@"NSTextViewDidChangeTypingAttributesNotification";
+APPKIT_DECLARE NSString *NSTextViewDidChangeSelectionNotification = @"NSTextViewDidChangeSelectionNotification";
+APPKIT_DECLARE NSString *NSTextViewWillChangeNotifyingTextViewNotification = @"NSTextViewWillChangeNotifyingTextViewNotification";
+APPKIT_DECLARE NSString *NSTextViewDidChangeTypingAttributesNotification = @"NSTextViewDidChangeTypingAttributesNotification";
 
 // NSView notifications
-NSString *NSViewFocusDidChangeNotification
-    = @"NSViewFocusDidChangeNotification";
-NSString *NSViewFrameDidChangeNotification
-    = @"NSViewFrameDidChangeNotification";
-NSString *NSViewBoundsDidChangeNotification
-    = @"NSViewBoundsDidChangeNotification";
-NSString *NSViewGlobalFrameDidChangeNotification
-    = @"NSViewGlobalFrameDidChangeNotification";
+APPKIT_DECLARE NSString *NSViewFocusDidChangeNotification = @"NSViewFocusDidChangeNotification";
+APPKIT_DECLARE NSString *NSViewFrameDidChangeNotification = @"NSViewFrameDidChangeNotification";
+APPKIT_DECLARE NSString *NSViewBoundsDidChangeNotification = @"NSViewBoundsDidChangeNotification";
+APPKIT_DECLARE NSString *NSViewGlobalFrameDidChangeNotification = @"NSViewGlobalFrameDidChangeNotification";
 
 // NSViewAnimation 
-NSString *NSViewAnimationTargetKey     = @"NSViewAnimationTargetKey";
-NSString *NSViewAnimationStartFrameKey = @"NSViewAnimationStartFrameKey";
-NSString *NSViewAnimationEndFrameKey   = @"NSViewAnimationEndFrameKey";
-NSString *NSViewAnimationEffectKey     = @"NSViewAnimationEffectKey";
-NSString *NSViewAnimationFadeInEffect  = @"NSViewAnimationFadeInEffect";
-NSString *NSViewAnimationFadeOutEffect = @"NSViewAnimationFadeOutEffect";
+APPKIT_DECLARE NSString *NSViewAnimationTargetKey     = @"NSViewAnimationTargetKey";
+APPKIT_DECLARE NSString *NSViewAnimationStartFrameKey = @"NSViewAnimationStartFrameKey";
+APPKIT_DECLARE NSString *NSViewAnimationEndFrameKey   = @"NSViewAnimationEndFrameKey";
+APPKIT_DECLARE NSString *NSViewAnimationEffectKey     = @"NSViewAnimationEffectKey";
+APPKIT_DECLARE NSString *NSViewAnimationFadeInEffect  = @"NSViewAnimationFadeInEffect";
+APPKIT_DECLARE NSString *NSViewAnimationFadeOutEffect = @"NSViewAnimationFadeOutEffect";
 
 
 // NSMenu notifications
@@ -464,239 +420,220 @@ NSString* const NSMenuDidBeginTrackingNotification = @"NSMenuDidBeginTrackingNot
 NSString* const NSMenuDidEndTrackingNotification = @"NSMenuDidEndTrackingNotification";
 
 // NSPopUpButton notification
-NSString *NSPopUpButtonWillPopUpNotification = @"NSPopUpButtonWillPopUpNotification";
-NSString *NSPopUpButtonCellWillPopUpNotification = @"NSPopUpButtonCellWillPopUpNotification";
+APPKIT_DECLARE NSString *NSPopUpButtonWillPopUpNotification = @"NSPopUpButtonWillPopUpNotification";
+APPKIT_DECLARE NSString *NSPopUpButtonCellWillPopUpNotification = @"NSPopUpButtonCellWillPopUpNotification";
 
 // NSPopover notifications
-NSString *NSPopoverWillShowNotification = @"NSPopoverWillShowNotification";
-NSString *NSPopoverDidShowNotification = @"NSPopoverDidShowNotification";
-NSString *NSPopoverWillCloseNotification = @"NSPopoverWillCloseNotification";
-NSString *NSPopoverDidCloseNotification = @"NSPopoverDidCloseNotification";
+APPKIT_DECLARE NSString *NSPopoverWillShowNotification = @"NSPopoverWillShowNotification";
+APPKIT_DECLARE NSString *NSPopoverDidShowNotification = @"NSPopoverDidShowNotification";
+APPKIT_DECLARE NSString *NSPopoverWillCloseNotification = @"NSPopoverWillCloseNotification";
+APPKIT_DECLARE NSString *NSPopoverDidCloseNotification = @"NSPopoverDidCloseNotification";
 
 // NSPopover keys
-NSString *NSPopoverCloseReasonKey = @"NSPopoverCloseReasonKey";
-NSString *NSPopoverCloseReasonStandard = @"NSPopoverCloseReasonStandard";
-NSString *NSPopoverCloseReasonDetachToWindow = @"NSPopoverCloseReasonDetachToWindow";
+APPKIT_DECLARE NSString *NSPopoverCloseReasonKey = @"NSPopoverCloseReasonKey";
+APPKIT_DECLARE NSString *NSPopoverCloseReasonStandard = @"NSPopoverCloseReasonStandard";
+APPKIT_DECLARE NSString *NSPopoverCloseReasonDetachToWindow = @"NSPopoverCloseReasonDetachToWindow";
 
 // NSTable notifications
-NSString *NSTableViewSelectionDidChangeNotification = @"NSTableViewSelectionDidChangeNotification";
-NSString *NSTableViewColumnDidMoveNotification = @"NSTableViewColumnDidMoveNotification";
-NSString *NSTableViewColumnDidResizeNotification = @"NSTableViewColumnDidResizeNotification";
-NSString *NSTableViewSelectionIsChangingNotification = @"NSTableViewSelectionIsChangingNotification";
+APPKIT_DECLARE NSString *NSTableViewSelectionDidChangeNotification = @"NSTableViewSelectionDidChangeNotification";
+APPKIT_DECLARE NSString *NSTableViewColumnDidMoveNotification = @"NSTableViewColumnDidMoveNotification";
+APPKIT_DECLARE NSString *NSTableViewColumnDidResizeNotification = @"NSTableViewColumnDidResizeNotification";
+APPKIT_DECLARE NSString *NSTableViewSelectionIsChangingNotification = @"NSTableViewSelectionIsChangingNotification";
 
 // NSOutlineView notifications
-NSString *NSOutlineViewSelectionDidChangeNotification = @"NSOutlineViewSelectionDidChangeNotification";
-NSString *NSOutlineViewColumnDidMoveNotification = @"NSOutlineViewColumnDidMoveNotification";
-NSString *NSOutlineViewColumnDidResizeNotification = @"NSOutlineViewColumnDidResizeNotification";
-NSString *NSOutlineViewSelectionIsChangingNotification = @"NSOutlineViewSelectionIsChangingNotification";
-NSString *NSOutlineViewItemDidExpandNotification = @"NSOutlineViewItemDidExpandNotification";
-NSString *NSOutlineViewItemDidCollapseNotification = @"NSOutlineViewItemDidCollapseNotification";
-NSString *NSOutlineViewItemWillExpandNotification = @"NSOutlineViewItemWillExpandNotification";
-NSString *NSOutlineViewItemWillCollapseNotification = @"NSOutlineViewItemWillCollapseNotification";
+APPKIT_DECLARE NSString *NSOutlineViewSelectionDidChangeNotification = @"NSOutlineViewSelectionDidChangeNotification";
+APPKIT_DECLARE NSString *NSOutlineViewColumnDidMoveNotification = @"NSOutlineViewColumnDidMoveNotification";
+APPKIT_DECLARE NSString *NSOutlineViewColumnDidResizeNotification = @"NSOutlineViewColumnDidResizeNotification";
+APPKIT_DECLARE NSString *NSOutlineViewSelectionIsChangingNotification = @"NSOutlineViewSelectionIsChangingNotification";
+APPKIT_DECLARE NSString *NSOutlineViewItemDidExpandNotification = @"NSOutlineViewItemDidExpandNotification";
+APPKIT_DECLARE NSString *NSOutlineViewItemDidCollapseNotification = @"NSOutlineViewItemDidCollapseNotification";
+APPKIT_DECLARE NSString *NSOutlineViewItemWillExpandNotification = @"NSOutlineViewItemWillExpandNotification";
+APPKIT_DECLARE NSString *NSOutlineViewItemWillCollapseNotification = @"NSOutlineViewItemWillCollapseNotification";
 
 // NSWindow notifications
-NSString *NSWindowDidBecomeKeyNotification = @"NSWindowDidBecomeKeyNotification";
-NSString *NSWindowDidBecomeMainNotification = @"NSWindowDidBecomeMainNotification";
-NSString *NSWindowDidChangeScreenNotification = @"NSWindowDidChangeScreenNotification";
-NSString *NSWindowDidChangeScreenProfileNotification = @"NSWindowDidChangeScreenProfileNotification";
-NSString *NSWindowDidDeminiaturizeNotification = @"NSWindowDidDeminiaturizeNotification";
-NSString *NSWindowDidEndSheetNotification = @"NSWindowDidEndSheetNotification";
-NSString *NSWindowDidExposeNotification = @"NSWindowDidExposeNotification";
-NSString *NSWindowDidMiniaturizeNotification = @"NSWindowDidMiniaturizeNotification";
-NSString *NSWindowDidMoveNotification = @"NSWindowDidMoveNotification";
-NSString *NSWindowDidResignKeyNotification = @"NSWindowDidResignKeyNotification";
-NSString *NSWindowDidResignMainNotification = @"NSWindowDidResignMainNotification";
-NSString *NSWindowDidResizeNotification = @"NSWindowDidResizeNotification";
-NSString *NSWindowDidUpdateNotification = @"NSWindowDidUpdateNotification";
-NSString *NSWindowWillBeginSheetNotification = @"NSWindowWillBeginSheetNotification";
-NSString *NSWindowWillCloseNotification = @"NSWindowWillCloseNotification";
-NSString *NSWindowWillMiniaturizeNotification = @"NSWindowWillMiniaturizeNotification";
-NSString *NSWindowWillMoveNotification = @"NSWindowWillMoveNotification";
+APPKIT_DECLARE NSString *NSWindowDidBecomeKeyNotification = @"NSWindowDidBecomeKeyNotification";
+APPKIT_DECLARE NSString *NSWindowDidBecomeMainNotification = @"NSWindowDidBecomeMainNotification";
+APPKIT_DECLARE NSString *NSWindowDidChangeScreenNotification = @"NSWindowDidChangeScreenNotification";
+APPKIT_DECLARE NSString *NSWindowDidChangeScreenProfileNotification = @"NSWindowDidChangeScreenProfileNotification";
+APPKIT_DECLARE NSString *NSWindowDidDeminiaturizeNotification = @"NSWindowDidDeminiaturizeNotification";
+APPKIT_DECLARE NSString *NSWindowDidEndSheetNotification = @"NSWindowDidEndSheetNotification";
+APPKIT_DECLARE NSString *NSWindowDidExposeNotification = @"NSWindowDidExposeNotification";
+APPKIT_DECLARE NSString *NSWindowDidMiniaturizeNotification = @"NSWindowDidMiniaturizeNotification";
+APPKIT_DECLARE NSString *NSWindowDidMoveNotification = @"NSWindowDidMoveNotification";
+APPKIT_DECLARE NSString *NSWindowDidResignKeyNotification = @"NSWindowDidResignKeyNotification";
+APPKIT_DECLARE NSString *NSWindowDidResignMainNotification = @"NSWindowDidResignMainNotification";
+APPKIT_DECLARE NSString *NSWindowDidResizeNotification = @"NSWindowDidResizeNotification";
+APPKIT_DECLARE NSString *NSWindowDidUpdateNotification = @"NSWindowDidUpdateNotification";
+APPKIT_DECLARE NSString *NSWindowWillBeginSheetNotification = @"NSWindowWillBeginSheetNotification";
+APPKIT_DECLARE NSString *NSWindowWillCloseNotification = @"NSWindowWillCloseNotification";
+APPKIT_DECLARE NSString *NSWindowWillMiniaturizeNotification = @"NSWindowWillMiniaturizeNotification";
+APPKIT_DECLARE NSString *NSWindowWillMoveNotification = @"NSWindowWillMoveNotification";
 
 // Workspace File Type Globals
-NSString *NSPlainFileType = @"NSPlainFileType";
-NSString *NSDirectoryFileType = @"NSDirectoryFileType";
-NSString *NSApplicationFileType = @"NSApplicationFileType";
-NSString *NSFilesystemFileType = @"NSFilesystemFileType";
-NSString *NSShellCommandFileType = @"NSShellCommandFileType";
+APPKIT_DECLARE NSString *NSPlainFileType = @"NSPlainFileType";
+APPKIT_DECLARE NSString *NSDirectoryFileType = @"NSDirectoryFileType";
+APPKIT_DECLARE NSString *NSApplicationFileType = @"NSApplicationFileType";
+APPKIT_DECLARE NSString *NSFilesystemFileType = @"NSFilesystemFileType";
+APPKIT_DECLARE NSString *NSShellCommandFileType = @"NSShellCommandFileType";
 
 // Workspace File Operation Globals
-NSString *NSWorkspaceCompressOperation = @"compress";
-NSString *NSWorkspaceCopyOperation = @"copy";
-NSString *NSWorkspaceDecompressOperation = @"decompress";
-NSString *NSWorkspaceDecryptOperation = @"decrypt";
-NSString *NSWorkspaceDestroyOperation = @"destroy";
-NSString *NSWorkspaceDuplicateOperation = @"duplicate";
-NSString *NSWorkspaceEncryptOperation = @"encrypt";
-NSString *NSWorkspaceLinkOperation = @"link";
-NSString *NSWorkspaceMoveOperation = @"move";
-NSString *NSWorkspaceRecycleOperation = @"recycle";
+APPKIT_DECLARE NSString *NSWorkspaceCompressOperation = @"compress";
+APPKIT_DECLARE NSString *NSWorkspaceCopyOperation = @"copy";
+APPKIT_DECLARE NSString *NSWorkspaceDecompressOperation = @"decompress";
+APPKIT_DECLARE NSString *NSWorkspaceDecryptOperation = @"decrypt";
+APPKIT_DECLARE NSString *NSWorkspaceDestroyOperation = @"destroy";
+APPKIT_DECLARE NSString *NSWorkspaceDuplicateOperation = @"duplicate";
+APPKIT_DECLARE NSString *NSWorkspaceEncryptOperation = @"encrypt";
+APPKIT_DECLARE NSString *NSWorkspaceLinkOperation = @"link";
+APPKIT_DECLARE NSString *NSWorkspaceMoveOperation = @"move";
+APPKIT_DECLARE NSString *NSWorkspaceRecycleOperation = @"recycle";
 
 // NSWorkspace notifications
-NSString *NSWorkspaceDidLaunchApplicationNotification =
-@"NSWorkspaceDidLaunchApplicationNotification";
-NSString *NSWorkspaceDidMountNotification = @"NSWorkspaceDidMountNotification";
-NSString *NSWorkspaceDidPerformFileOperationNotification =
-@"NSWorkspaceDidPerformFileOperationNotification";
-NSString *NSWorkspaceDidTerminateApplicationNotification =
-@"NSWorkspaceDidTerminateApplicationNotification";
-NSString *NSWorkspaceDidUnmountNotification =
-@"NSWorkspaceDidUnmountNotification";
-NSString *NSWorkspaceWillLaunchApplicationNotification =
-@"NSWorkspaceWillLaunchApplicationNotification";
-NSString *NSWorkspaceWillPowerOffNotification =
-@"NSWorkspaceWillPowerOffNotification";
-NSString *NSWorkspaceWillUnmountNotification =
-@"NSWorkspaceWillUnmountNotification";
-NSString *NSWorkspaceDidWakeNotification =
-@"NSWorkspaceDidWakeNotification";
-NSString *NSWorkspaceSessionDidBecomeActiveNotification =
-@"NSWorkspaceSessionDidBecomeActiveNotification";
-NSString *NSWorkspaceSessionDidResignActiveNotification =
-@"NSWorkspaceSessionDidResignActiveNotification";
-NSString *NSWorkspaceWillSleepNotification =
-@"NSWorkspaceWillSleepNotification";
+APPKIT_DECLARE NSString *NSWorkspaceDidLaunchApplicationNotification = @"NSWorkspaceDidLaunchApplicationNotification";
+APPKIT_DECLARE NSString *NSWorkspaceDidMountNotification = @"NSWorkspaceDidMountNotification";
+APPKIT_DECLARE NSString *NSWorkspaceDidPerformFileOperationNotification = @"NSWorkspaceDidPerformFileOperationNotification";
+APPKIT_DECLARE NSString *NSWorkspaceDidTerminateApplicationNotification = @"NSWorkspaceDidTerminateApplicationNotification";
+APPKIT_DECLARE NSString *NSWorkspaceDidUnmountNotification = @"NSWorkspaceDidUnmountNotification";
+APPKIT_DECLARE NSString *NSWorkspaceWillLaunchApplicationNotification = @"NSWorkspaceWillLaunchApplicationNotification";
+APPKIT_DECLARE NSString *NSWorkspaceWillPowerOffNotification = @"NSWorkspaceWillPowerOffNotification";
+APPKIT_DECLARE NSString *NSWorkspaceWillUnmountNotification = @"NSWorkspaceWillUnmountNotification";
+APPKIT_DECLARE NSString *NSWorkspaceDidWakeNotification = @"NSWorkspaceDidWakeNotification";
+APPKIT_DECLARE NSString *NSWorkspaceSessionDidBecomeActiveNotification = @"NSWorkspaceSessionDidBecomeActiveNotification";
+APPKIT_DECLARE NSString *NSWorkspaceSessionDidResignActiveNotification = @"NSWorkspaceSessionDidResignActiveNotification";
+APPKIT_DECLARE NSString *NSWorkspaceWillSleepNotification = @"NSWorkspaceWillSleepNotification";
 
 /*
  *	NSStringDrawing NSAttributedString additions
  */
-NSString *NSAttachmentAttributeName = @"NSAttachment";
-NSString *NSBackgroundColorAttributeName = @"NSBackgroundColor";
-NSString *NSBaselineOffsetAttributeName = @"NSBaselineOffset";
-NSString *NSCursorAttributeName = @"NSCursor";
-NSString *NSExpansionAttributeName = @"NSExpansion";
-NSString *NSFontAttributeName = @"NSFont";
-NSString *NSForegroundColorAttributeName = @"NSColor";
-NSString *NSKernAttributeName = @"NSKern";
-NSString *NSLigatureAttributeName = @"NSLigature";
-NSString *NSLinkAttributeName = @"NSLink";
-NSString *NSObliquenessAttributeName = @"NSObliqueness";
-NSString *NSParagraphStyleAttributeName = @"NSParagraphStyle";
-NSString *NSShadowAttributeName = @"NSShadow";
-NSString *NSStrikethroughColorAttributeName
-  = @"NSStrikethroughColor";
-NSString *NSStrikethroughStyleAttributeName = @"NSStrikethrough";
-NSString *NSStrokeColorAttributeName = @"NSStrokeColor";
-NSString *NSStrokeWidthAttributeName = @"NSStrokeWidth";
-NSString *NSSuperscriptAttributeName = @"NSSuperScript";
-NSString *NSToolTipAttributeName = @"NSToolTip";
-NSString *NSUnderlineColorAttributeName = @"NSUnderlineColor";
-NSString *NSUnderlineStyleAttributeName = @"NSUnderline";
+APPKIT_DECLARE NSString *NSAttachmentAttributeName = @"NSAttachment";
+APPKIT_DECLARE NSString *NSBackgroundColorAttributeName = @"NSBackgroundColor";
+APPKIT_DECLARE NSString *NSBaselineOffsetAttributeName = @"NSBaselineOffset";
+APPKIT_DECLARE NSString *NSCursorAttributeName = @"NSCursor";
+APPKIT_DECLARE NSString *NSExpansionAttributeName = @"NSExpansion";
+APPKIT_DECLARE NSString *NSFontAttributeName = @"NSFont";
+APPKIT_DECLARE NSString *NSForegroundColorAttributeName = @"NSColor";
+APPKIT_DECLARE NSString *NSKernAttributeName = @"NSKern";
+APPKIT_DECLARE NSString *NSLigatureAttributeName = @"NSLigature";
+APPKIT_DECLARE NSString *NSLinkAttributeName = @"NSLink";
+APPKIT_DECLARE NSString *NSObliquenessAttributeName = @"NSObliqueness";
+APPKIT_DECLARE NSString *NSParagraphStyleAttributeName = @"NSParagraphStyle";
+APPKIT_DECLARE NSString *NSShadowAttributeName = @"NSShadow";
+APPKIT_DECLARE NSString *NSStrikethroughColorAttributeName = @"NSStrikethroughColor";
+APPKIT_DECLARE NSString *NSStrikethroughStyleAttributeName = @"NSStrikethrough";
+APPKIT_DECLARE NSString *NSStrokeColorAttributeName = @"NSStrokeColor";
+APPKIT_DECLARE NSString *NSStrokeWidthAttributeName = @"NSStrokeWidth";
+APPKIT_DECLARE NSString *NSSuperscriptAttributeName = @"NSSuperScript";
+APPKIT_DECLARE NSString *NSToolTipAttributeName = @"NSToolTip";
+APPKIT_DECLARE NSString *NSUnderlineColorAttributeName = @"NSUnderlineColor";
+APPKIT_DECLARE NSString *NSUnderlineStyleAttributeName = @"NSUnderline";
 
-NSString *NSTextAlternativesAttributeName = @"NSTextAlternatives";
-NSString *NSWritingDirectionAttributeName = @"NSWritingDirection";
+APPKIT_DECLARE NSString *NSTextAlternativesAttributeName = @"NSTextAlternatives";
+APPKIT_DECLARE NSString *NSWritingDirectionAttributeName = @"NSWritingDirection";
 
-NSString *NSCharacterShapeAttributeName = @"NSCharacterShape";
-NSString *NSGlyphInfoAttributeName = @"NSGlyphInfo";
+APPKIT_DECLARE NSString *NSCharacterShapeAttributeName = @"NSCharacterShape";
+APPKIT_DECLARE NSString *NSGlyphInfoAttributeName = @"NSGlyphInfo";
 
-NSString *NSPaperSizeDocumentAttribute = @"PaperSize";
-NSString *NSLeftMarginDocumentAttribute = @"LeftMargin";
-NSString *NSRightMarginDocumentAttribute = @"RightMargin";
-NSString *NSTopMarginDocumentAttribute = @"TopMargin";
-NSString *NSBottomMarginDocumentAttribute = @"BottomMargin";
-NSString *NSHyphenationFactorDocumentAttribute = @"HyphenationFactor";
-NSString *NSDocumentTypeDocumentAttribute = @"DocumentType";
-NSString *NSCharacterEncodingDocumentAttribute = @"CharacterEncoding";
-NSString *NSViewSizeDocumentAttribute = @"ViewSize";
-NSString *NSViewZoomDocumentAttribute = @"ViewZoom";
-NSString *NSViewModeDocumentAttribute = @"ViewMode";
-NSString *NSBackgroundColorDocumentAttribute = @"BackgroundColor";
-NSString *NSCocoaVersionDocumentAttribute = @"CocoaVersion";
-NSString *NSReadOnlyDocumentAttribute = @"ReadOnly";
-NSString *NSConvertedDocumentAttribute = @"Converted";
-NSString *NSDefaultTabIntervalDocumentAttribute = @"DefaultTabInterval";
-NSString *NSTitleDocumentAttribute = @"Title";
-NSString *NSCompanyDocumentAttribute = @"Company";
-NSString *NSCopyrightDocumentAttribute = @"Copyright";
-NSString *NSSubjectDocumentAttribute = @"Subject";
-NSString *NSAuthorDocumentAttribute = @"Author";
-NSString *NSKeywordsDocumentAttribute = @"Keywords";
-NSString *NSCommentDocumentAttribute = @"Comment";
-NSString *NSEditorDocumentAttribute = @"Editor";
-NSString *NSCreationTimeDocumentAttribute = @"CreationTime";
-NSString *NSModificationTimeDocumentAttribute = @"ModificationTime";
+APPKIT_DECLARE NSString *NSPaperSizeDocumentAttribute = @"PaperSize";
+APPKIT_DECLARE NSString *NSLeftMarginDocumentAttribute = @"LeftMargin";
+APPKIT_DECLARE NSString *NSRightMarginDocumentAttribute = @"RightMargin";
+APPKIT_DECLARE NSString *NSTopMarginDocumentAttribute = @"TopMargin";
+APPKIT_DECLARE NSString *NSBottomMarginDocumentAttribute = @"BottomMargin";
+APPKIT_DECLARE NSString *NSHyphenationFactorDocumentAttribute = @"HyphenationFactor";
+APPKIT_DECLARE NSString *NSDocumentTypeDocumentAttribute = @"DocumentType";
+APPKIT_DECLARE NSString *NSCharacterEncodingDocumentAttribute = @"CharacterEncoding";
+APPKIT_DECLARE NSString *NSViewSizeDocumentAttribute = @"ViewSize";
+APPKIT_DECLARE NSString *NSViewZoomDocumentAttribute = @"ViewZoom";
+APPKIT_DECLARE NSString *NSViewModeDocumentAttribute = @"ViewMode";
+APPKIT_DECLARE NSString *NSBackgroundColorDocumentAttribute = @"BackgroundColor";
+APPKIT_DECLARE NSString *NSCocoaVersionDocumentAttribute = @"CocoaVersion";
+APPKIT_DECLARE NSString *NSReadOnlyDocumentAttribute = @"ReadOnly";
+APPKIT_DECLARE NSString *NSConvertedDocumentAttribute = @"Converted";
+APPKIT_DECLARE NSString *NSDefaultTabIntervalDocumentAttribute = @"DefaultTabInterval";
+APPKIT_DECLARE NSString *NSTitleDocumentAttribute = @"Title";
+APPKIT_DECLARE NSString *NSCompanyDocumentAttribute = @"Company";
+APPKIT_DECLARE NSString *NSCopyrightDocumentAttribute = @"Copyright";
+APPKIT_DECLARE NSString *NSSubjectDocumentAttribute = @"Subject";
+APPKIT_DECLARE NSString *NSAuthorDocumentAttribute = @"Author";
+APPKIT_DECLARE NSString *NSKeywordsDocumentAttribute = @"Keywords";
+APPKIT_DECLARE NSString *NSCommentDocumentAttribute = @"Comment";
+APPKIT_DECLARE NSString *NSEditorDocumentAttribute = @"Editor";
+APPKIT_DECLARE NSString *NSCreationTimeDocumentAttribute = @"CreationTime";
+APPKIT_DECLARE NSString *NSModificationTimeDocumentAttribute = @"ModificationTime";
 
-NSString *NSTextInsertionUndoableAttributeName =
-  @"NSTextInsertionUndoableAttributeName";
+APPKIT_DECLARE NSString *NSTextInsertionUndoableAttributeName =   @"NSTextInsertionUndoableAttributeName";
 
-const unsigned NSUnderlineByWordMask = 0x01;
+APPKIT_DECLARE const unsigned NSUnderlineByWordMask = 0x01;
 
-NSString *NSSpellingStateAttributeName = @"NSSpellingState";
-const unsigned NSSpellingStateSpellingFlag = 1;
-const unsigned NSSpellingStateGrammarFlag = 2;
+APPKIT_DECLARE NSString *NSSpellingStateAttributeName = @"NSSpellingState";
+APPKIT_DECLARE const unsigned NSSpellingStateSpellingFlag = 1;
+APPKIT_DECLARE const unsigned NSSpellingStateGrammarFlag = 2;
 
-NSString *NSSpellCheckerDidChangeAutomaticSpellingCorrectionNotification =
-  @"NSSpellCheckerDidChangeAutomaticSpellingCorrectionNotification";
-NSString *NSSpellCheckerDidChangeAutomaticTextReplacementNotification =
-  @"NSSpellCheckerDidChangeAutomaticTextReplacementNotification";
-NSString *NSSpellCheckerDidChangeAutomaticQuoteSubstitutionNotification =
-  @"NSSpellCheckerDidChangeAutomaticQuoteSubstitutionNotification";
-NSString *NSSpellCheckerDidChangeAutomaticDashSubstitutionNotification =
-  @"NSSpellCheckerDidChangeAutomaticDashSubstitutionNotification";
+APPKIT_DECLARE NSString *NSSpellCheckerDidChangeAutomaticSpellingCorrectionNotification = @"NSSpellCheckerDidChangeAutomaticSpellingCorrectionNotification";
+APPKIT_DECLARE NSString *NSSpellCheckerDidChangeAutomaticTextReplacementNotification = @"NSSpellCheckerDidChangeAutomaticTextReplacementNotification";
+APPKIT_DECLARE NSString *NSSpellCheckerDidChangeAutomaticQuoteSubstitutionNotification = @"NSSpellCheckerDidChangeAutomaticQuoteSubstitutionNotification";
+APPKIT_DECLARE NSString *NSSpellCheckerDidChangeAutomaticDashSubstitutionNotification = @"NSSpellCheckerDidChangeAutomaticDashSubstitutionNotification";
 
 
-NSString *NSPlainTextDocumentType = @"NSPlainText";
-NSString *NSRTFTextDocumentType = @"NSRTF";
-NSString *NSRTFDTextDocumentType = @"NSRTFD";
-NSString *NSMacSimpleTextDocumentType = @"NSMacSimpleText";
-NSString *NSHTMLTextDocumentType = @"NSHTML";
-NSString *NSDocFormatTextDocumentType = @"NSDocFormat";
-NSString *NSWordMLTextDocumentType = @"NSWordML";
-NSString *NSOfficeOpenXMLTextDocumentType = @"NSOfficeOpenXML";
-NSString *NSOpenDocumentTextDocumentType = @"NSOpenDocumentText";
+APPKIT_DECLARE NSString *NSPlainTextDocumentType = @"NSPlainText";
+APPKIT_DECLARE NSString *NSRTFTextDocumentType = @"NSRTF";
+APPKIT_DECLARE NSString *NSRTFDTextDocumentType = @"NSRTFD";
+APPKIT_DECLARE NSString *NSMacSimpleTextDocumentType = @"NSMacSimpleText";
+APPKIT_DECLARE NSString *NSHTMLTextDocumentType = @"NSHTML";
+APPKIT_DECLARE NSString *NSDocFormatTextDocumentType = @"NSDocFormat";
+APPKIT_DECLARE NSString *NSWordMLTextDocumentType = @"NSWordML";
+APPKIT_DECLARE NSString *NSOfficeOpenXMLTextDocumentType = @"NSOfficeOpenXML";
+APPKIT_DECLARE NSString *NSOpenDocumentTextDocumentType = @"NSOpenDocumentText";
 
-NSString *NSExcludedElementsDocumentAttribute = @"ExcludedElements";
-NSString *NSTextEncodingNameDocumentAttribute = @"TextEncodingName";
-NSString *NSPrefixSpacesDocumentAttribute = @"PrefixSpaces";
+APPKIT_DECLARE NSString *NSExcludedElementsDocumentAttribute = @"ExcludedElements";
+APPKIT_DECLARE NSString *NSTextEncodingNameDocumentAttribute = @"TextEncodingName";
+APPKIT_DECLARE NSString *NSPrefixSpacesDocumentAttribute = @"PrefixSpaces";
 
-NSString *NSBaseURLDocumentOption = @"BaseURL";
-NSString *NSCharacterEncodingDocumentOption = @"CharacterEncoding";
-NSString *NSDefaultAttributesDocumentOption = @"DefaultAttributes";
-NSString *NSDocumentTypeDocumentOption = @"DocumentType";
-NSString *NSTextEncodingNameDocumentOption = @"TextEncodingName";
-NSString *NSTextSizeMultiplierDocumentOption = @"TextSizeMultiplier";
-NSString *NSTimeoutDocumentOption = @"Timeout";
-NSString *NSWebPreferencesDocumentOption = @"WebPreferences";
-NSString *NSWebResourceLoadDelegateDocumentOption = @"WebResourceLoadDelegate";
+APPKIT_DECLARE NSString *NSBaseURLDocumentOption = @"BaseURL";
+APPKIT_DECLARE NSString *NSCharacterEncodingDocumentOption = @"CharacterEncoding";
+APPKIT_DECLARE NSString *NSDefaultAttributesDocumentOption = @"DefaultAttributes";
+APPKIT_DECLARE NSString *NSDocumentTypeDocumentOption = @"DocumentType";
+APPKIT_DECLARE NSString *NSTextEncodingNameDocumentOption = @"TextEncodingName";
+APPKIT_DECLARE NSString *NSTextSizeMultiplierDocumentOption = @"TextSizeMultiplier";
+APPKIT_DECLARE NSString *NSTimeoutDocumentOption = @"Timeout";
+APPKIT_DECLARE NSString *NSWebPreferencesDocumentOption = @"WebPreferences";
+APPKIT_DECLARE NSString *NSWebResourceLoadDelegateDocumentOption = @"WebResourceLoadDelegate";
 
 // NSTextTab
-NSString *NSTabColumnTerminatorsAttributeName = @"NSTabColumnTerminatorsAttributeName"; 
+APPKIT_DECLARE NSString *NSTabColumnTerminatorsAttributeName = @"NSTabColumnTerminatorsAttributeName"; 
 
 // Private Exports
-NSString *NSMarkedClauseSegmentAttributeName =
-  @"NSMarkedClauseSegmentAttributeName";
-NSString *NSTextInputReplacementRangeAttributeName =
-  @"NSTextInputReplacementRangeAttributeName";
+APPKIT_DECLARE NSString *NSMarkedClauseSegmentAttributeName = @"NSMarkedClauseSegmentAttributeName";
+APPKIT_DECLARE NSString *NSTextInputReplacementRangeAttributeName = @"NSTextInputReplacementRangeAttributeName";
 
 // NSToolbar notifications
-NSString *NSToolbarDidRemoveItemNotification = @"NSToolbarDidRemoveItemNotification";
-NSString *NSToolbarWillAddItemNotification = @"NSToolbarWillAddItemNotification";
+APPKIT_DECLARE NSString *NSToolbarDidRemoveItemNotification = @"NSToolbarDidRemoveItemNotification";
+APPKIT_DECLARE NSString *NSToolbarWillAddItemNotification = @"NSToolbarWillAddItemNotification";
 
 // NSToolbarItem constants
-NSString *NSToolbarSeparatorItemIdentifier = @"NSToolbarSeparatorItem";
-NSString *NSToolbarSpaceItemIdentifier = @"NSToolbarSpaceItem";
-NSString *NSToolbarFlexibleSpaceItemIdentifier = @"NSToolbarFlexibleSpaceItem";
-NSString *NSToolbarShowColorsItemIdentifier = @"NSToolbarShowColorsItem";
-NSString *NSToolbarShowFontsItemIdentifier = @"NSToolbarShowFontsItem";
-NSString *NSToolbarCustomizeToolbarItemIdentifier = @"NSToolbarCustomizeToolbarItem";
-NSString *NSToolbarPrintItemIdentifier = @"NSToolbarPrintItem";
+APPKIT_DECLARE NSString *NSToolbarSeparatorItemIdentifier = @"NSToolbarSeparatorItem";
+APPKIT_DECLARE NSString *NSToolbarSpaceItemIdentifier = @"NSToolbarSpaceItem";
+APPKIT_DECLARE NSString *NSToolbarFlexibleSpaceItemIdentifier = @"NSToolbarFlexibleSpaceItem";
+APPKIT_DECLARE NSString *NSToolbarShowColorsItemIdentifier = @"NSToolbarShowColorsItem";
+APPKIT_DECLARE NSString *NSToolbarShowFontsItemIdentifier = @"NSToolbarShowFontsItem";
+APPKIT_DECLARE NSString *NSToolbarCustomizeToolbarItemIdentifier = @"NSToolbarCustomizeToolbarItem";
+APPKIT_DECLARE NSString *NSToolbarPrintItemIdentifier = @"NSToolbarPrintItem";
 
-NSString *NSImageNameTrashEmpty = @"NSImageTrashEmpty";
-NSString *NSImageNameTrashFull = @"NSImageTrashFull";
+APPKIT_DECLARE NSString *NSImageNameTrashEmpty = @"NSImageTrashEmpty";
+APPKIT_DECLARE NSString *NSImageNameTrashFull = @"NSImageTrashFull";
 
 // Misc named images
-NSString *NSImageNameMultipleDocuments = @"NSImageNameMultipleDocuments";
+APPKIT_DECLARE NSString *NSImageNameMultipleDocuments = @"NSImageNameMultipleDocuments";
 
 /*
  * NSTextView userInfo for notifications 
  */
-NSString *NSOldSelectedCharacterRange = @"NSOldSelectedCharacterRange";
+APPKIT_DECLARE NSString *NSOldSelectedCharacterRange = @"NSOldSelectedCharacterRange";
 
 /* NSFont matrix */
-const CGFloat NSFontIdentityMatrix[] = {1, 0, 0, 1, 0, 0};
+APPKIT_DECLARE const CGFloat NSFontIdentityMatrix[] = {1, 0, 0, 1, 0, 0};
 
 /* Drawing engine externs */
-NSString *NSBackendContext = @"NSBackendContext";
+APPKIT_DECLARE NSString *NSBackendContext = @"NSBackendContext";
 
 typedef int NSWindowDepth;
 
@@ -705,103 +642,103 @@ typedef int NSWindowDepth;
    to do the OR directly.  If you change the
    _GS*BitValue numbers, please remember to
    change the corresponding depth values */
-const NSWindowDepth _GSGrayBitValue = 256;
-const NSWindowDepth _GSRGBBitValue = 512;
-const NSWindowDepth _GSCMYKBitValue = 1024;
-const NSWindowDepth _GSNamedBitValue = 2048;
-const NSWindowDepth _GSCustomBitValue = 4096;
-const NSWindowDepth NSDefaultDepth = 0;            // GRAY = 256, RGB = 512
-const NSWindowDepth NSTwoBitGrayDepth = 258;       // 0100000010 GRAY | 2bps
-const NSWindowDepth NSEightBitGrayDepth = 264;     // 0100001000 GRAY | 8bps
-const NSWindowDepth NSEightBitRGBDepth = 514;      // 1000000010 RGB  | 2bps
-const NSWindowDepth NSTwelveBitRGBDepth = 516;     // 1000000100 RGB  | 4bps
-const NSWindowDepth GSSixteenBitRGBDepth = 517;    // 1000000101 RGB  | 5bps GNUstep specific
-const NSWindowDepth NSTwentyFourBitRGBDepth = 520; // 1000001000 RGB  | 8bps
-const NSWindowDepth _GSWindowDepths[7] = { 258, 264, 514, 516, 517, 520, 0 };
+APPKIT_DECLARE const NSWindowDepth _GSGrayBitValue = 256;
+APPKIT_DECLARE const NSWindowDepth _GSRGBBitValue = 512;
+APPKIT_DECLARE const NSWindowDepth _GSCMYKBitValue = 1024;
+APPKIT_DECLARE const NSWindowDepth _GSNamedBitValue = 2048;
+APPKIT_DECLARE const NSWindowDepth _GSCustomBitValue = 4096;
+APPKIT_DECLARE const NSWindowDepth NSDefaultDepth = 0;            // GRAY = 256, RGB = 512
+APPKIT_DECLARE const NSWindowDepth NSTwoBitGrayDepth = 258;       // 0100000010 GRAY | 2bps
+APPKIT_DECLARE const NSWindowDepth NSEightBitGrayDepth = 264;     // 0100001000 GRAY | 8bps
+APPKIT_DECLARE const NSWindowDepth NSEightBitRGBDepth = 514;      // 1000000010 RGB  | 2bps
+APPKIT_DECLARE const NSWindowDepth NSTwelveBitRGBDepth = 516;     // 1000000100 RGB  | 4bps
+APPKIT_DECLARE const NSWindowDepth GSSixteenBitRGBDepth = 517;    // 1000000101 RGB  | 5bps GNUstep specific
+APPKIT_DECLARE const NSWindowDepth NSTwentyFourBitRGBDepth = 520; // 1000001000 RGB  | 8bps
+APPKIT_DECLARE const NSWindowDepth _GSWindowDepths[7] = { 258, 264, 514, 516, 517, 520, 0 };
 
 /* End of color functions externs */
 
 // NSKeyValueBinding
-NSString *NSObservedObjectKey = @"NSObservedObject";
-NSString *NSObservedKeyPathKey = @"NSObservedKeyPath";
-NSString *NSOptionsKey = @"NSOptions";
+APPKIT_DECLARE NSString *NSObservedObjectKey = @"NSObservedObject";
+APPKIT_DECLARE NSString *NSObservedKeyPathKey = @"NSObservedKeyPath";
+APPKIT_DECLARE NSString *NSOptionsKey = @"NSOptions";
 
-NSString *NSAllowsEditingMultipleValuesSelectionBindingOption = @"NSAllowsEditingMultipleValuesSelection";
-NSString *NSAllowsNullArgumentBindingOption = @"NSAllowsNullArgument";
-NSString *NSConditionallySetsEditableBindingOption = @"NSConditionallySetsEditable";
-NSString *NSConditionallySetsEnabledBindingOption = @"NSConditionallySetsEnabled";
-NSString *NSConditionallySetsHiddenBindingOption = @"NSConditionallySetsHidden";
-NSString *NSContinuouslyUpdatesValueBindingOption = @"NSContinuouslyUpdatesValue";
-NSString *NSCreatesSortDescriptorBindingOption = @"NSCreatesSortDescriptor";
-NSString *NSDeletesObjectsOnRemoveBindingsOption = @"NSDeletesObjectsOnRemove";
-NSString *NSDisplayNameBindingOption = @"NSDisplayName";
-NSString *NSDisplayPatternBindingOption = @"NSDisplayPattern";
-NSString *NSHandlesContentAsCompoundValueBindingOption = @"NSHandlesContentAsCompoundValue";
-NSString *NSInsertsNullPlaceholderBindingOption = @"NSInsertsNullPlaceholder";
-NSString *NSInvokesSeparatelyWithArrayObjectsBindingOption = @"NSInvokesSeparatelyWithArrayObjects";
-NSString *NSMultipleValuesPlaceholderBindingOption = @"NSMultipleValuesPlaceholder";
-NSString *NSNoSelectionPlaceholderBindingOption = @"NSNoSelectionPlaceholder";
-NSString *NSNotApplicablePlaceholderBindingOption = @"NSNotApplicablePlaceholder";
-NSString *NSNullPlaceholderBindingOption = @"NSNullPlaceholder";
-NSString *NSPredicateFormatBindingOption = @"NSPredicateFormat";
-NSString *NSRaisesForNotApplicableKeysBindingOption = @"NSRaisesForNotApplicableKeys";
-NSString *NSSelectorNameBindingOption = @"NSSelectorName";
-NSString *NSSelectsAllWhenSettingContentBindingOption = @"NSSelectsAllWhenSettingContent";
-NSString *NSValidatesImmediatelyBindingOption = @"NSValidatesImmediately";
-NSString *NSValueTransformerNameBindingOption = @"NSValueTransformerName";
-NSString *NSValueTransformerBindingOption = @"NSValueTransformer";
+APPKIT_DECLARE NSString *NSAllowsEditingMultipleValuesSelectionBindingOption = @"NSAllowsEditingMultipleValuesSelection";
+APPKIT_DECLARE NSString *NSAllowsNullArgumentBindingOption = @"NSAllowsNullArgument";
+APPKIT_DECLARE NSString *NSConditionallySetsEditableBindingOption = @"NSConditionallySetsEditable";
+APPKIT_DECLARE NSString *NSConditionallySetsEnabledBindingOption = @"NSConditionallySetsEnabled";
+APPKIT_DECLARE NSString *NSConditionallySetsHiddenBindingOption = @"NSConditionallySetsHidden";
+APPKIT_DECLARE NSString *NSContinuouslyUpdatesValueBindingOption = @"NSContinuouslyUpdatesValue";
+APPKIT_DECLARE NSString *NSCreatesSortDescriptorBindingOption = @"NSCreatesSortDescriptor";
+APPKIT_DECLARE NSString *NSDeletesObjectsOnRemoveBindingsOption = @"NSDeletesObjectsOnRemove";
+APPKIT_DECLARE NSString *NSDisplayNameBindingOption = @"NSDisplayName";
+APPKIT_DECLARE NSString *NSDisplayPatternBindingOption = @"NSDisplayPattern";
+APPKIT_DECLARE NSString *NSHandlesContentAsCompoundValueBindingOption = @"NSHandlesContentAsCompoundValue";
+APPKIT_DECLARE NSString *NSInsertsNullPlaceholderBindingOption = @"NSInsertsNullPlaceholder";
+APPKIT_DECLARE NSString *NSInvokesSeparatelyWithArrayObjectsBindingOption = @"NSInvokesSeparatelyWithArrayObjects";
+APPKIT_DECLARE NSString *NSMultipleValuesPlaceholderBindingOption = @"NSMultipleValuesPlaceholder";
+APPKIT_DECLARE NSString *NSNoSelectionPlaceholderBindingOption = @"NSNoSelectionPlaceholder";
+APPKIT_DECLARE NSString *NSNotApplicablePlaceholderBindingOption = @"NSNotApplicablePlaceholder";
+APPKIT_DECLARE NSString *NSNullPlaceholderBindingOption = @"NSNullPlaceholder";
+APPKIT_DECLARE NSString *NSPredicateFormatBindingOption = @"NSPredicateFormat";
+APPKIT_DECLARE NSString *NSRaisesForNotApplicableKeysBindingOption = @"NSRaisesForNotApplicableKeys";
+APPKIT_DECLARE NSString *NSSelectorNameBindingOption = @"NSSelectorName";
+APPKIT_DECLARE NSString *NSSelectsAllWhenSettingContentBindingOption = @"NSSelectsAllWhenSettingContent";
+APPKIT_DECLARE NSString *NSValidatesImmediatelyBindingOption = @"NSValidatesImmediately";
+APPKIT_DECLARE NSString *NSValueTransformerNameBindingOption = @"NSValueTransformerName";
+APPKIT_DECLARE NSString *NSValueTransformerBindingOption = @"NSValueTransformer";
  
-NSString *NSAlignmentBinding = @"alignment";
-NSString *NSContentArrayBinding = @"contentArray";
-NSString *NSContentBinding = @"content";
-NSString *NSContentObjectBinding = @"contentObject";
-NSString *NSContentValuesBinding = @"contentValues";
-NSString *NSEditableBinding = @"editable";
-NSString *NSEnabledBinding = @"enabled";
-NSString *NSFontBinding = @"font";
-NSString *NSFontNameBinding = @"fontName";
-NSString *NSFontSizeBinding = @"fontSize";
-NSString *NSHiddenBinding = @"hidden";
-NSString *NSSelectedIndexBinding = @"selectedIndex";
-NSString *NSSelectedObjectBinding = @"selectedObject";
-NSString *NSSelectedTagBinding = @"selectedTag";
-NSString *NSSelectedValueBinding = @"selectedValue";
-NSString *NSSelectionIndexesBinding = @"selectionIndexes";
-NSString *NSSortDescriptorsBinding = @"sortDescriptors";
-NSString *NSTextColorBinding = @"textColor";
-NSString *NSTitleBinding = @"title";
-NSString *NSToolTipBinding = @"toolTip";
-NSString *NSValueBinding = @"value";
+APPKIT_DECLARE NSString *NSAlignmentBinding = @"alignment";
+APPKIT_DECLARE NSString *NSContentArrayBinding = @"contentArray";
+APPKIT_DECLARE NSString *NSContentBinding = @"content";
+APPKIT_DECLARE NSString *NSContentObjectBinding = @"contentObject";
+APPKIT_DECLARE NSString *NSContentValuesBinding = @"contentValues";
+APPKIT_DECLARE NSString *NSEditableBinding = @"editable";
+APPKIT_DECLARE NSString *NSEnabledBinding = @"enabled";
+APPKIT_DECLARE NSString *NSFontBinding = @"font";
+APPKIT_DECLARE NSString *NSFontNameBinding = @"fontName";
+APPKIT_DECLARE NSString *NSFontSizeBinding = @"fontSize";
+APPKIT_DECLARE NSString *NSHiddenBinding = @"hidden";
+APPKIT_DECLARE NSString *NSSelectedIndexBinding = @"selectedIndex";
+APPKIT_DECLARE NSString *NSSelectedObjectBinding = @"selectedObject";
+APPKIT_DECLARE NSString *NSSelectedTagBinding = @"selectedTag";
+APPKIT_DECLARE NSString *NSSelectedValueBinding = @"selectedValue";
+APPKIT_DECLARE NSString *NSSelectionIndexesBinding = @"selectionIndexes";
+APPKIT_DECLARE NSString *NSSortDescriptorsBinding = @"sortDescriptors";
+APPKIT_DECLARE NSString *NSTextColorBinding = @"textColor";
+APPKIT_DECLARE NSString *NSTitleBinding = @"title";
+APPKIT_DECLARE NSString *NSToolTipBinding = @"toolTip";
+APPKIT_DECLARE NSString *NSValueBinding = @"value";
 
 // FIXME: Need to define class _NSStateMarker!
-id NSMultipleValuesMarker = @"<MULTIPLE VALUES MARKER>";
-id NSNoSelectionMarker = @"<NO SELECTION MARKER>";
-id NSNotApplicableMarker = @"<NOT APPLICABLE MARKER>";
+APPKIT_DECLARE id NSMultipleValuesMarker = @"<MULTIPLE VALUES MARKER>";
+APPKIT_DECLARE id NSNoSelectionMarker = @"<NO SELECTION MARKER>";
+APPKIT_DECLARE id NSNotApplicableMarker = @"<NOT APPLICABLE MARKER>";
 
 
 // NSNib
-NSString *NSNibTopLevelObjects = @"NSTopLevelObjects";
-NSString *NSNibOwner = @"NSOwner";
+APPKIT_DECLARE NSString *NSNibTopLevelObjects = @"NSTopLevelObjects";
+APPKIT_DECLARE NSString *NSNibOwner = @"NSOwner";
 
 // NSImage directly mapped NS named images constants
-NSString *NSImageNameUserAccounts = @"NSUserAccounts";
-NSString *NSImageNamePreferencesGeneral = @"NSPreferencesGeneral";
-NSString *NSImageNameAdvanced = @"NSAdvanced";
-NSString *NSImageNameInfo = @"NSInfo";
-NSString *NSImageNameFontPanel = @"NSFontPanel";
-NSString *NSImageNameColorPanel = @"NSColorPanel";
-NSString *NSImageNameCaution = @"NSCaution";
+APPKIT_DECLARE NSString *NSImageNameUserAccounts = @"NSUserAccounts";
+APPKIT_DECLARE NSString *NSImageNamePreferencesGeneral = @"NSPreferencesGeneral";
+APPKIT_DECLARE NSString *NSImageNameAdvanced = @"NSAdvanced";
+APPKIT_DECLARE NSString *NSImageNameInfo = @"NSInfo";
+APPKIT_DECLARE NSString *NSImageNameFontPanel = @"NSFontPanel";
+APPKIT_DECLARE NSString *NSImageNameColorPanel = @"NSColorPanel";
+APPKIT_DECLARE NSString *NSImageNameCaution = @"NSCaution";
 
 // NSRuleEditor
-NSString *const NSRuleEditorPredicateLeftExpression = @"NSRuleEditorPredicateLeftExpression";
-NSString *const NSRuleEditorPredicateRightExpression = @"NSRuleEditorPredicateRightExpression";
-NSString *const NSRuleEditorPredicateComparisonModifier = @"NSRuleEditorPredicateComparisonModifier";
-NSString *const NSRuleEditorPredicateOptions = @"NSRuleEditorPredicateOptions";
-NSString *const NSRuleEditorPredicateOperatorType = @"NSRuleEditorPredicateOperatorType";
-NSString *const NSRuleEditorPredicateCustomSelector = @"NSRuleEditorPredicateCustomSelector";
-NSString *const NSRuleEditorPredicateCompoundType = @"NSRuleEditorPredicateCompoundType";
+APPKIT_DECLARE NSString *const NSRuleEditorPredicateLeftExpression = @"NSRuleEditorPredicateLeftExpression";
+APPKIT_DECLARE NSString *const NSRuleEditorPredicateRightExpression = @"NSRuleEditorPredicateRightExpression";
+APPKIT_DECLARE NSString *const NSRuleEditorPredicateComparisonModifier = @"NSRuleEditorPredicateComparisonModifier";
+APPKIT_DECLARE NSString *const NSRuleEditorPredicateOptions = @"NSRuleEditorPredicateOptions";
+APPKIT_DECLARE NSString *const NSRuleEditorPredicateOperatorType = @"NSRuleEditorPredicateOperatorType";
+APPKIT_DECLARE NSString *const NSRuleEditorPredicateCustomSelector = @"NSRuleEditorPredicateCustomSelector";
+APPKIT_DECLARE NSString *const NSRuleEditorPredicateCompoundType = @"NSRuleEditorPredicateCompoundType";
 
-NSString *NSRuleEditorRowsDidChangeNotification = @"NSRuleEditorRowsDidChangeNotification";
+APPKIT_DECLARE NSString *NSRuleEditorRowsDidChangeNotification = @"NSRuleEditorRowsDidChangeNotification";
 
 // NSAppearance
 const NSAppearanceName NSAppearanceNameAqua = @"NSAppearanceNameAqua";
@@ -810,39 +747,36 @@ const NSAppearanceName NSAppearanceNameVibrantLight = @"NSAppearanceNameVibrantL
 const NSAppearanceName NSAppearanceNameVibrantDark = @"NSAppearanceNameVibrantDark";
 const NSAppearanceName NSAppearanceNameAccessibilityHighContrastAqua = @"NSAppearanceNameAccessibilityHighContrastAqua";
 const NSAppearanceName NSAppearanceNameAccessibilityHighContrastDarkAqua = @"NSAppearanceNameAccessibilityHighContrastDarkAqua";
-const NSAppearanceName NSAppearanceNameAccessibilityHighContrastVibrantLight =
-  @"NSAppearanceNameAccessibilityHighContrastVibrantLight";
-const NSAppearanceName NSAppearanceNameAccessibilityHighContrastVibrantDark =
-  @"NSAppearanceNameAccessibilityHighContrastVibrantDark";
+const NSAppearanceName NSAppearanceNameAccessibilityHighContrastVibrantLight = @"NSAppearanceNameAccessibilityHighContrastVibrantLight";
+const NSAppearanceName NSAppearanceNameAccessibilityHighContrastVibrantDark = @"NSAppearanceNameAccessibilityHighContrastVibrantDark";
 const NSAppearanceName NSAppearanceNameLightContent = @"NSAppearanceNameLightContent";
 
 // Values for NSFontCollectionAction
-NSFontCollectionActionTypeKey const NSFontCollectionWasShown = @"NSFontCollectionWasShown";
-NSFontCollectionActionTypeKey const NSFontCollectionWasHidden = @"NSFontCollectionWasHidden";
-NSFontCollectionActionTypeKey const NSFontCollectionWasRenamed = @"NSFontCollectionWasRenamed";
+APPKIT_DECLARE NSFontCollectionActionTypeKey const NSFontCollectionWasShown = @"NSFontCollectionWasShown";
+APPKIT_DECLARE NSFontCollectionActionTypeKey const NSFontCollectionWasHidden = @"NSFontCollectionWasHidden";
+APPKIT_DECLARE NSFontCollectionActionTypeKey const NSFontCollectionWasRenamed = @"NSFontCollectionWasRenamed";
 
 // Standard named collections
-NSFontCollectionName const NSFontCollectionAllFonts = @"NSFontCollectionAllFonts";
-NSFontCollectionName const NSFontCollectionUser = @"NSFontCollectionUser";
-NSFontCollectionName const NSFontCollectionFavorites = @"NSFontCollectionFavorites";
-NSFontCollectionName const NSFontCollectionRecentlyUsed = @"NSFontCollectionRecentlyUsed";
+APPKIT_DECLARE NSFontCollectionName const NSFontCollectionAllFonts = @"NSFontCollectionAllFonts";
+APPKIT_DECLARE NSFontCollectionName const NSFontCollectionUser = @"NSFontCollectionUser";
+APPKIT_DECLARE NSFontCollectionName const NSFontCollectionFavorites = @"NSFontCollectionFavorites";
+APPKIT_DECLARE NSFontCollectionName const NSFontCollectionRecentlyUsed = @"NSFontCollectionRecentlyUsed";
 
 // Collections
-NSFontCollectionMatchingOptionKey const NSFontCollectionIncludeDisabledFontsOption = @"NSFontCollectionIncludeDisabledFontsOption";
-NSFontCollectionMatchingOptionKey const NSFontCollectionRemoveDuplicatesOption = @"NSFontCollectionRemoveDuplicatesOption";
-NSFontCollectionMatchingOptionKey const NSFontCollectionDisallowAutoActivationOption = @"NSFontCollectionDisallowAutoActivationOption";
+APPKIT_DECLARE NSFontCollectionMatchingOptionKey const NSFontCollectionIncludeDisabledFontsOption = @"NSFontCollectionIncludeDisabledFontsOption";
+APPKIT_DECLARE NSFontCollectionMatchingOptionKey const NSFontCollectionRemoveDuplicatesOption = @"NSFontCollectionRemoveDuplicatesOption";
+APPKIT_DECLARE NSFontCollectionMatchingOptionKey const NSFontCollectionDisallowAutoActivationOption = @"NSFontCollectionDisallowAutoActivationOption";
 
 // Speech recognition...
-const NSString *GSSpeechRecognizerDidRecognizeWordNotification = @"GSSpeechRecognizerDidRecognizeWordNotification"; 
+APPKIT_DECLARE const NSString *GSSpeechRecognizerDidRecognizeWordNotification = @"GSSpeechRecognizerDidRecognizeWordNotification"; 
 
 // NSTextInputContext notifications
-NSString *NSTextInputContextKeyboardSelectionDidChangeNotification =
-  @"NSTextInputContextKeyboardSelectionDidChangeNotification";
+APPKIT_DECLARE NSString *NSTextInputContextKeyboardSelectionDidChangeNotification = @"NSTextInputContextKeyboardSelectionDidChangeNotification";
 
-NSPasteboardTypeTextFinderOptionKey const NSTextFinderCaseInsensitiveKey = @"NSTextFinderCaseInsensitiveKey";
-NSPasteboardTypeTextFinderOptionKey const NSTextFinderMatchingTypeKey = @"NSTextFinderMatchingTypeKey";
+APPKIT_DECLARE NSPasteboardTypeTextFinderOptionKey const NSTextFinderCaseInsensitiveKey = @"NSTextFinderCaseInsensitiveKey";
+APPKIT_DECLARE NSPasteboardTypeTextFinderOptionKey const NSTextFinderMatchingTypeKey = @"NSTextFinderMatchingTypeKey";
 
-CGFloat const NSGridViewSizeForContent = 0.0;
+APPKIT_DECLARE CGFloat const NSGridViewSizeForContent = 0.0;
 
 extern void __objc_gui_force_linking (void);
 


### PR DESCRIPTION
This PR adds the defines needed to export the classes when building on Windows.   This is necessary to get the references to classes and externs when building under MSVC.