### PR TITLE
Partially implement the constraint based layout methods

### DIFF
--- a/Headers/AppKit/NSLayoutConstraint.h
+++ b/Headers/AppKit/NSLayoutConstraint.h
@@ -29,6 +29,8 @@
 #import <Foundation/NSGeometry.h>
 #import <Foundation/NSKeyedArchiver.h>
 #import <AppKit/NSLayoutAnchor.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSWindow.h>
 
 @class NSControl, NSView, NSAnimation, NSArray, NSMutableArray, NSDictionary;
 
@@ -103,6 +105,11 @@ enum {
 };
 typedef NSUInteger NSLayoutFormatOptions;
 
+typedef struct GSIntrinsicContentSizePriority {
+  NSLayoutPriority horizontal;
+  NSLayoutPriority vertical;
+} GSIntrinsicContentSizePriority;
+
 @interface NSLayoutConstraint : NSObject <NSCoding, NSCopying>
 {
   NSLayoutAnchor *_firstAnchor;
@@ -156,7 +163,45 @@ typedef NSUInteger NSLayoutFormatOptions;
 
 - (NSLayoutAnchor *) secondAnchor;
 
+-(void) setPriority: (NSLayoutPriority)priority;
+
+-(void)setConstant: (CGFloat)constant;
+
 - (NSLayoutPriority) priority;  
+
+@end
+
+@interface NSView (NSConstraintBasedLayoutLayering)
+
+@property (readonly) NSSize intrinsicContentSize;
+
+@property (readonly) CGFloat firstBaselineOffsetFromTop;
+
+@property (readonly) CGFloat baselineOffsetFromBottom;
+
+- (NSLayoutPriority)contentHuggingPriorityForOrientation:(NSLayoutConstraintOrientation)orientation;
+
+- (void)setContentHuggingPriority:(NSLayoutPriority)priority forOrientation:(NSLayoutConstraintOrientation)orientation;
+
+- (NSLayoutPriority)contentCompressionResistancePriorityForOrientation:(NSLayoutConstraintOrientation)orientation;
+
+- (void)setContentCompressionResistancePriority:(NSLayoutPriority)priority forOrientation:(NSLayoutConstraintOrientation)orientation;
+
+@end
+
+@interface NSWindow (NSConstraintBasedLayoutCoreMethods)
+
+- (void)layoutIfNeeded;
+
+@end
+
+@interface NSView (NSConstraintBasedLayoutCoreMethods)
+
+- (void)updateConstraints;
+
+-(void) updateConstraintsForSubtreeIfNeeded;
+
+@property BOOL needsUpdateConstraints;
 
 @end
 

--- a/Headers/AppKit/NSView.h
+++ b/Headers/AppKit/NSView.h
@@ -178,6 +178,8 @@ PACKAGE_SCOPE
   BOOL _is_hidden;
   BOOL _in_live_resize;
 
+  BOOL _needsLayout;
+
   NSUInteger _autoresizingMask;
   NSFocusRingType _focusRingType;
   NSRect _autoresizingFrameError;
@@ -637,6 +639,20 @@ PACKAGE_SCOPE
 - (NSUserInterfaceLayoutDirection) userInterfaceLayoutDirection;
 - (void) setUserInterfaceLayoutDirection: (NSUserInterfaceLayoutDirection)dir;
 #endif
+#endif
+
+/**
+Layout
+*/
+
+- (void)layoutSubtreeIfNeeded;
+- (void)layout;
+
+#if GS_HAS_DECLARED_PROPERTIES
+@property (nonatomic) BOOL needsLayout;
+#else
+-(BOOL)needsLayout;
+-(void)setNeedsLayout: (BOOL)needsLayout;
 #endif
 
 @end

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -630,6 +630,8 @@ GSSetDragTypes(NSView* obj, NSArray *types)
   //_previousKeyView = 0;
 
   _alphaValue = 1.0;
+
+  _needsLayout = YES;
   
   return self;
 }
@@ -5127,6 +5129,45 @@ static NSView* findByTag(NSView *view, NSInteger aTag, NSUInteger *level)
 {
   // FIXME: implement this
   return;
+}
+
+/**
+* Layout 
+*/
+
+- (void) layoutSubtreeIfNeeded
+{
+  [self updateConstraintsForSubtreeIfNeeded];
+  [self _layoutViewAndSubViews];
+}
+
+-(void) _layoutViewAndSubViews
+{
+  if (_needsLayout) {
+    [self layout];
+    _needsLayout = NO;
+  }
+  for (NSView *subView in [self subviews]) {
+    [subView _layoutViewAndSubViews];
+  }
+}
+
+-(void) setNeedsLayout: (BOOL)needsLayout 
+{
+  if (!needsLayout) {
+    return;
+  }
+  _needsLayout = needsLayout;
+}
+
+-(BOOL) needsLayout
+{
+  return _needsLayout;
+}
+
+- (void)layout
+{
+
 }
 
 @end


### PR DESCRIPTION
This PR implements part of the behavior for the constraint based layout methods. I wrote the code using information from the [High Performance Auto Layout talk](https://developer.apple.com/videos/play/wwdc2018/220/), documentation and what I observed in experiments with the Cocoa implementation. Also I have written a suite of tests which document the expected behaviour [here](https://github.com/BennyKJohnson/ConstraintBasedLayoutTests/blob/master/LayoutConstraintTestCase.m) but I wasn't sure if it was suitable to include them given XCTest is not used in the other tests for this repo.

I will be continuing my work on auto layout but I would like to get some early feedback on this.

Thank you