### PR TITLE
NSMenuItemCell: Fix small typo that causes display character check to fail

### DIFF
--- a/Source/NSMenuItemCell.m
+++ b/Source/NSMenuItemCell.m
@@ -283,7 +283,7 @@ static NSString *commandKeyString = @"#";
       else
         {
           // shift mask and not an upper case string?
-          shift = (m & NSShiftKeyMask) & ![key isEqualToString: ucKey];
+          shift = (m & NSShiftKeyMask) && ![key isEqualToString: ucKey];
           key = [NSString stringWithFormat:@"%@%@%@%@%@",
                           (m & NSControlKeyMask) ? controlKeyString : @"",
                           (m & NSAlternateKeyMask) ? alternateKeyString : @"",


### PR DESCRIPTION
NSMenu's don't seem to display the Shift character. I believe this change makes it display as intended.