### PR TITLE
Implement acceptsFirstMouse to return YES

### DIFF
--- a/Source/NSTableView.m
+++ b/Source/NSTableView.m
@@ -3568,6 +3568,11 @@ static inline NSTimeInterval computePeriod(NSPoint mouseLocationWin,
   return NO;
 }
 
+- (BOOL) acceptsFirstMouse: (NSEvent *)theEvent
+{
+  return YES;
+}
+
 - (void) mouseDown: (NSEvent *)theEvent
 {
   NSPoint initialLocation = [theEvent locationInWindow];


### PR DESCRIPTION
We need this, or tables in new windows do not get mouse selection events.
Seems to match Apple's implementation.

A test case is GNUMail's autocomplete text field for addresses. on GNUstep it is not selectable via mouse, on Mac it is.

This patch fixes it, I worked already on it with @fredkiefer. I went up as far as putting a breakpoint on NSTableView on Mac 10.5, seeing it is implemented and reading the assembler which is trivial and means push 1, eax and return. So we are pretty confident it is correct and that it is a corner case not usually detected because of the new window and the first mouse event in it.

Still a check on existing applications and a review from people is fine, @gcasa & @wlux come to my mind.