### PR TITLE
`NSGraphicsContext`: Add `methods` method

### DIFF
--- a/Headers/AppKit/NSGraphicsContext.h
+++ b/Headers/AppKit/NSGraphicsContext.h
@@ -211,6 +211,7 @@ APPKIT_EXPORT_CLASS
                                              flipped: (BOOL)flipped;
 #endif
 
+- (const gsMethodTable *) methods;
 - (NSDictionary *) attributes;
 - (void *) graphicsPort;
 

--- a/Source/NSGraphicsContext.m
+++ b/Source/NSGraphicsContext.m
@@ -375,6 +375,11 @@ NSGraphicsContext	*GSCurrentContext(void)
   return context_info;
 }
 
+- (const gsMethodTable *) methods
+{
+  return methods;
+}
+
 - (void) flushGraphics
 {
   [self subclassResponsibility: _cmd];


### PR DESCRIPTION
gnustep-back uses the `NSGraphicsContext->methods` _variable_ (directly or via inline functions), but using an instance variable across module boundaries is not supported when building with Visual Studio.

This commits adds a `[NSGraphicsContext methods]` _method_, which can be accessed across module boundaries (and hence when building with Visual Studio).