### PR TITLE
Implement constraintsWithVisualFormat method on NSLayoutConstraint

### DIFF
--- a/Headers/AppKit/NSLayoutConstraint.h
+++ b/Headers/AppKit/NSLayoutConstraint.h
@@ -157,7 +157,12 @@ APPKIT_EXPORT_CLASS
 
 - (NSLayoutAnchor *) secondAnchor;
 
-- (NSLayoutPriority) priority;  
+#if GS_HAS_DECLARED_PROPERTIES
+@property NSLayoutPriority priority;
+#else
+- (NSLayoutPriority) priority;
+- (void) setPriority: (NSLayoutPriority)priority;
+#endif
 
 @end
 

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -349,7 +349,8 @@ GSXibLoader.m \
 GSXibLoading.m \
 GSXibKeyedUnarchiver.m \
 GSXib5KeyedUnarchiver.m \
-GSHelpAttachment.m 
+GSHelpAttachment.m \
+GSAutoLayoutVFLParser.m
 
 # Turn off NSMenuItem warning that NSMenuItem conforms to <NSObject>,
 # but does not implement <NSObject>'s methods itself (it inherits
@@ -658,7 +659,8 @@ GSWindowDecorationView.h \
 GSXibElement.h \
 GSXibLoading.h \
 GSXibKeyedUnarchiver.h \
-GSHelpAttachment.h
+GSHelpAttachment.h \
+GSAutoLayoutVFLParser.h
 
 libgnustep-gui_HEADER_FILES = ${GUI_HEADERS}
 

--- a/Source/GSAutoLayoutVFLParser.h
+++ b/Source/GSAutoLayoutVFLParser.h
@@ -1,22 +1,45 @@
+/* Copyright (C) 2022 Free Software Foundation, Inc.
+   
+   By: Benjamin Johnson
+   Date: 11-11-2022
+   This file is part of the GNUstep Library.
+   
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+   
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+   
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free
+   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110 USA.
+*/
+
 #import <AppKit/AppKit.h>
 
 @interface GSAutoLayoutVFLParser : NSObject
 {
- NSDictionary *_views;
- NSLayoutFormatOptions _options;
- NSDictionary *_metrics;
- NSScanner *_scanner;
- NSMutableArray *_constraints;
- NSMutableArray *_layoutFormatConstraints;  
- NSView *_view;
- BOOL _createLeadingConstraintToSuperview;
- BOOL _isVerticalOrientation;
+  NSDictionary *_views;
+  NSLayoutFormatOptions _options;
+  NSDictionary *_metrics;
+  NSScanner *_scanner;
+  NSMutableArray *_constraints;
+  NSMutableArray *_layoutFormatConstraints;
+  NSView *_view;
+  BOOL _createLeadingConstraintToSuperview;
+  BOOL _isVerticalOrientation;
 }
 
+- (instancetype) initWithFormat:(NSString *)format
+                        options:(NSLayoutFormatOptions)options
+                        metrics:(NSDictionary *)metrics
+                          views:(NSDictionary *)views;
 
--(instancetype)initWithFormat: (NSString*)format options: (NSLayoutFormatOptions)options metrics: (NSDictionary*)metrics views: (NSDictionary*)views;
-
--(NSArray*)parse;
+- (NSArray *) parse;
 
 @end
-

--- a/Source/GSAutoLayoutVFLParser.h
+++ b/Source/GSAutoLayoutVFLParser.h
@@ -1,0 +1,22 @@
+#import <AppKit/AppKit.h>
+
+@interface GSAutoLayoutVFLParser : NSObject
+{
+ NSDictionary *_views;
+ NSLayoutFormatOptions _options;
+ NSDictionary *_metrics;
+ NSScanner *_scanner;
+ NSMutableArray *_constraints;
+ NSMutableArray *_layoutFormatConstraints;  
+ NSView *_view;
+ BOOL _createLeadingConstraintToSuperview;
+ BOOL _isVerticalOrientation;
+}
+
+
+-(instancetype)initWithFormat: (NSString*)format options: (NSLayoutFormatOptions)options metrics: (NSDictionary*)metrics views: (NSDictionary*)views;
+
+-(NSArray*)parse;
+
+@end
+

--- a/Source/GSAutoLayoutVFLParser.h
+++ b/Source/GSAutoLayoutVFLParser.h
@@ -20,7 +20,9 @@
    Boston, MA 02110 USA.
 */
 
-#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+#import "AppKit/NSView.h"
+#import "AppKit/NSLayoutConstraint.h"
 
 @interface GSAutoLayoutVFLParser : NSObject
 {

--- a/Source/GSAutoLayoutVFLParser.m
+++ b/Source/GSAutoLayoutVFLParser.m
@@ -21,7 +21,6 @@
 */
 
 #import "GSAutoLayoutVFLParser.h"
-#import <AppKit/AppKit.h>
 
 struct GSObjectOfPredicate
 {
@@ -46,14 +45,14 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
     {
       if ([format length] == 0)
         {
-          [self failParseWithMessage:@"Cannot parse an empty string"];
+          [self failParseWithMessage: @"Cannot parse an empty string"];
         }
 
       _views = views;
       _metrics = metrics;
       _options = options;
 
-      _scanner = [NSScanner scannerWithString:format];
+      _scanner = [NSScanner scannerWithString: format];
       _constraints = [NSMutableArray array];
       _layoutFormatConstraints = [NSMutableArray array];
     }
@@ -72,27 +71,27 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
       NSArray *viewConstraints = [self parseView];
       if (_createLeadingConstraintToSuperview)
         {
-          [self addLeadingSuperviewConstraint:spacingConstant];
+          [self addLeadingSuperviewConstraint: spacingConstant];
           _createLeadingConstraintToSuperview = NO;
         }
 
       if (previousView != nil)
         {
-          [self addViewSpacingConstraint:spacingConstant
-                            previousView:previousView];
-          [self addFormattingConstraints:previousView];
+          [self addViewSpacingConstraint: spacingConstant
+                            previousView: previousView];
+          [self addFormattingConstraints: previousView];
         }
-      [_constraints addObjectsFromArray:viewConstraints];
+      [_constraints addObjectsFromArray: viewConstraints];
 
       spacingConstant = [self parseConnection];
-      if ([_scanner scanString:@"|" intoString:nil])
+      if ([_scanner scanString: @"|" intoString:nil])
         {
-          [self addTrailingToSuperviewConstraint:spacingConstant];
+          [self addTrailingToSuperviewConstraint: spacingConstant];
         }
       previousView = _view;
     }
 
-  [_constraints addObjectsFromArray:_layoutFormatConstraints];
+  [_constraints addObjectsFromArray: _layoutFormatConstraints];
 
   return _constraints;
 }
@@ -110,42 +109,42 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
   for (NSNumber *layoutAttribute in attributes)
     {
       NSLayoutConstraint *formatConstraint =
-          [NSLayoutConstraint constraintWithItem:lastView
-                                       attribute:[layoutAttribute integerValue]
-                                       relatedBy:NSLayoutRelationEqual
-                                          toItem:_view
-                                       attribute:[layoutAttribute integerValue]
-                                      multiplier:1.0
-                                        constant:0];
-      [_layoutFormatConstraints addObject:formatConstraint];
+          [NSLayoutConstraint constraintWithItem: lastView
+                                       attribute: [layoutAttribute integerValue]
+                                       relatedBy: NSLayoutRelationEqual
+                                          toItem: _view
+                                       attribute: [layoutAttribute integerValue]
+                                      multiplier: 1.0
+                                        constant: 0];
+      [_layoutFormatConstraints addObject: formatConstraint];
     }
 }
 
 - (void) assertHasValidFormatLayoutOptions
 {
   if (_isVerticalOrientation &&
-      [self isVerticalEdgeFormatLayoutOption:_options])
+      [self isVerticalEdgeFormatLayoutOption: _options])
     {
-      [self failParseWithMessage:@"A vertical alignment format option cannot "
+      [self failParseWithMessage: @"A vertical alignment format option cannot "
                                  @"be used with a vertical layout"];
     }
   else if (!_isVerticalOrientation
-           && ![self isVerticalEdgeFormatLayoutOption:_options])
+           && ![self isVerticalEdgeFormatLayoutOption: _options])
     {
-      [self failParseWithMessage:@"A horizontal alignment format option "
+      [self failParseWithMessage: @"A horizontal alignment format option "
                                  @"cannot be used with a horizontal layout"];
     }
 }
 
 - (void) parseOrientation
 {
-  if ([_scanner scanString:@"V:" intoString:nil])
+  if ([_scanner scanString: @"V:" intoString: nil])
     {
       _isVerticalOrientation = true;
     }
   else
     {
-      [_scanner scanString:@"H:" intoString:nil];
+      [_scanner scanString: @"H:" intoString: nil];
     }
 }
 
@@ -164,22 +163,22 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 {
   NSString *viewName = nil;
   NSCharacterSet *viewTerminators =
-      [NSCharacterSet characterSetWithCharactersInString:@"]("];
-  [_scanner scanUpToCharactersFromSet:viewTerminators intoString:&viewName];
+      [NSCharacterSet characterSetWithCharactersInString: @"]("];
+  [_scanner scanUpToCharactersFromSet: viewTerminators intoString: &viewName];
 
   if (viewName == nil)
     {
-      [self failParseWithMessage:@"Failed to parse view name"];
+      [self failParseWithMessage: @"Failed to parse view name"];
     }
 
-  if (![self isValidIdentifier:viewName])
+  if (![self isValidIdentifier: viewName])
     {
       [self failParseWithMessage:
                 @"Invalid view name. A view name must be a valid C identifier "
                 @"and may only contain letters, numbers and underscores"];
     }
 
-  return [self resolveViewWithIdentifier:viewName];
+  return [self resolveViewWithIdentifier: viewName];
 }
 
 - (BOOL) isVerticalEdgeFormatLayoutOption:(NSLayoutFormatOptions)options
@@ -250,15 +249,15 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
     }
 
   NSLayoutConstraint *viewSeparatorConstraint =
-      [NSLayoutConstraint constraintWithItem:firstItem
-                                   attribute:firstAttribute
-                                   relatedBy:NSLayoutRelationEqual
-                                      toItem:secondItem
-                                   attribute:secondAttribute
-                                  multiplier:1.0
-                                    constant:viewSpacingConstant];
+      [NSLayoutConstraint constraintWithItem: firstItem
+                                   attribute: firstAttribute
+                                   relatedBy: NSLayoutRelationEqual
+                                      toItem: secondItem
+                                   attribute: secondAttribute
+                                  multiplier: 1.0
+                                    constant: viewSpacingConstant];
 
-  [_constraints addObject:viewSeparatorConstraint];
+  [_constraints addObject: viewSeparatorConstraint];
 }
 
 - (void) addLeadingSuperviewConstraint:(NSNumber *)spacing
@@ -299,14 +298,14 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
       = spacing ? [spacing doubleValue] : GS_DEFAULT_SUPERVIEW_SPACING;
 
   NSLayoutConstraint *leadingConstraintToSuperview =
-      [NSLayoutConstraint constraintWithItem:firstItem
-                                   attribute:firstAttribute
-                                   relatedBy:NSLayoutRelationEqual
-                                      toItem:secondItem
-                                   attribute:firstAttribute
-                                  multiplier:1.0
-                                    constant:viewSpacingConstant];
-  [_constraints addObject:leadingConstraintToSuperview];
+      [NSLayoutConstraint constraintWithItem: firstItem
+                                   attribute: firstAttribute
+                                   relatedBy: NSLayoutRelationEqual
+                                      toItem: secondItem
+                                   attribute: firstAttribute
+                                  multiplier: 1.0
+                                    constant: viewSpacingConstant];
+  [_constraints addObject: leadingConstraintToSuperview];
 }
 
 - (void) addTrailingToSuperviewConstraint:(NSNumber *)spacing
@@ -346,19 +345,19 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
     }
 
   NSLayoutConstraint *trailingConstraintToSuperview =
-      [NSLayoutConstraint constraintWithItem:firstItem
-                                   attribute:attribute
-                                   relatedBy:NSLayoutRelationEqual
-                                      toItem:secondItem
-                                   attribute:attribute
-                                  multiplier:1.0
-                                    constant:viewSpacingConstant];
-  [_constraints addObject:trailingConstraintToSuperview];
+      [NSLayoutConstraint constraintWithItem: firstItem
+                                   attribute: attribute
+                                   relatedBy: NSLayoutRelationEqual
+                                      toItem: secondItem
+                                   attribute: attribute
+                                  multiplier: 1.0
+                                    constant: viewSpacingConstant];
+  [_constraints addObject: trailingConstraintToSuperview];
 }
 
 - (NSNumber *) parseLeadingSuperViewConnection
 {
-  BOOL foundSuperview = [_scanner scanString:@"|" intoString:nil];
+  BOOL foundSuperview = [_scanner scanString: @"|" intoString: nil];
   if (!foundSuperview)
     {
       return nil;
@@ -369,22 +368,22 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 
 - (NSNumber *) parseConnection
 {
-  BOOL foundConnection = [_scanner scanString:@"-" intoString:nil];
+  BOOL foundConnection = [_scanner scanString: @"-" intoString: nil];
   if (!foundConnection)
     {
-      return [NSNumber numberWithDouble:0];
+      return [NSNumber numberWithDouble: 0];
     }
 
   NSNumber *simplePredicateValue = [self parseSimplePredicate];
-  BOOL endConnectionFound = [_scanner scanString:@"-" intoString:nil];
+  BOOL endConnectionFound = [_scanner scanString: @"-" intoString: nil];
 
   if (simplePredicateValue != nil && !endConnectionFound)
     {
-      [self failParseWithMessage:@"A connection must end with a '-'"];
+      [self failParseWithMessage: @"A connection must end with a '-'"];
     }
   else if (simplePredicateValue == nil && endConnectionFound)
     {
-      [self failParseWithMessage:@"Found invalid connection"];
+      [self failParseWithMessage: @"Found invalid connection"];
     }
 
   return simplePredicateValue;
@@ -393,24 +392,24 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 - (NSNumber *) parseSimplePredicate
 {
   float constant;
-  BOOL scanConstantResult = [_scanner scanFloat:&constant];
+  BOOL scanConstantResult = [_scanner scanFloat: &constant];
   if (scanConstantResult)
     {
-      return [NSNumber numberWithDouble:constant];
+      return [NSNumber numberWithDouble: constant];
     }
   else
     {
       NSString *metricName = nil;
       NSCharacterSet *simplePredicateTerminatorsCharacterSet =
-          [NSCharacterSet characterSetWithCharactersInString:@"-[|"];
+          [NSCharacterSet characterSetWithCharactersInString: @"-[|"];
       BOOL didParseMetricName = [_scanner
-          scanUpToCharactersFromSet:simplePredicateTerminatorsCharacterSet
-                         intoString:&metricName];
+          scanUpToCharactersFromSet: simplePredicateTerminatorsCharacterSet
+                         intoString: &metricName];
       if (!didParseMetricName)
         {
           return nil;
         }
-      if (![self isValidIdentifier:metricName])
+      if (![self isValidIdentifier: metricName])
         {
           [self failParseWithMessage:
                     @"Invalid metric identifier. Metric identifiers must be a "
@@ -418,14 +417,14 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
                     @"numbers and underscores"];
         }
 
-      NSNumber *metric = [self resolveMetricWithIdentifier:metricName];
+      NSNumber *metric = [self resolveMetricWithIdentifier: metricName];
       return metric;
     }
 }
 
 - (NSArray *) parsePredicateList
 {
-  BOOL startsWithPredicateList = [_scanner scanString:@"(" intoString:nil];
+  BOOL startsWithPredicateList = [_scanner scanString: @"(" intoString:nil];
   if (!startsWithPredicateList)
     {
       return [NSArray array];
@@ -437,15 +436,15 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
     {
       GSObjectOfPredicate *predicate = [self parseObjectOfPredicate];
       [viewPredicateConstraints
-          addObject:[self createConstraintFromParsedPredicate:predicate]];
-      [self freeObjectOfPredicate:predicate];
+          addObject: [self createConstraintFromParsedPredicate: predicate]];
+      [self freeObjectOfPredicate: predicate];
 
-      shouldParsePredicate = [_scanner scanString:@"," intoString:nil];
+      shouldParsePredicate = [_scanner scanString: @"," intoString:nil];
     }
 
-  if (![_scanner scanString:@")" intoString:nil])
+  if (![_scanner scanString: @")" intoString: nil])
     {
-      [self failParseWithMessage:@"A predicate on a view must end with ')'"];
+      [self failParseWithMessage: @"A predicate on a view must end with ')'"];
     }
 
   return viewPredicateConstraints;
@@ -460,24 +459,24 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
                                     : NSLayoutAttributeWidth;
   if (predicate->view != nil)
     {
-      constraint = [NSLayoutConstraint constraintWithItem:_view
-                                                attribute:attribute
-                                                relatedBy:predicate->relation
-                                                   toItem:predicate->view
-                                                attribute:attribute
-                                               multiplier:1.0
-                                                 constant:predicate->constant];
+      constraint = [NSLayoutConstraint constraintWithItem: _view
+                                                attribute: attribute
+                                                relatedBy: predicate->relation
+                                                   toItem: predicate->view
+                                                attribute: attribute
+                                               multiplier: 1.0
+                                                 constant: predicate->constant];
     }
   else
     {
       constraint = [NSLayoutConstraint
-          constraintWithItem:_view
-                   attribute:attribute
-                   relatedBy:predicate->relation
-                      toItem:nil
-                   attribute:NSLayoutAttributeNotAnAttribute
-                  multiplier:1.0
-                    constant:predicate->constant];
+          constraintWithItem: _view
+                   attribute: attribute
+                   relatedBy: predicate->relation
+                      toItem: nil
+                   attribute: NSLayoutAttributeNotAnAttribute
+                  multiplier: 1.0
+                    constant: predicate->constant];
     }
 
   if (predicate->priority)
@@ -494,11 +493,11 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 
   CGFloat parsedConstant;
   NSView *predicatedView = nil;
-  BOOL scanConstantResult = [_scanner scanDouble:&parsedConstant];
+  BOOL scanConstantResult = [_scanner scanDouble: &parsedConstant];
   if (!scanConstantResult)
     {
       NSString *identiferName = [self parseIdentifier];
-      if (![self isValidIdentifier:identiferName])
+      if (![self isValidIdentifier: identiferName])
         {
           [self failParseWithMessage:
                     @"Invalid metric or view identifier. Metric/View "
@@ -506,15 +505,15 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
                     @"contain letters, numbers and underscores"];
         }
 
-      NSNumber *metric = [_metrics objectForKey:identiferName];
+      NSNumber *metric = [_metrics objectForKey: identiferName];
       if (metric != nil)
         {
           parsedConstant = [metric doubleValue];
         }
-      else if ([_views objectForKey:identiferName])
+      else if ([_views objectForKey: identiferName])
         {
           parsedConstant = 0;
-          predicatedView = [_views objectForKey:identiferName];
+          predicatedView = [_views objectForKey: identiferName];
         }
       else
         {
@@ -522,7 +521,7 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
               stringWithFormat:
                   @"Failed to find constant or metric for identifier '%@'",
                   identiferName];
-          [self failParseWithMessage:message];
+          [self failParseWithMessage: message];
         }
     }
 
@@ -539,15 +538,15 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 
 - (NSLayoutRelation) parseRelation
 {
-  if ([_scanner scanString:@"==" intoString:nil])
+  if ([_scanner scanString: @"==" intoString: nil])
     {
       return NSLayoutRelationEqual;
     }
-  else if ([_scanner scanString:@">=" intoString:nil])
+  else if ([_scanner scanString: @">=" intoString: nil])
     {
       return NSLayoutRelationGreaterThanOrEqual;
     }
-  else if ([_scanner scanString:@"<=" intoString:nil])
+  else if ([_scanner scanString: @"<=" intoString: nil])
     {
       return NSLayoutRelationLessThanOrEqual;
     }
@@ -560,10 +559,10 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 - (NSNumber *) parsePriority
 {
   NSCharacterSet *priorityMarkerCharacterSet =
-      [NSCharacterSet characterSetWithCharactersInString:@"@"];
+      [NSCharacterSet characterSetWithCharactersInString: @"@"];
   BOOL foundPriorityMarker =
-      [_scanner scanCharactersFromSet:priorityMarkerCharacterSet
-                           intoString:nil];
+      [_scanner scanCharactersFromSet: priorityMarkerCharacterSet
+                           intoString: nil];
   if (!foundPriorityMarker)
     {
       return nil;
@@ -574,20 +573,20 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 
 - (NSNumber *) resolveMetricWithIdentifier:(NSString *)identifier
 {
-  NSNumber *metric = [_metrics objectForKey:identifier];
+  NSNumber *metric = [_metrics objectForKey: identifier];
   if (metric == nil)
     {
-      [self failParseWithMessage:@"Found metric not inside metric dictionary"];
+      [self failParseWithMessage: @"Found metric not inside metric dictionary"];
     }
   return metric;
 }
 
 - (NSView *) resolveViewWithIdentifier:(NSString *)identifier
 {
-  NSView *view = [_views objectForKey:identifier];
+  NSView *view = [_views objectForKey: identifier];
   if (view == nil)
     {
-      [self failParseWithMessage:@"Found view not inside view dictionary"];
+      [self failParseWithMessage: @"Found view not inside view dictionary"];
     }
   return view;
 }
@@ -595,14 +594,14 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 - (NSNumber *) parseConstant
 {
   CGFloat constant;
-  BOOL scanConstantResult = [_scanner scanDouble:&constant];
+  BOOL scanConstantResult = [_scanner scanDouble: &constant];
   if (scanConstantResult)
     {
-      return [NSNumber numberWithFloat:constant];
+      return [NSNumber numberWithFloat: constant];
     }
 
   NSString *metricName = [self parseIdentifier];
-  if (![self isValidIdentifier:metricName])
+  if (![self isValidIdentifier: metricName])
     {
       [self failParseWithMessage:
                 @"Invalid metric identifier. Metric identifiers must be a "
@@ -610,20 +609,20 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
                 @"and underscores"];
     }
 
-  return [self resolveMetricWithIdentifier:metricName];
+  return [self resolveMetricWithIdentifier: metricName];
 }
 
 - (NSString *) parseIdentifier
 {
   NSString *identifierName = nil;
   NSCharacterSet *identifierTerminators =
-      [NSCharacterSet characterSetWithCharactersInString:@"),"];
+      [NSCharacterSet characterSetWithCharactersInString: @"),"];
   BOOL scannedIdentifier =
-      [_scanner scanUpToCharactersFromSet:identifierTerminators
-                               intoString:&identifierName];
+      [_scanner scanUpToCharactersFromSet: identifierTerminators
+                               intoString: &identifierName];
   if (!scannedIdentifier)
     {
-      [self failParseWithMessage:@"Failed to find constant or metric"];
+      [self failParseWithMessage: @"Failed to find constant or metric"];
     }
 
   return identifierName;
@@ -632,41 +631,41 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 - (void) parseViewOpen
 {
   NSCharacterSet *openViewIdentifier =
-      [NSCharacterSet characterSetWithCharactersInString:@"["];
-  BOOL scannedOpenBracket = [_scanner scanCharactersFromSet:openViewIdentifier
-                                                 intoString:nil];
+      [NSCharacterSet characterSetWithCharactersInString: @"["];
+  BOOL scannedOpenBracket = [_scanner scanCharactersFromSet: openViewIdentifier
+                                                 intoString: nil];
   if (!scannedOpenBracket)
     {
-      [[NSException exceptionWithName:NSInternalInconsistencyException
-                               reason:@"A view must start with a '['"
-                             userInfo:nil] raise];
+      [[NSException exceptionWithName: NSInternalInconsistencyException
+                               reason: @"A view must start with a '['"
+                             userInfo: nil] raise];
     }
 }
 
 - (void) parseViewClose
 {
   NSCharacterSet *closeViewIdentifier =
-      [NSCharacterSet characterSetWithCharactersInString:@"]"];
+      [NSCharacterSet characterSetWithCharactersInString: @"]"];
   BOOL scannedCloseBracket =
-      [_scanner scanCharactersFromSet:closeViewIdentifier intoString:nil];
+      [_scanner scanCharactersFromSet: closeViewIdentifier intoString: nil];
   if (!scannedCloseBracket)
     {
-      [[NSException exceptionWithName:NSInternalInconsistencyException
-                               reason:@"A view must end with a ']'"
-                             userInfo:nil] raise];
+      [[NSException exceptionWithName: NSInternalInconsistencyException
+                               reason: @"A view must end with a ']'"
+                             userInfo: nil] raise];
     }
 }
 
 - (BOOL) isValidIdentifier:(NSString *)identifer
 {
   NSRegularExpression *cIdentifierRegex = [NSRegularExpression
-      regularExpressionWithPattern:@"^[a-zA-Z_][a-zA-Z0-9_]*$"
-                           options:0
-                             error:nil];
+      regularExpressionWithPattern: @"^[a-zA-Z_][a-zA-Z0-9_]*$"
+                           options: 0
+                             error: nil];
   NSArray *matches =
-      [cIdentifierRegex matchesInString:identifer
-                                options:0
-                                  range:NSMakeRange (0, identifer.length)];
+      [cIdentifierRegex matchesInString: identifer
+                                options: 0
+                                  range: NSMakeRange (0, identifer.length)];
 
   return [matches count] > 0;
 }
@@ -679,52 +678,52 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
   if (options & NSLayoutFormatAlignAllLeft)
     {
       [attributes
-          addObject:[NSNumber numberWithInteger:NSLayoutAttributeLeft]];
+          addObject: [NSNumber numberWithInteger: NSLayoutAttributeLeft]];
     }
   if (options & NSLayoutFormatAlignAllRight)
     {
       [attributes
-          addObject:[NSNumber numberWithInteger:NSLayoutAttributeRight]];
+          addObject: [NSNumber numberWithInteger: NSLayoutAttributeRight]];
     }
   if (options & NSLayoutFormatAlignAllTop)
     {
-      [attributes addObject:[NSNumber numberWithInteger:NSLayoutAttributeTop]];
+      [attributes addObject: [NSNumber numberWithInteger: NSLayoutAttributeTop]];
     }
   if (options & NSLayoutFormatAlignAllBottom)
     {
       [attributes
-          addObject:[NSNumber numberWithInteger:NSLayoutAttributeBottom]];
+          addObject: [NSNumber numberWithInteger: NSLayoutAttributeBottom]];
     }
   if (options & NSLayoutFormatAlignAllLeading)
     {
       [attributes
-          addObject:[NSNumber numberWithInteger:NSLayoutAttributeLeading]];
+          addObject: [NSNumber numberWithInteger: NSLayoutAttributeLeading]];
     }
   if (options & NSLayoutFormatAlignAllTrailing)
     {
       [attributes
-          addObject:[NSNumber numberWithInteger:NSLayoutAttributeTrailing]];
+          addObject: [NSNumber numberWithInteger: NSLayoutAttributeTrailing]];
     }
   if (options & NSLayoutFormatAlignAllCenterX)
     {
       [attributes
-          addObject:[NSNumber numberWithInteger:NSLayoutAttributeCenterX]];
+          addObject: [NSNumber numberWithInteger: NSLayoutAttributeCenterX]];
     }
   if (options & NSLayoutFormatAlignAllCenterY)
     {
       [attributes
-          addObject:[NSNumber numberWithInteger:NSLayoutAttributeCenterY]];
+          addObject: [NSNumber numberWithInteger: NSLayoutAttributeCenterY]];
     }
   if (options & NSLayoutFormatAlignAllBaseline)
     {
       [attributes
-          addObject:[NSNumber numberWithInteger:NSLayoutAttributeBaseline]];
+          addObject: [NSNumber numberWithInteger: NSLayoutAttributeBaseline]];
     }
   if (options & NSLayoutFormatAlignAllFirstBaseline)
     {
       [attributes
-          addObject:[NSNumber
-                        numberWithInteger:NSLayoutAttributeFirstBaseline]];
+          addObject: [NSNumber
+                        numberWithInteger: NSLayoutAttributeFirstBaseline]];
     }
 
   if ([attributes count] == 0)

--- a/Source/GSAutoLayoutVFLParser.m
+++ b/Source/GSAutoLayoutVFLParser.m
@@ -1,0 +1,526 @@
+#import "GSAutoLayoutVFLParser.h"
+#import <AppKit/AppKit.h>
+
+struct GSObjectOfPredicate {
+    NSNumber *priority;
+    NSView *view;
+    NSLayoutRelation relation;
+    CGFloat constant;
+};
+typedef struct GSObjectOfPredicate GSObjectOfPredicate;
+
+NSInteger const GS_DEFAULT_VIEW_SPACING = 8;
+NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
+
+@implementation GSAutoLayoutVFLParser
+
+-(instancetype)initWithFormat: (NSString*)format options: (NSLayoutFormatOptions)options metrics: (NSDictionary*)metrics views: (NSDictionary*)views
+{
+    if (self = [super init]) {
+        if ([format length] == 0) {
+            [self failParseWithMessage:@"Cannot parse an empty string"];
+        }
+        
+        _views = views;
+        _metrics = metrics;
+        _options = options;
+        
+        _scanner = [NSScanner scannerWithString:format];
+        _constraints = [NSMutableArray array];
+        _layoutFormatConstraints = [NSMutableArray array];
+    }
+    
+    return self;
+}
+
+-(NSArray*)parse
+{
+    [self parseOrientation];
+    NSNumber *spacingConstant = [self parseLeadingSuperViewConnection];
+    NSView *previousView = nil;
+
+    while (![_scanner isAtEnd]) {
+        NSArray *viewConstraints = [self parseView];
+        if (_createLeadingConstraintToSuperview) {
+            [self addLeadingSuperviewConstraint: spacingConstant];
+            _createLeadingConstraintToSuperview = NO;
+        }
+             
+        if (previousView != nil) {
+            [self addViewSpacingConstraint:spacingConstant previousView:previousView];
+            [self addFormattingConstraints: previousView];
+        }
+        [_constraints addObjectsFromArray:viewConstraints];
+        
+        spacingConstant = [self parseConnection];
+        if ([_scanner scanString:@"|" intoString:nil]) {
+            [self addTrailingToSuperviewConstraint: spacingConstant];
+        }
+        previousView = _view;
+    }
+    
+    [_constraints addObjectsFromArray:_layoutFormatConstraints];
+        
+    return _constraints;
+}
+
+-(void)addFormattingConstraints: (NSView*)lastView
+{
+    BOOL hasFormatOptions = (_options & NSLayoutFormatAlignmentMask) > 0;
+    if (!hasFormatOptions) {
+         return;
+     }
+    [self assertHasValidFormatLayoutOptions];
+    
+    NSArray *attributes = [self layoutAttributesForLayoutFormatOptions:_options];
+    for (NSNumber *layoutAttribute in attributes) {
+        NSLayoutConstraint *formatConstraint = [NSLayoutConstraint constraintWithItem:lastView  attribute:[layoutAttribute integerValue] relatedBy:NSLayoutRelationEqual toItem:_view attribute:[layoutAttribute integerValue] multiplier:1.0 constant:0];
+        [_layoutFormatConstraints addObject:formatConstraint];
+    }
+}
+
+-(void)assertHasValidFormatLayoutOptions
+{
+    if (_isVerticalOrientation && [self isVerticalEdgeFormatLayoutOption: _options]) {
+        [self failParseWithMessage:@"A vertical alignment format option cannot be used with a vertical layout"];
+    } else if (!_isVerticalOrientation && ![self isVerticalEdgeFormatLayoutOption:_options]) {
+        [self failParseWithMessage:@"A horizontal alignment format option cannot be used with a horizontal layout"];
+    }
+}
+         
+-(void)parseOrientation
+{
+    if ([_scanner scanString:@"V:" intoString:nil]) {
+        _isVerticalOrientation = true;
+    } else {
+        [_scanner scanString:@"H:" intoString:nil];
+    }
+}
+
+-(NSArray*)parseView
+{
+    [self parseViewOpen];
+    
+    _view = [self parseViewName];
+    NSArray *viewConstraints = [self parsePredicateList];
+    [self parseViewClose];
+    
+    return viewConstraints;
+}
+
+-(NSView*)parseViewName
+{
+    NSString *viewName = nil;
+    NSCharacterSet *viewTerminators = [NSCharacterSet characterSetWithCharactersInString:@"]("];
+    [_scanner scanUpToCharactersFromSet:viewTerminators intoString:&viewName];
+        
+    if (viewName == nil) {
+        [self failParseWithMessage:@"Failed to parse view name"];
+    }
+    
+    if (![self isValidIdentifer:viewName]) {
+        [self failParseWithMessage:@"Invalid view name. A view name must be a valid C identifier and may only contain letters, numbers and underscores"];
+    }
+    
+    return [self resolveViewWithIdentifier:viewName];
+}
+
+-(BOOL)isVerticalEdgeFormatLayoutOption: (NSLayoutFormatOptions)options
+{
+    if (options & NSLayoutFormatAlignAllTop) {
+        return YES;
+    }
+    if (options & NSLayoutFormatAlignAllBaseline) {
+        return YES;
+    }
+    if (options & NSLayoutFormatAlignAllFirstBaseline) {
+        return YES;
+    }
+    if (options & NSLayoutFormatAlignAllBottom) {
+        return YES;
+    }
+    if (options & NSLayoutFormatAlignAllCenterY) {
+        return YES;
+    }
+    
+    return NO;
+}
+
+-(void)addViewSpacingConstraint: (NSNumber*)spacing previousView: (NSView*)previousView
+{
+    CGFloat viewSpacingConstant = spacing ? [spacing doubleValue] : GS_DEFAULT_VIEW_SPACING;
+    NSLayoutAttribute firstAttribute;
+    NSLayoutAttribute secondAttribute;
+    NSView *firstItem;
+    NSView *secondItem;
+    
+    NSLayoutFormatOptions directionOptions = _options & NSLayoutFormatDirectionMask;
+    if (_isVerticalOrientation) {
+        firstAttribute = NSLayoutAttributeTop;
+        secondAttribute = NSLayoutAttributeBottom;
+        firstItem = _view;
+        secondItem = previousView;
+    } else if (directionOptions & NSLayoutFormatDirectionRightToLeft) {
+        firstAttribute = NSLayoutAttributeLeft;
+        secondAttribute = NSLayoutAttributeRight;
+        firstItem = previousView;
+        secondItem = _view;
+    } else if (directionOptions & NSLayoutFormatDirectionLeftToRight) {
+        firstAttribute = NSLayoutAttributeLeft;
+         secondAttribute = NSLayoutAttributeRight;
+         firstItem = _view;
+         secondItem = previousView;
+    } else {
+        firstAttribute = NSLayoutAttributeLeading;
+        secondAttribute = NSLayoutAttributeTrailing;
+        firstItem = _view;
+        secondItem = previousView;
+    }
+    
+    NSLayoutConstraint *viewSeparatorConstraint = [NSLayoutConstraint constraintWithItem:firstItem attribute:firstAttribute relatedBy:NSLayoutRelationEqual toItem:secondItem attribute:secondAttribute multiplier:1.0 constant:viewSpacingConstant];
+
+    [_constraints addObject:viewSeparatorConstraint];
+}
+
+-(void)addLeadingSuperviewConstraint: (NSNumber*)spacing
+{
+    NSLayoutAttribute firstAttribute;
+    NSView *firstItem;
+    NSView *secondItem;
+
+    NSLayoutFormatOptions directionOptions = _options & NSLayoutFormatDirectionMask;
+    if (_isVerticalOrientation) {
+        firstAttribute = NSLayoutAttributeTop;
+        firstItem = _view;
+        secondItem = _view.superview;
+    } else if (directionOptions & NSLayoutFormatDirectionRightToLeft) {
+        firstAttribute = NSLayoutAttributeRight;
+        firstItem = _view.superview;
+        secondItem = _view;
+    } else if (directionOptions & NSLayoutFormatDirectionLeftToRight) {
+        firstAttribute = NSLayoutAttributeLeft;
+        firstItem = _view;
+        secondItem = _view.superview;
+    } else {
+        firstAttribute = _isVerticalOrientation ? NSLayoutAttributeTop : NSLayoutAttributeLeading;
+        firstItem = _view;
+        secondItem = _view.superview;
+    }
+    
+    CGFloat viewSpacingConstant = spacing ? [spacing doubleValue] : GS_DEFAULT_SUPERVIEW_SPACING;
+
+    NSLayoutConstraint *leadingConstraintToSuperview = [NSLayoutConstraint constraintWithItem:firstItem attribute:firstAttribute relatedBy:NSLayoutRelationEqual toItem:secondItem attribute:firstAttribute multiplier:1.0 constant:viewSpacingConstant];
+    [_constraints addObject:leadingConstraintToSuperview];
+}
+
+-(void)addTrailingToSuperviewConstraint: (NSNumber*)spacing
+{
+    CGFloat viewSpacingConstant = spacing ? [spacing doubleValue] : GS_DEFAULT_SUPERVIEW_SPACING;
+    
+    NSLayoutFormatOptions directionOptions = _options & NSLayoutFormatDirectionMask;
+    NSLayoutAttribute attribute;
+    NSView *firstItem;
+    NSView *secondItem;
+    
+    if (_isVerticalOrientation) {
+        attribute = NSLayoutAttributeBottom;
+        firstItem = _view.superview;
+        secondItem = _view;
+    } else if (directionOptions & NSLayoutFormatDirectionRightToLeft) {
+        attribute = NSLayoutAttributeLeft;
+        firstItem = _view;
+        secondItem = _view.superview;
+    } else if (directionOptions & NSLayoutFormatDirectionLeftToRight) {
+        attribute = NSLayoutAttributeRight;
+        firstItem =  _view.superview;
+        secondItem = _view;
+    } else {
+        attribute = NSLayoutAttributeTrailing;
+        firstItem = _view.superview;
+        secondItem = _view;
+    }
+    
+    NSLayoutConstraint *trailingConstraintToSuperview = [NSLayoutConstraint constraintWithItem: firstItem  attribute:attribute relatedBy:NSLayoutRelationEqual toItem: secondItem attribute:attribute multiplier:1.0 constant:viewSpacingConstant];
+    [_constraints addObject:trailingConstraintToSuperview];
+}
+
+-(NSNumber*)parseLeadingSuperViewConnection
+{
+    BOOL foundSuperview = [_scanner scanString:@"|" intoString:nil];
+    if (!foundSuperview) {
+        return nil;
+    }
+    _createLeadingConstraintToSuperview = YES;
+    return [self parseConnection];
+}
+
+-(NSNumber*)parseConnection
+{
+    BOOL foundConnection = [_scanner scanString:@"-" intoString:nil];
+    if (!foundConnection) {
+        return [NSNumber numberWithDouble:0];
+    }
+
+    NSNumber *simplePredicateValue = [self parseSimplePredicate];
+    BOOL endConnectionFound = [_scanner scanString:@"-" intoString:nil];
+
+    if (simplePredicateValue != nil && !endConnectionFound) {
+        [self failParseWithMessage:@"A connection must end with a '-'"];
+    } else if (simplePredicateValue == nil && endConnectionFound) {
+        [self failParseWithMessage:@"Found invalid connection"];
+    }
+
+    return simplePredicateValue;
+}
+
+-(NSNumber*)parseSimplePredicate
+{
+    float constant;
+    BOOL scanConstantResult = [_scanner scanFloat:&constant];
+    if (scanConstantResult) {
+        return [NSNumber numberWithDouble:constant];
+    } else {
+        NSString *metricName = nil;
+        NSCharacterSet *simplePredicateTerminatorsCharacterSet = [NSCharacterSet characterSetWithCharactersInString:@"-[|"];
+        BOOL didParseMetricName = [_scanner scanUpToCharactersFromSet:simplePredicateTerminatorsCharacterSet intoString:&metricName];
+        if (!didParseMetricName) {
+            return nil;
+        }
+        if (![self isValidIdentifer:metricName]) {
+            [self failParseWithMessage:@"Invalid metric identifier. Metric identifiers must be a valid C identifier and may only contain letters, numbers and underscores"];
+        }
+        
+        NSNumber *metric = [self resolveMetricWithIdentifier:metricName];
+        return metric;
+    }
+}
+
+-(NSArray*)parsePredicateList
+{
+    BOOL startsWithPredicateList = [_scanner scanString:@"(" intoString:nil];
+    if (!startsWithPredicateList) {
+        return [NSArray array];
+    }
+        
+    NSMutableArray *viewPredicateConstraints = [NSMutableArray array];
+    BOOL shouldParsePredicate = YES;
+    while (shouldParsePredicate) {
+        GSObjectOfPredicate *predicate = [self parseObjectOfPredicate];
+        [viewPredicateConstraints addObject:[self createConstraintFromParsedPredicate:predicate]];
+        [self freeObjectOfPredicate:predicate];
+        
+        shouldParsePredicate = [_scanner scanString:@"," intoString:nil];
+    }
+    
+    if (![_scanner scanString:@")" intoString:nil]) {
+        [self failParseWithMessage:@"A predicate on a view must end with ')'"];
+    }
+    
+    return viewPredicateConstraints;
+}
+
+-(NSLayoutConstraint*)createConstraintFromParsedPredicate: (GSObjectOfPredicate*)predicate
+{
+    NSLayoutConstraint *constraint = nil;
+    NSLayoutAttribute attribute = _isVerticalOrientation ? NSLayoutAttributeHeight : NSLayoutAttributeWidth;
+    if (predicate->view != nil) {
+        constraint = [NSLayoutConstraint constraintWithItem:_view attribute:attribute relatedBy:predicate->relation toItem:predicate->view attribute:attribute multiplier:1.0 constant:predicate->constant];
+    } else {
+        constraint = [NSLayoutConstraint constraintWithItem:_view attribute:attribute relatedBy:predicate->relation toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:predicate->constant];
+    }
+
+     if (predicate->priority) {
+         constraint.priority = [predicate->priority doubleValue];
+     }
+    
+    return constraint;
+}
+
+-(GSObjectOfPredicate*)parseObjectOfPredicate
+{
+    NSLayoutRelation relation = [self parseRelation];
+    
+    CGFloat parsedConstant;
+    NSView *predicatedView = nil;
+    BOOL scanConstantResult = [_scanner scanDouble:&parsedConstant];
+    if (!scanConstantResult) {
+        NSString *identiferName = [self parseIdentifier];
+        if (![self isValidIdentifer:identiferName]) {
+            [self failParseWithMessage:@"Invalid metric or view identifier. Metric/View identifiers must be a valid C identifier and may only contain letters, numbers and underscores"];
+        }
+        
+        NSNumber *metric = [_metrics objectForKey:identiferName];
+        if (metric != nil) {
+            parsedConstant = [metric doubleValue];
+        } else if ([_views objectForKey:identiferName]) {
+            parsedConstant = 0;
+            predicatedView = [_views objectForKey:identiferName];
+        } else {
+            NSString *message = [NSString stringWithFormat:@"Failed to find constant or metric for identifier '%@'", identiferName];
+            [self failParseWithMessage:message];
+        }
+    }
+    
+    NSNumber *priorityValue = [self parsePriority];
+
+    GSObjectOfPredicate *predicate = calloc(1, sizeof(GSObjectOfPredicate));
+    predicate->priority = priorityValue;
+    predicate->relation = relation;
+    predicate->constant = parsedConstant;
+    predicate->view = predicatedView;
+    
+    return predicate;
+}
+
+-(NSLayoutRelation)parseRelation
+{
+    if ([_scanner scanString:@"==" intoString:nil]) {
+        return NSLayoutRelationEqual;
+    } else if ([_scanner scanString:@">=" intoString:nil]) {
+        return NSLayoutRelationGreaterThanOrEqual;
+    } else if ([_scanner scanString:@"<=" intoString:nil]) {
+        return NSLayoutRelationLessThanOrEqual;
+    } else {
+        return NSLayoutRelationEqual;
+    }
+}
+
+-(NSNumber*)parsePriority
+{
+    NSCharacterSet *priorityMarkerCharacterSet = [NSCharacterSet characterSetWithCharactersInString:@"@"];
+    BOOL foundPriorityMarker = [_scanner scanCharactersFromSet:priorityMarkerCharacterSet intoString:nil];
+    if (!foundPriorityMarker) {
+        return nil;
+    }
+    
+    return [self parseConstant];
+}
+
+-(NSNumber*)resolveMetricWithIdentifier: (NSString*)identifier
+{
+    NSNumber *metric = [_metrics objectForKey:identifier];
+    if (metric == nil) {
+        [self failParseWithMessage:@"Found metric not inside metric dictionary"];
+    }
+    return metric;
+}
+
+-(NSView*)resolveViewWithIdentifier: (NSString*)identifier
+{
+    NSView *view = [_views objectForKey:identifier];
+    if (view == nil) {
+        [self failParseWithMessage:@"Found view not inside view dictionary"];
+    }
+    return view;
+}
+
+-(NSNumber*)parseConstant
+{
+    CGFloat constant;
+    BOOL scanConstantResult = [_scanner scanDouble:&constant];
+    if (scanConstantResult) {
+        return [NSNumber numberWithFloat:constant];
+    }
+    
+    NSString *metricName = [self parseIdentifier];
+    if (![self isValidIdentifer:metricName]) {
+        [self failParseWithMessage:@"Invalid metric identifier. Metric identifiers must be a valid C identifier and may only contain letters, numbers and underscores"];
+    }
+    
+    return [self resolveMetricWithIdentifier:metricName];
+}
+
+-(NSString*)parseIdentifier
+{
+    NSString *identifierName = nil;
+    NSCharacterSet *identifierTerminators = [NSCharacterSet characterSetWithCharactersInString:@"),"];
+    BOOL scannedIdentifier = [_scanner scanUpToCharactersFromSet:identifierTerminators intoString:&identifierName];
+    if (!scannedIdentifier) {
+        [self failParseWithMessage:@"Failed to find constant or metric"];
+    }
+    
+    return identifierName;
+}
+
+-(void)parseViewOpen
+{
+    NSCharacterSet *openViewIdentifier = [NSCharacterSet characterSetWithCharactersInString:@"["];
+     BOOL scannedOpenBracket = [_scanner scanCharactersFromSet:openViewIdentifier intoString:nil];
+     if (!scannedOpenBracket) {
+         [[NSException exceptionWithName:NSInternalInconsistencyException reason:@"A view must start with a '['" userInfo:nil] raise];
+     }
+}
+
+-(void)parseViewClose
+{
+    NSCharacterSet *closeViewIdentifier = [NSCharacterSet characterSetWithCharactersInString:@"]"];
+    BOOL scannedCloseBracket = [_scanner scanCharactersFromSet:closeViewIdentifier intoString:nil];
+    if (!scannedCloseBracket) {
+        [[NSException exceptionWithName:NSInternalInconsistencyException reason:@"A view must end with a ']'" userInfo:nil] raise];
+    }
+}
+
+-(BOOL)isValidIdentifer: (NSString*)identifer
+{
+    NSRegularExpression *cIdentifierRegex = [NSRegularExpression regularExpressionWithPattern:@"^[a-zA-Z_][a-zA-Z0-9_]*$" options:0 error:nil];
+    NSArray *matches = [cIdentifierRegex matchesInString:identifer options:0 range:NSMakeRange(0, identifer.length)];
+    
+    return [matches count] > 0;
+}
+
+-(NSArray*)layoutAttributesForLayoutFormatOptions: (NSLayoutFormatOptions)options {
+    NSMutableArray *attributes = [NSMutableArray array];
+    
+    if (options & NSLayoutFormatAlignAllLeft) {
+        [attributes addObject:[NSNumber numberWithInteger:NSLayoutAttributeLeft]];
+    }
+    if (options & NSLayoutFormatAlignAllRight) {
+        [attributes addObject:[NSNumber numberWithInteger:NSLayoutAttributeRight]];
+    }
+    if (options & NSLayoutFormatAlignAllTop) {
+        [attributes addObject:[NSNumber numberWithInteger:NSLayoutAttributeTop]];
+    }
+    if (options & NSLayoutFormatAlignAllBottom) {
+        [attributes addObject:[NSNumber numberWithInteger:NSLayoutAttributeBottom]];
+    }
+    if (options & NSLayoutFormatAlignAllLeading) {
+        [attributes addObject:[NSNumber numberWithInteger:NSLayoutAttributeLeading]];
+    }
+    if (options & NSLayoutFormatAlignAllTrailing) {
+        [attributes addObject:[NSNumber numberWithInteger:NSLayoutAttributeTrailing]];
+    }
+    if (options & NSLayoutFormatAlignAllCenterX) {
+        [attributes addObject:[NSNumber numberWithInteger:NSLayoutAttributeCenterX]];
+    }
+    if (options & NSLayoutFormatAlignAllCenterY) {
+        [attributes addObject:[NSNumber numberWithInteger:NSLayoutAttributeCenterY]];
+    }
+    if (options & NSLayoutFormatAlignAllBaseline) {
+        [attributes addObject:[NSNumber numberWithInteger:NSLayoutAttributeBaseline]];
+    }
+    if (options & NSLayoutFormatAlignAllFirstBaseline) {
+        [attributes addObject:[NSNumber numberWithInteger:NSLayoutAttributeFirstBaseline]];
+    }
+    
+    if ([attributes count] == 0) {
+        [self failParseWithMessage:@"Unrecognized layout formatting option"];
+    }
+    
+    return attributes;
+}
+
+-(void)failParseWithMessage: (NSString*)parseErrorMessage
+{
+    NSException *parseException = [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"Unable to parse constraint format: %@", parseErrorMessage] userInfo:nil];
+    [parseException raise];
+}
+
+
+-(void)freeObjectOfPredicate: (GSObjectOfPredicate*)predicate
+{
+    predicate->view = nil;
+    predicate->priority = nil;
+    free(predicate);
+}
+
+@end

--- a/Source/GSAutoLayoutVFLParser.m
+++ b/Source/GSAutoLayoutVFLParser.m
@@ -35,6 +35,67 @@ typedef struct GSObjectOfPredicate GSObjectOfPredicate;
 NSInteger const GS_DEFAULT_VIEW_SPACING = 8;
 NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 
+@interface GSAutoLayoutVFLParser (PrivateMethods)
+
+- (void) parseOrientation;
+
+- (NSArray *) parseView;
+
+- (NSView *) parseViewName;
+
+- (void) addFormattingConstraints:(NSView *)lastView;
+
+- (BOOL) isVerticalEdgeFormatLayoutOption:(NSLayoutFormatOptions)options;
+
+- (void) assertHasValidFormatLayoutOptions;
+
+- (void) addLeadingSuperviewConstraint:(NSNumber *)spacing;
+
+- (void) addViewSpacingConstraint:(NSNumber *)spacing
+                     previousView:(NSView *)previousView;
+
+- (void) addLeadingSuperviewConstraint:(NSNumber *)spacing;
+
+- (void) addTrailingToSuperviewConstraint:(NSNumber *)spacing;
+
+- (NSNumber *) parseLeadingSuperViewConnection;
+
+- (NSNumber *) parseConnection;
+
+- (NSNumber *) parseSimplePredicate;
+
+- (NSArray *) parsePredicateList;
+
+- (NSLayoutConstraint *) createConstraintFromParsedPredicate:
+    (GSObjectOfPredicate *)predicate;
+
+- (void) parseObjectOfPredicate: (GSObjectOfPredicate *)predicate;
+
+- (NSLayoutRelation) parseRelation;
+
+- (NSNumber *) parsePriority;
+
+- (NSNumber *) resolveMetricWithIdentifier:(NSString *)identifier;
+
+- (NSView *) resolveViewWithIdentifier:(NSString *)identifier;
+
+- (NSNumber *) parseConstant;
+
+- (NSString *) parseIdentifier;
+
+- (void) parseViewOpen;
+
+- (void) parseViewClose;
+
+- (BOOL) isValidIdentifier:(NSString *)identifer;
+
+- (NSArray *) layoutAttributesForLayoutFormatOptions:
+    (NSLayoutFormatOptions)options;
+
+- (void) failParseWithMessage:(NSString *)parseErrorMessage;
+
+@end
+
 @implementation GSAutoLayoutVFLParser
 
 - (instancetype) initWithFormat:(NSString *)format
@@ -42,7 +103,8 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
                        metrics:(NSDictionary *)metrics
                          views:(NSDictionary *)views
 {
-  if (self = [super init])
+  self = [super init];
+  if (self != nil)
     {
       _views = views;
       _metrics = metrics;
@@ -85,7 +147,7 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
       [_constraints addObjectsFromArray: viewConstraints];
 
       spacingConstant = [self parseConnection];
-      if ([_scanner scanString: @"|" intoString: nil])
+      if ([_scanner scanString: @"|" intoString: NULL])
         {
           [self addTrailingToSuperviewConstraint: spacingConstant];
         }
@@ -138,13 +200,13 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 
 - (void) parseOrientation
 {
-  if ([_scanner scanString: @"V:" intoString: nil])
+  if ([_scanner scanString: @"V:" intoString: NULL])
     {
       _isVerticalOrientation = true;
     }
   else
     {
-      [_scanner scanString: @"H:" intoString: nil];
+      [_scanner scanString: @"H:" intoString: NULL];
     }
 }
 
@@ -357,7 +419,7 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 
 - (NSNumber *) parseLeadingSuperViewConnection
 {
-  BOOL foundSuperview = [_scanner scanString: @"|" intoString: nil];
+  BOOL foundSuperview = [_scanner scanString: @"|" intoString: NULL];
   if (!foundSuperview)
     {
       return nil;
@@ -368,14 +430,14 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 
 - (NSNumber *) parseConnection
 {
-  BOOL foundConnection = [_scanner scanString: @"-" intoString: nil];
+  BOOL foundConnection = [_scanner scanString: @"-" intoString: NULL];
   if (!foundConnection)
     {
       return [NSNumber numberWithDouble: 0];
     }
 
   NSNumber *simplePredicateValue = [self parseSimplePredicate];
-  BOOL endConnectionFound = [_scanner scanString: @"-" intoString: nil];
+  BOOL endConnectionFound = [_scanner scanString: @"-" intoString: NULL];
 
   if (simplePredicateValue != nil && !endConnectionFound)
     {
@@ -423,7 +485,7 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 
 - (NSArray *) parsePredicateList
 {
-  BOOL startsWithPredicateList = [_scanner scanString: @"(" intoString: nil];
+  BOOL startsWithPredicateList = [_scanner scanString: @"(" intoString: NULL];
   if (!startsWithPredicateList)
     {
       return [NSArray array];
@@ -438,10 +500,10 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
       [viewPredicateConstraints
           addObject: [self createConstraintFromParsedPredicate: &predicate]];
 
-      shouldParsePredicate = [_scanner scanString: @"," intoString: nil];
+      shouldParsePredicate = [_scanner scanString: @"," intoString: NULL];
     }
 
-  if (![_scanner scanString: @")" intoString: nil])
+  if (![_scanner scanString: @")" intoString: NULL])
     {
       [self failParseWithMessage: @"A predicate on a view must end with ')'"];
     }
@@ -534,15 +596,15 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
 
 - (NSLayoutRelation) parseRelation
 {
-  if ([_scanner scanString: @"==" intoString: nil])
+  if ([_scanner scanString: @"==" intoString: NULL])
     {
       return NSLayoutRelationEqual;
     }
-  else if ([_scanner scanString: @">=" intoString: nil])
+  else if ([_scanner scanString: @">=" intoString: NULL])
     {
       return NSLayoutRelationGreaterThanOrEqual;
     }
-  else if ([_scanner scanString: @"<=" intoString: nil])
+  else if ([_scanner scanString: @"<=" intoString: NULL])
     {
       return NSLayoutRelationLessThanOrEqual;
     }
@@ -558,7 +620,7 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
       [NSCharacterSet characterSetWithCharactersInString: @"@"];
   BOOL foundPriorityMarker =
       [_scanner scanCharactersFromSet: priorityMarkerCharacterSet
-                           intoString: nil];
+                           intoString: NULL];
   if (!foundPriorityMarker)
     {
       return nil;
@@ -629,7 +691,7 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
   NSCharacterSet *openViewIdentifier =
       [NSCharacterSet characterSetWithCharactersInString: @"["];
   BOOL scannedOpenBracket = [_scanner scanCharactersFromSet: openViewIdentifier
-                                                 intoString: nil];
+                                                 intoString: NULL];
   if (!scannedOpenBracket)
     {
       [[NSException exceptionWithName: NSInternalInconsistencyException
@@ -643,7 +705,7 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
   NSCharacterSet *closeViewIdentifier =
       [NSCharacterSet characterSetWithCharactersInString: @"]"];
   BOOL scannedCloseBracket =
-      [_scanner scanCharactersFromSet: closeViewIdentifier intoString: nil];
+      [_scanner scanCharactersFromSet: closeViewIdentifier intoString: NULL];
   if (!scannedCloseBracket)
     {
       [[NSException exceptionWithName: NSInternalInconsistencyException
@@ -657,7 +719,7 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
   NSRegularExpression *cIdentifierRegex = [NSRegularExpression
       regularExpressionWithPattern: @"^[a-zA-Z_][a-zA-Z0-9_]*$"
                            options: 0
-                             error: nil];
+                             error: NULL];
   NSArray *matches =
       [cIdentifierRegex matchesInString: identifer
                                 options: 0

--- a/Source/NSLayoutConstraint.m
+++ b/Source/NSLayoutConstraint.m
@@ -32,6 +32,7 @@
 #import "AppKit/NSLayoutConstraint.h"
 #import "AppKit/NSWindow.h"
 #import "AppKit/NSApplication.h"
+#import "GSAutoLayoutVFLParser.h"
 
 static NSMutableArray *activeConstraints = nil;
 // static NSNotificationCenter *nc = nil;
@@ -236,8 +237,16 @@ static NSMutableArray *activeConstraints = nil;
                                   metrics: (NSDictionary *)metrics 
                                     views: (NSDictionary *)views
 {
-  NSMutableArray *array = [NSMutableArray arrayWithCapacity: 10];
-  return array;
+  GSAutoLayoutVFLParser *parser = [[GSAutoLayoutVFLParser alloc]
+    initWithFormat: fmt
+    options: opt
+    metrics: metrics
+    views: views];
+  NSArray *constraints = [parser parse];
+
+  [parser release];
+
+  return constraints;
 }
 
 - (instancetype) initWithItem: (id)firstItem 

--- a/Source/NSLayoutConstraint.m
+++ b/Source/NSLayoutConstraint.m
@@ -244,7 +244,7 @@ static NSMutableArray *activeConstraints = nil;
     views: views];
   NSArray *constraints = [parser parse];
 
-  [parser release];
+  RELEASE(parser);
 
   return constraints;
 }


### PR DESCRIPTION
This PR implements [constraintsWithVisualFormat](https://developer.apple.com/documentation/uikit/nslayoutconstraint/1526944-constraintswithvisualformat). I chose to place all the functionality in an auxiliary class due to its complexity. To the best of my knowledge it implements all the behaviour of the original implementation. My test suite which I developed alongside the code is located [here](https://github.com/BennyKJohnson/GSAutoLayoutVFLParser), this can be used as a guide to its expected behaviour, all the tests pass on both MacOS and Ubuntu with GNUStep.  I would be happy to contribute the test suite as well if there was motivation to support XCTest for this project. 

Let me know if I need to make any adjustments in terms of style etc @fredkiefer.

Thank you 

<img width="1405" alt="Screen Shot 2022-11-05 at 8 59 35 pm" src="https://user-images.githubusercontent.com/7237725/200114259-4b207ab8-efb5-421a-9e48-ac97ec5eb53e.png">

