### PR TITLE
Implement supporting core layout methods on NSView

### DIFF
--- a/Headers/AppKit/NSLayoutConstraint.h
+++ b/Headers/AppKit/NSLayoutConstraint.h
@@ -167,29 +167,11 @@ APPKIT_EXPORT_CLASS
 
 @end
 
-@interface NSView (NSConstraintBasedCompatibility)
-
-#if GS_HAS_DECLARED_PROPERTIES
-@property BOOL translatesAutoresizingMaskIntoConstraints;
-#else
-- (BOOL) translatesAutoresizingMaskIntoConstraints;
-- (void) setTranslatesAutoresizingMaskIntoConstraints: (BOOL)translatesAutoresizingMaskIntoConstraints;
-#endif
-
-@end
-
 @interface NSView (NSConstraintBasedLayoutCoreMethods)
 
 - (void) updateConstraints;
 
 - (void) updateConstraintsForSubtreeIfNeeded;
-
-#if GS_HAS_DECLARED_PROPERTIES
-@property BOOL needsUpdateConstraints;
-#else
-- (BOOL) needsUpdateConstraints;
-- (void) setNeedsUpdateConstraints: (BOOL)needsUpdateConstraints;
-#endif
 
 @end
 

--- a/Headers/AppKit/NSLayoutConstraint.h
+++ b/Headers/AppKit/NSLayoutConstraint.h
@@ -29,8 +29,9 @@
 #import <Foundation/NSGeometry.h>
 #import <Foundation/NSKeyedArchiver.h>
 #import <AppKit/NSLayoutAnchor.h>
+#import <AppKit/NSView.h>
 
-@class NSControl, NSView, NSAnimation, NSArray, NSMutableArray, NSDictionary;
+@class NSControl, NSAnimation, NSArray, NSMutableArray, NSDictionary;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
 
@@ -163,6 +164,40 @@ APPKIT_EXPORT_CLASS
 - (NSLayoutPriority) priority;
 - (void) setPriority: (NSLayoutPriority)priority;
 #endif
+
+@end
+
+@interface NSView (NSConstraintBasedCompatibility)
+
+#if GS_HAS_DECLARED_PROPERTIES
+@property BOOL translatesAutoresizingMaskIntoConstraints;
+#else
+- (BOOL) translatesAutoresizingMaskIntoConstraints;
+- (void) setTranslatesAutoresizingMaskIntoConstraints: (BOOL)translatesAutoresizingMaskIntoConstraints;
+#endif
+
+@end
+
+@interface NSView (NSConstraintBasedLayoutCoreMethods)
+
+- (void) updateConstraints;
+
+- (void) updateConstraintsForSubtreeIfNeeded;
+
+#if GS_HAS_DECLARED_PROPERTIES
+@property BOOL needsUpdateConstraints;
+#else
+- (BOOL) needsUpdateConstraints;
+- (void) setNeedsUpdateConstraints: (BOOL)needsUpdateConstraints;
+#endif
+
+@end
+
+@interface NSView (NSConstraintBasedLayoutInstallingConstraints)
+
+- (void) addConstraint: (NSLayoutConstraint *)constraint;
+
+- (void) addConstraints: (NSArray*)constraints;
 
 @end
 

--- a/Headers/AppKit/NSView.h
+++ b/Headers/AppKit/NSView.h
@@ -179,6 +179,7 @@ PACKAGE_SCOPE
   BOOL _renew_gstate;
   BOOL _is_hidden;
   BOOL _in_live_resize;
+  BOOL _needsLayout;
 
   NSUInteger _autoresizingMask;
   NSFocusRingType _focusRingType;
@@ -638,6 +639,22 @@ PACKAGE_SCOPE
 #else
 - (NSUserInterfaceLayoutDirection) userInterfaceLayoutDirection;
 - (void) setUserInterfaceLayoutDirection: (NSUserInterfaceLayoutDirection)dir;
+#endif
+#endif
+
+/**
+* Layout
+*/
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
+- (void) layoutSubtreeIfNeeded;
+- (void) layout;
+
+#if GS_HAS_DECLARED_PROPERTIES
+@property (nonatomic) BOOL needsLayout;
+#else
+-(BOOL) needsLayout;
+-(void) setNeedsLayout: (BOOL)needsLayout;
 #endif
 #endif
 

--- a/Headers/AppKit/NSView.h
+++ b/Headers/AppKit/NSView.h
@@ -180,6 +180,8 @@ PACKAGE_SCOPE
   BOOL _is_hidden;
   BOOL _in_live_resize;
   BOOL _needsLayout;
+  BOOL _needsUpdateConstraints;
+  BOOL _translatesAutoresizingMaskIntoConstraints;
 
   NSUInteger _autoresizingMask;
   NSFocusRingType _focusRingType;
@@ -655,6 +657,20 @@ PACKAGE_SCOPE
 #else
 -(BOOL) needsLayout;
 -(void) setNeedsLayout: (BOOL)needsLayout;
+#endif
+
+#if GS_HAS_DECLARED_PROPERTIES
+@property (nonatomic) BOOL needsUpdateConstraints;
+#else
+- (BOOL) needsUpdateConstraints;
+- (void) setNeedsUpdateConstraints: (BOOL)needsUpdateConstraints;
+#endif
+
+#if GS_HAS_DECLARED_PROPERTIES
+@property BOOL translatesAutoresizingMaskIntoConstraints;
+#else
+- (BOOL) translatesAutoresizingMaskIntoConstraints;
+- (void) setTranslatesAutoresizingMaskIntoConstraints: (BOOL)translatesAutoresizingMaskIntoConstraints;
 #endif
 #endif
 

--- a/Source/NSLayoutConstraint.m
+++ b/Source/NSLayoutConstraint.m
@@ -30,6 +30,7 @@
 #import "AppKit/NSView.h"
 #import "AppKit/NSAnimation.h"
 #import "AppKit/NSLayoutConstraint.h"
+#import "NSViewPrivate.h"
 #import "AppKit/NSWindow.h"
 #import "AppKit/NSApplication.h"
 #import "NSAutoresizingMaskLayoutConstraint.h" 
@@ -615,39 +616,7 @@ static NSMutableArray *activeConstraints = nil;
 
 @end
 
-@implementation NSView (NSConstraintBasedCompatibility)
-
-NSString static const *translatesAutoresizingMaskKey
-    = @"NSConstraintBasedCompatibility.translatesAutoresizingMaskKey";
-
-- (void) setTranslatesAutoresizingMaskIntoConstraints: (BOOL)translate
-{
-  NSValue *value = [NSValue valueWithBytes: &translate objCType: @encode (BOOL)];
-  objc_setAssociatedObject(self, &translatesAutoresizingMaskKey, value,
-                            OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-- (BOOL) translatesAutoresizingMaskIntoConstraints
-{
-  NSValue *value
-      = objc_getAssociatedObject(self, &translatesAutoresizingMaskKey);
-  if (value == nil)
-    {
-      return YES;
-    }
-
-  BOOL translate;
-  [value getValue:&translate];
-
-  return translate;
-}
-
-@end
-
 @implementation NSView (NSConstraintBasedLayoutCoreMethods)
-
-NSString static const *needsUpdateConstraintsKey
-    = @"NSConstraintBasedLayoutCoreMethods.needsUpdateConstraintsKey";
 
 - (void) updateConstraintsForSubtreeIfNeeded
 {
@@ -675,39 +644,8 @@ NSString static const *needsUpdateConstraintsKey
                                    bounds: [[self superview] bounds]];
       [self addConstraints:autoresizingConstraints];
     }
-  [self _setNeedsUpdateConstraints:NO];
-}
 
-- (void)_setNeedsUpdateConstraints: (BOOL) needsUpdateConstraints
-{
-  NSValue *value = [NSValue valueWithBytes: &needsUpdateConstraints
-                                  objCType: @encode (BOOL)];
-  objc_setAssociatedObject (self, &needsUpdateConstraintsKey, value,
-                            OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-- (void) setNeedsUpdateConstraints: (BOOL)needsUpdateConstraints
-{
-  if (!needsUpdateConstraints)
-    {
-      return;
-    }
-  [self _setNeedsUpdateConstraints:YES];
-}
-
-- (BOOL) needsUpdateConstraints
-{
-  NSValue *needsUpdateConstraintsValue
-      = objc_getAssociatedObject (self, &needsUpdateConstraintsKey);
-  if (needsUpdateConstraintsValue == nil)
-    {
-      return YES;
-    }
-
-  BOOL needsUpdateConstraints;
-  [needsUpdateConstraintsValue getValue:&needsUpdateConstraints];
-
-  return needsUpdateConstraints;
+  [self _setNeedsUpdateConstraints: NO];
 }
 
 @end

--- a/Source/NSLayoutConstraint.m
+++ b/Source/NSLayoutConstraint.m
@@ -642,7 +642,7 @@ static NSMutableArray *activeConstraints = nil;
                                     frame: [self frame]
                                 superitem: [self superview]
                                    bounds: [[self superview] bounds]];
-      [self addConstraints:autoresizingConstraints];
+      [self addConstraints: autoresizingConstraints];
     }
 
   [self _setNeedsUpdateConstraints: NO];

--- a/Source/NSLayoutConstraint.m
+++ b/Source/NSLayoutConstraint.m
@@ -32,6 +32,8 @@
 #import "AppKit/NSLayoutConstraint.h"
 #import "AppKit/NSWindow.h"
 #import "AppKit/NSApplication.h"
+#import "NSAutoresizingMaskLayoutConstraint.h" 
+#import "GSFastEnumeration.h"
 #import "GSAutoLayoutVFLParser.h"
 
 static NSMutableArray *activeConstraints = nil;
@@ -609,6 +611,119 @@ static NSMutableArray *activeConstraints = nil;
         }
     }
   */
+}
+
+@end
+
+@implementation NSView (NSConstraintBasedCompatibility)
+
+NSString static const *translatesAutoresizingMaskKey
+    = @"NSConstraintBasedCompatibility.translatesAutoresizingMaskKey";
+
+- (void) setTranslatesAutoresizingMaskIntoConstraints: (BOOL)translate
+{
+  NSValue *value = [NSValue valueWithBytes: &translate objCType: @encode (BOOL)];
+  objc_setAssociatedObject(self, &translatesAutoresizingMaskKey, value,
+                            OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (BOOL) translatesAutoresizingMaskIntoConstraints
+{
+  NSValue *value
+      = objc_getAssociatedObject(self, &translatesAutoresizingMaskKey);
+  if (value == nil)
+    {
+      return YES;
+    }
+
+  BOOL translate;
+  [value getValue:&translate];
+
+  return translate;
+}
+
+@end
+
+@implementation NSView (NSConstraintBasedLayoutCoreMethods)
+
+NSString static const *needsUpdateConstraintsKey
+    = @"NSConstraintBasedLayoutCoreMethods.needsUpdateConstraintsKey";
+
+- (void) updateConstraintsForSubtreeIfNeeded
+{
+  NSArray *subviews = [self subviews];
+  FOR_IN (NSView *, subview, subviews)
+    [subview updateConstraintsForSubtreeIfNeeded];
+  END_FOR_IN (subviews);
+
+  if ([self needsUpdateConstraints])
+    {
+      [self updateConstraints];
+    }
+}
+
+- (void) updateConstraints
+{
+  if ([self translatesAutoresizingMaskIntoConstraints] &&
+      [self superview] != nil)
+    {
+      NSArray *autoresizingConstraints = [NSAutoresizingMaskLayoutConstraint
+          constraintsWithAutoresizingMask: [self autoresizingMask]
+                                  subitem: self
+                                    frame: [self frame]
+                                superitem: [self superview]
+                                   bounds: [[self superview] bounds]];
+      [self addConstraints:autoresizingConstraints];
+    }
+  [self _setNeedsUpdateConstraints:NO];
+}
+
+- (void)_setNeedsUpdateConstraints: (BOOL) needsUpdateConstraints
+{
+  NSValue *value = [NSValue valueWithBytes: &needsUpdateConstraints
+                                  objCType: @encode (BOOL)];
+  objc_setAssociatedObject (self, &needsUpdateConstraintsKey, value,
+                            OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (void) setNeedsUpdateConstraints: (BOOL)needsUpdateConstraints
+{
+  if (!needsUpdateConstraints)
+    {
+      return;
+    }
+  [self _setNeedsUpdateConstraints:YES];
+}
+
+- (BOOL) needsUpdateConstraints
+{
+  NSValue *needsUpdateConstraintsValue
+      = objc_getAssociatedObject (self, &needsUpdateConstraintsKey);
+  if (needsUpdateConstraintsValue == nil)
+    {
+      return YES;
+    }
+
+  BOOL needsUpdateConstraints;
+  [needsUpdateConstraintsValue getValue:&needsUpdateConstraints];
+
+  return needsUpdateConstraints;
+}
+
+@end
+
+@implementation NSView (NSConstraintBasedLayoutInstallingConstraints)
+
+- (void) addConstraint: (NSLayoutConstraint *)constraint
+{
+  // FIXME: Implement adding constraint to layout engine
+}
+
+- (void) addConstraints: (NSArray*)constraints
+{
+  FOR_IN (NSLayoutConstraint*, constraint, constraints)
+    [self addConstraint: constraint];
+  END_FOR_IN (constraints);
 }
 
 @end

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -632,6 +632,9 @@ GSSetDragTypes(NSView* obj, NSArray *types)
   //_previousKeyView = 0;
 
   _alphaValue = 1.0;
+
+  _needsUpdateConstraints = YES;
+  _translatesAutoresizingMaskIntoConstraints = YES;
   
   return self;
 }
@@ -5172,6 +5175,41 @@ static NSView* findByTag(NSView *view, NSInteger aTag, NSUInteger *level)
 - (BOOL) needsLayout
 {
   return _needsLayout;
+}
+
+- (void) setNeedsUpdateConstraints: (BOOL)needsUpdateConstraints
+{
+  // Calling setNeedsUpdateConstraints with NO should not have an effect
+  if (!needsUpdateConstraints)
+    {
+      return;
+    }
+
+  _needsUpdateConstraints = YES;
+}
+
+- (BOOL) needsUpdateConstraints
+{
+  return _needsUpdateConstraints;
+}
+
+- (void) setTranslatesAutoresizingMaskIntoConstraints: (BOOL)translate
+{
+  _translatesAutoresizingMaskIntoConstraints = translate;
+}
+
+- (BOOL) translatesAutoresizingMaskIntoConstraints
+{
+  return _translatesAutoresizingMaskIntoConstraints;
+}
+
+@end
+
+@implementation NSView (NSConstraintBasedLayoutCorePrivateMethods)
+// This private setter allows the updateConstraints method to toggle needsUpdateConstraints
+- (void) _setNeedsUpdateConstraints: (BOOL)needsUpdateConstraints
+{
+  _needsUpdateConstraints = needsUpdateConstraints;
 }
 
 @end

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -62,6 +62,7 @@
 #import "AppKit/NSFont.h"
 #import "AppKit/NSGraphics.h"
 #import "AppKit/NSKeyValueBinding.h"
+#import "AppKit/NSLayoutConstraint.h"
 #import "AppKit/NSMenu.h"
 #import "AppKit/NSPasteboard.h"
 #import "AppKit/NSPrintInfo.h"
@@ -76,6 +77,7 @@
 #import "GNUstepGUI/GSNibLoading.h"
 #import "GSToolTips.h"
 #import "GSBindingHelpers.h"
+#import "GSFastEnumeration.h"
 #import "GSGuiPrivate.h"
 #import "NSViewPrivate.h"
 
@@ -5127,6 +5129,49 @@ static NSView* findByTag(NSView *view, NSInteger aTag, NSUInteger *level)
 {
   // FIXME: implement this
   return;
+}
+
+/**
+* Layout 
+*/
+
+- (void) layout
+{
+  // FIXME: Implement asking layout engine for the alignment rect of each subview and set the alignment rect of each sub view
+}
+
+- (void) layoutSubtreeIfNeeded
+{
+  [self updateConstraintsForSubtreeIfNeeded];
+  [self _layoutViewAndSubViews];
+}
+
+- (void) _layoutViewAndSubViews
+{
+  if (_needsLayout)
+    {
+      [self layout];
+      _needsLayout = NO;
+    }
+
+  NSArray *subviews = [self subviews];
+  FOR_IN (NSView *, subview, subviews)
+    [subview _layoutViewAndSubViews];
+  END_FOR_IN (subviews);
+}
+
+- (void) setNeedsLayout: (BOOL) needsLayout
+{
+  if (!needsLayout)
+    {
+      return;
+    }
+  _needsLayout = needsLayout;
+}
+
+- (BOOL) needsLayout
+{
+  return _needsLayout;
 }
 
 @end

--- a/Source/NSViewPrivate.h
+++ b/Source/NSViewPrivate.h
@@ -38,4 +38,10 @@
 - (void) _insertSubview: (NSView *)sv atIndex: (NSUInteger)idx;
 @end
 
+@interface NSView (NSConstraintBasedLayoutCorePrivateMethods)
+
+- (void) _setNeedsUpdateConstraints: (BOOL)needsUpdateConstraints;
+
+@end
+
 #endif // _GNUstep_H_NSViewPrivate


### PR DESCRIPTION
This PR implements a small subset of the core layout methods to support Autolayout. I've stubbed out a few methods that require the autolayout engine to keep this PR manageable. I plan to submit a future PR to add the missing functionality.

The best way to get an understanding of the desired behaviour is to watch the High Performance Auto Layout WWDC presentation.
https://developer.apple.com/videos/play/wwdc2018/220/
