### PR TITLE
Fix click on TextAttachmentCells, where the left side was not respected.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2022-10-11 Riccardo Mottola <rm@gnu.org>
+
+	* Source/NSTextView.m
+	Fix click on TextAttachmentCells, where the left side was not respected.
+	This was because index was respecting fraction and thus loosing the
+	attachment when clicking on the right part, only for this case,
+	recalculate character index without respectFraction.
+
 2022-09-01 Gregory John Casamento <greg.casamento@gmail.com>
 
 	* Source/NSButtonCell.m: Move method to detect if button is a

--- a/Source/NSTextView.m
+++ b/Source/NSTextView.m
@@ -5554,12 +5554,18 @@ other than copy/paste or dragging. */
       if (granularity == NSSelectByCharacter)
 	{
 	  NSTextAttachment *attachment;
+	  NSInteger startIndexNoFraction;
+
+	  /* since we look for an attachment with by-character granularity,
+	     recalculate the index without resepecting fraction */
+	  startIndexNoFraction = [self _characterIndexForPoint: startPoint
+					       respectFraction: NO];
 
 	  /* Check if the click was on an attachment cell.  */
 	  attachment = [_textStorage attribute: NSAttachmentAttributeName
-				       atIndex: startIndex
+				       atIndex: startIndexNoFraction
 				effectiveRange: NULL];
-	      
+
 	  if (attachment != nil)
 	    {
 	      id <NSTextAttachmentCell> cell = [attachment attachmentCell];
@@ -5594,11 +5600,11 @@ other than copy/paste or dragging. */
 		  if ([cell wantsToTrackMouseForEvent: theEvent
 			inRect: cellFrame
 			ofView: self
-			atCharacterIndex: startIndex]
+			atCharacterIndex: startIndexNoFraction]
 		      && [cell trackMouse: theEvent
 				   inRect: cellFrame 
 				   ofView: self
-			 atCharacterIndex: startIndex
+			 atCharacterIndex: startIndexNoFraction
 			     untilMouseUp: NO])
 		    {
 		      return;


### PR DESCRIPTION
This was because index was respecting fraction and thus loosing the attachment when clicking on the right part, only for this case, recalculate character index without respectFraction.