### PR TITLE
Remove now unused NSCurrentServerThreadKey key, previously it was use…

### DIFF
--- a/Source/GSDisplayServer.m
+++ b/Source/GSDisplayServer.m
@@ -62,7 +62,6 @@ static NSMapTable *windowmaps = NULL;
 /* Lock for use when creating contexts */
 static NSRecursiveLock  *serverLock = nil;
 
-static NSString *NSCurrentServerThreadKey;
 static GSDisplayServer *currentServer = nil;
 
 /** Returns the GSDisplayServer that created the interal
@@ -130,7 +129,6 @@ GSCurrentServer(void)
           serverLock = [NSRecursiveLock new];
           _globalGSZone = NSDefaultMallocZone();
           defaultServerClass = [GSDisplayServer class];
-          NSCurrentServerThreadKey  = @"NSCurrentServerThreadKey";
           windowmaps = NSCreateMapTable(NSNonOwnedPointerMapKeyCallBacks,
                                         NSNonOwnedPointerMapValueCallBacks, 20);
         }


### PR DESCRIPTION
Remove now unused NSCurrentServerThreadKey key, previously it was used tor GSCurrentServer(), but it it is not needed anymore. Please use the function directly. Only known usage to me is GNUMail, it has just been converted.
Fixes https://github.com/gnustep/libs-gui/issues/182