### PR TITLE
Open on side away from the edge of the screen if there is not enough room

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-01-03 Gregory John Casamento <greg.casamento@gmail.com>
+
+	* Source/NSDrawer.m: Open drawer on the opposite edge if needed when
+	close to the boundary of the screen.
+
 2022-12-29 Richard Frith-Macdonald <rfm@gnu.org>
 
         * ChangeLog: Update for new release

--- a/Source/NSDrawer.m
+++ b/Source/NSDrawer.m
@@ -139,9 +139,9 @@ static NSNotificationCenter *nc = nil;
     }
 
   self = [super initWithContentRect: contentRect
-		styleMask: aStyle
-		backing: bufferingType
-		defer: flag];
+			  styleMask: aStyle
+			    backing: bufferingType
+			      defer: flag];
 
   if (self != nil)
     {
@@ -547,40 +547,41 @@ static NSNotificationCenter *nc = nil;
 
 - (id) initWithContentSize: (NSSize)contentSize 
 	     preferredEdge: (NSRectEdge)edge
-{
+{  
   self = [super init];
 
-  if (self == nil)
-    return nil;
-  
-  // initialize the drawer window...
-  _drawerWindow =  [[GSDrawerWindow alloc] 
-		     initWithContentRect: NSMakeRect(0, 0, contentSize.width,  
-						     contentSize.height)
-		     styleMask: 0
-		     backing: NSBackingStoreBuffered
-		     defer: NO];
-  [_drawerWindow setDrawer: self];
-  [_drawerWindow setReleasedWhenClosed: NO];
-
-  _preferredEdge = edge;
-  _currentEdge = edge;
-  _maxContentSize = NSMakeSize(200,200);
-  _minContentSize = contentSize;
-
-  // for side drawers, top of drawer is immediately below the title bar
-  if (edge == NSMinXEdge || edge == NSMaxXEdge)
+  if (self != nil)
     {
-      _leadingOffset = 0.0;
-      _trailingOffset = 10.0;
-    }
-  else
-    { 
-      _leadingOffset = 10.0;
-      _trailingOffset = 10.0;
-    }
-  _state = NSDrawerClosedState;
+        NSRect rect = NSMakeRect(0, 0, contentSize.width, contentSize.height);
 
+	// initialize the drawer window...  
+	_drawerWindow =  [[GSDrawerWindow alloc] 
+			     initWithContentRect: rect
+				       styleMask: 0
+					 backing: NSBackingStoreBuffered
+					   defer: NO];
+	[_drawerWindow setDrawer: self];
+	[_drawerWindow setReleasedWhenClosed: NO];
+	
+	_preferredEdge = edge;
+	_currentEdge = edge;
+	_maxContentSize = NSMakeSize(200,200);
+	_minContentSize = contentSize;
+	
+	// for side drawers, top of drawer is immediately below the title bar
+	if (edge == NSMinXEdge || edge == NSMaxXEdge)
+	  {
+	    _leadingOffset = 0.0;
+	    _trailingOffset = 10.0;
+	  }
+	else
+	  { 
+	    _leadingOffset = 10.0;
+	    _trailingOffset = 10.0;
+	  }
+	_state = NSDrawerClosedState;
+    }
+  
   return self;
 }
 
@@ -601,38 +602,45 @@ static NSNotificationCenter *nc = nil;
   NSRectEdge result = _preferredEdge;
   NSRect windowFrame = [[self parentWindow] frame];
   NSRect screenRect = [[NSScreen mainScreen] frame];
-
+  NSSize contentSize = [self contentSize];
+  
   // Diffs,,,
   CGFloat top = screenRect.size.height - (windowFrame.origin.y + windowFrame.size.height);
   CGFloat bottom = windowFrame.origin.y;
   CGFloat right = screenRect.size.width - (windowFrame.origin.x + windowFrame.size.width);
   CGFloat left = windowFrame.origin.x;
+
+  // Space left...
+  CGFloat topSpace = top - contentSize.height;
+  CGFloat bottomSpace = bottom - contentSize.height;
+  CGFloat rightSpace = right - contentSize.width;
+  CGFloat leftSpace = left - contentSize.width;
   
   switch (_preferredEdge)
     {
     case NSMinXEdge:
-      if (right > left)
+      if (leftSpace < 0.0 && rightSpace > leftSpace)
 	{
 	  result = NSMaxXEdge;
 	}
       break;
       
     case NSMinYEdge:
-      if (top > bottom)
+      if (bottomSpace < 0.0 && topSpace > bottomSpace)
 	{
 	  result = NSMaxYEdge;
 	}
       break;
       
     case NSMaxXEdge:
-      if (left > right)
+      if (rightSpace < 0.0 && leftSpace > rightSpace)
 	{
 	  result = NSMinXEdge;
 	}
       break;
       
     case NSMaxYEdge:
-      if (bottom > top)
+      if (topSpace < 0.0 && bottomSpace > topSpace)
 	{
 	  result = NSMinYEdge;
 	}
@@ -655,7 +663,7 @@ static NSNotificationCenter *nc = nil;
   _state = NSDrawerClosingState;
   [nc postNotificationName: NSDrawerWillCloseNotification object: self];
 
-   [_drawerWindow closeOnEdge];
+  [_drawerWindow closeOnEdge];
 
   _state = NSDrawerClosedState;
   [nc postNotificationName: NSDrawerDidCloseNotification object: self];

--- a/Source/NSDrawer.m
+++ b/Source/NSDrawer.m
@@ -348,9 +348,9 @@ static NSNotificationCenter *nc = nil;
 {
   NSUInteger count = 10;
   NSRect frame = [self frameFromParentWindowFrameInState:
-			    (opening?NSDrawerClosedState:NSDrawerOpenState)];
+			    (opening ? NSDrawerClosedState : NSDrawerOpenState)];
   NSRect newFrame = [self frameFromParentWindowFrameInState:
-				 (opening?NSDrawerOpenState:NSDrawerClosedState)];
+			       (opening ? NSDrawerOpenState : NSDrawerClosedState)];
   NSTimeInterval slideDelay = 0.03;
   NSDate *nextStop = [NSDate dateWithTimeIntervalSinceNow:slideDelay];
   CGFloat deltaX = (newFrame.origin.x - frame.origin.x) / count;

--- a/Source/NSDrawer.m
+++ b/Source/NSDrawer.m
@@ -162,14 +162,14 @@ static NSNotificationCenter *nc = nil;
 {
   NSRect newFrame = [_parentWindow frame];
   CGFloat totalOffset = [_drawer leadingOffset] + [_drawer trailingOffset];
-  NSRectEdge edge = _currentEdge; // [_drawer preferredEdge];
+  // NSRectEdge edge = _currentEdge;
   BOOL opened = (state == NSDrawerOpenState || state == NSDrawerOpeningState);
   NSSize size = [_parentWindow frame].size;
   NSRect windowContentRect = [[_parentWindow contentView] frame];
   CGFloat windowHeightWithoutTitleBar = windowContentRect.origin.y + windowContentRect.size.height;
   // FIXME: This should probably add the toolbar height too, if the window has a toolbar
   
-  if (edge == NSMinXEdge) // left
+  if (_currentEdge == NSMinXEdge) // left
     {
       if (opened)
         newFrame.size.width = [_drawer minContentSize].width + _borderSize.width;
@@ -181,7 +181,7 @@ static NSNotificationCenter *nc = nil;
       if (opened)
         newFrame.origin.x -= newFrame.size.width;
     }
-  else if (edge == NSMinYEdge) // bottom
+  else if (_currentEdge == NSMinYEdge) // bottom
     {
       if (opened)
         newFrame.size.height = [_drawer minContentSize].height + _borderSize.height;
@@ -193,7 +193,7 @@ static NSNotificationCenter *nc = nil;
       if (opened)
         newFrame.origin.y -= newFrame.size.height;
     }
-  else if (edge == NSMaxXEdge) // right
+  else if (_currentEdge == NSMaxXEdge) // right
     {
       if (opened)
         newFrame.size.width = [_drawer minContentSize].width + _borderSize.width;
@@ -206,7 +206,7 @@ static NSNotificationCenter *nc = nil;
       if (!opened)
         newFrame.origin.x -= newFrame.size.width;
     }
-  else if (edge == NSMaxYEdge) // top
+  else if (_currentEdge == NSMaxYEdge) // top
     {
       if (opened)
         newFrame.size.height = [_drawer minContentSize].height + _borderSize.height;
@@ -269,22 +269,21 @@ static NSNotificationCenter *nc = nil;
 // and attach it to the appropriate edge instead
 - (void) lockBorderBoxForSliding
 {
-  NSRectEdge edge = [_drawer preferredEdge];
   NSUInteger resizeMask = 0;
 
-  if (edge == NSMinXEdge) // left
+  if (_currentEdge == NSMinXEdge) // left
     {
       resizeMask = NSViewMaxXMargin;
     }
-  else if (edge == NSMinYEdge) // bottom
+  else if (_currentEdge == NSMinYEdge) // bottom
     {
       resizeMask = NSViewMaxYMargin;
     }
-  else if (edge == NSMaxXEdge) // right
+  else if (_currentEdge == NSMaxXEdge) // right
     {
       resizeMask = NSViewMinXMargin;
     }
-  else if (edge == NSMaxYEdge) // top
+  else if (_currentEdge == NSMaxYEdge) // top
     {
       resizeMask = NSViewMinYMargin;
     }  
@@ -304,6 +303,7 @@ static NSNotificationCenter *nc = nil;
 {
   NSRect frame = [self frameFromParentWindowFrameInState:NSDrawerOpenState];
 
+  _currentEdge = edge;
   [self setFrame:frame display: YES]; // make sure it's the full (open) size before locking the borderBox
   if ([_parentWindow isVisible]) // don't order front until parent window is visible
     {

--- a/Source/NSDrawer.m
+++ b/Source/NSDrawer.m
@@ -104,9 +104,8 @@ static NSNotificationCenter *nc = nil;
   NSRect rect = contentRect;
   NSSize containerContentSize;
 
-  rect.origin.x += 2.0;
+  rect.origin.x += 1.0;
   rect.origin.y -= 5.0;
-  
   if (_container == nil)
     {
       _container = [[NSBox alloc] initWithFrame: rect];

--- a/Source/NSDrawer.m
+++ b/Source/NSDrawer.m
@@ -601,32 +601,38 @@ static NSNotificationCenter *nc = nil;
   NSRectEdge result = _preferredEdge;
   NSRect windowFrame = [[self parentWindow] frame];
   NSRect screenRect = [[NSScreen mainScreen] frame];
+
+  // Diffs,,,
+  CGFloat top = screenRect.size.height - (windowFrame.origin.y + windowFrame.size.height);
+  CGFloat bottom = windowFrame.origin.y;
+  CGFloat right = screenRect.size.width - (windowFrame.origin.x + windowFrame.size.width);
+  CGFloat left = windowFrame.origin.x;
   
   switch (_preferredEdge)
     {
     case NSMinXEdge:
-      if (windowFrame.origin.x < _maxContentSize.width)
+      if (right > left)
 	{
 	  result = NSMaxXEdge;
 	}
       break;
       
     case NSMinYEdge:
-      if (windowFrame.origin.y < _maxContentSize.height)
+      if (top > bottom)
 	{
 	  result = NSMaxYEdge;
 	}
       break;
       
     case NSMaxXEdge:
-      if (windowFrame.origin.x + windowFrame.size.width > screenRect.size.width)
+      if (left > right)
 	{
 	  result = NSMinXEdge;
 	}
       break;
       
     case NSMaxYEdge:
-      if (windowFrame.origin.y + windowFrame.size.height > screenRect.size.height)
+      if (bottom > top)
 	{
 	  result = NSMinYEdge;
 	}

--- a/Source/NSDrawer.m
+++ b/Source/NSDrawer.m
@@ -99,6 +99,36 @@ static NSNotificationCenter *nc = nil;
     }
 }
 
+- (void) _configureContainer: (NSRect)contentRect
+{
+  NSRect rect = contentRect;
+  NSSize containerContentSize;
+
+  rect.origin.x += 2.0;
+  rect.origin.y -= 5.0;
+  
+  if (_container == nil)
+    {
+      _container = [[NSBox alloc] initWithFrame: rect];
+      [[super contentView] addSubview: _container];
+
+      [_container setTitle: @""];
+      [_container setTitlePosition: NSNoTitle];
+      [_container setBorderType: NSBezelBorder];
+      [_container setAutoresizingMask: NSViewWidthSizable | NSViewHeightSizable];
+      [_container setContentViewMargins: NSMakeSize(2,2)];  
+    }
+  else
+    {
+      [_container setFrame: rect];
+    }
+
+  // determine the difference between the container's content size and the window content size
+  containerContentSize = [[_container contentView] frame].size;
+  _borderSize = NSMakeSize(contentRect.size.width - containerContentSize.width,
+			   contentRect.size.height - containerContentSize.height);
+}
+
 - (id) initWithContentRect: (NSRect)contentRect
 		 styleMask: (NSUInteger)aStyle
 		   backing: (NSBackingStoreType)bufferingType
@@ -113,43 +143,12 @@ static NSNotificationCenter *nc = nil;
 		styleMask: aStyle
 		backing: bufferingType
 		defer: flag];
+
   if (self != nil)
     {
-      NSRect rect = contentRect;
-      NSRect border = contentRect;
-      NSSize containerContentSize;
-
-      rect.origin.x += 6;
-      rect.origin.y += 6;
-      rect.size.width -= 16;
-      rect.size.height -= 16;
-
-      border.origin.x += 1;
-      border.origin.y += 1;
-      border.size.width -= 2;
-      border.size.height -= 2;
-
-      _borderBox = [[NSBox alloc] initWithFrame: border];
-      [_borderBox setTitle: @""];
-      [_borderBox setTitlePosition: NSNoTitle];
-      [_borderBox setBorderType: NSLineBorder];
-      [_borderBox setAutoresizingMask: NSViewWidthSizable | NSViewHeightSizable];
-      [_borderBox setContentViewMargins: NSMakeSize(0,0)];
-      [[super contentView] addSubview: _borderBox];      
-      
-      _container = [[NSBox alloc] initWithFrame: rect];
-      [_container setTitle: @""];
-      [_container setTitlePosition: NSNoTitle];
-      [_container setBorderType: NSBezelBorder];
-      [_container setAutoresizingMask: NSViewWidthSizable | NSViewHeightSizable];
-      [_container setContentViewMargins: NSMakeSize(2,2)];
-      [_borderBox addSubview: _container]; 
-
-      // determine the difference between the container's content size and the window content size
-      containerContentSize = [[_container contentView] frame].size;
-      _borderSize = NSMakeSize(contentRect.size.width - containerContentSize.width,
-				contentRect.size.height - containerContentSize.height);
+      [self _configureContainer: contentRect];
     }
+  
   return self;
 }
 
@@ -162,13 +161,13 @@ static NSNotificationCenter *nc = nil;
 {
   NSRect newFrame = [_parentWindow frame];
   CGFloat totalOffset = [_drawer leadingOffset] + [_drawer trailingOffset];
-  // NSRectEdge edge = _currentEdge;
   BOOL opened = (state == NSDrawerOpenState || state == NSDrawerOpeningState);
   NSSize size = [_parentWindow frame].size;
   NSRect windowContentRect = [[_parentWindow contentView] frame];
   CGFloat windowHeightWithoutTitleBar = windowContentRect.origin.y + windowContentRect.size.height;
+
   // FIXME: This should probably add the toolbar height too, if the window has a toolbar
-  
+  [self _configureContainer: windowContentRect];
   if (_currentEdge == NSMinXEdge) // left
     {
       if (opened)
@@ -621,14 +620,14 @@ static NSNotificationCenter *nc = nil;
       break;
       
     case NSMaxXEdge:
-      if (windowFrame.origin.x + windowFrame.size.height > screenRect.size.height)
+      if (windowFrame.origin.x + windowFrame.size.width > screenRect.size.width)
 	{
 	  result = NSMinXEdge;
 	}
       break;
       
     case NSMaxYEdge:
-      if (windowFrame.origin.y + windowFrame.size.width > screenRect.size.width)
+      if (windowFrame.origin.y + windowFrame.size.height > screenRect.size.height)
 	{
 	  result = NSMinYEdge;
 	}


### PR DESCRIPTION
Fixes issue 54715 on savannah, detailed [here](https://savannah.gnu.org/bugs/?54715).  In summary, if a window with a drawer attached is near a screen boundary, then the preferredEdge is overridden to the edge that will open ON the screen.