### PR TITLE
Add missing #import <AppKit/AppKitDefines.h> to NSSound.h

### DIFF
--- a/Headers/AppKit/NSSound.h
+++ b/Headers/AppKit/NSSound.h
@@ -30,6 +30,7 @@
 
 #ifndef _GNUstep_H_NSSound
 #define _GNUstep_H_NSSound
+#import <AppKit/AppKitDefines.h>
 
 #import <Foundation/NSObject.h>
 #import <Foundation/NSBundle.h>


### PR DESCRIPTION

This broke building SimpleAgenda for me:

In file included from SoundBackend.m:1:
/usr/local/include/AppKit/NSSound.h:57:1: error: unknown type name 'APPKIT_EXPORT_CLASS' APPKIT_EXPORT_CLASS

