### PR TITLE
Add dummy awakeFromNib dummy method

### DIFF
--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -5231,6 +5231,10 @@ static NSView* findByTag(NSView *view, NSInteger aTag, NSUInteger *level)
   return 0;
 }
 
+- (void) awakeFromNib
+{
+}
+
 @end
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)


### PR DESCRIPTION
This adds a  dummy method for NSView so that subclasses can call awakeFromNib.  I have run into production code which does this and does not fail on macOS.  I also have a test which I will add to git and reference here.