### PR TITLE
NSWorkspace: Throw a descriptive exception when make_services could not be found

### DIFF
--- a/Source/NSWorkspace.m
+++ b/Source/NSWorkspace.m
@@ -1746,6 +1746,13 @@ inFileViewerRootedAtPath: (NSString*)rootFullpath
     {
       path = [[NSTask launchPathForTool: @"make_services"] retain];
     }
+
+  if (path == nil)
+    {
+      [NSException raise: NSInternalInconsistencyException
+	           format: @"Unable to find the make_services tool.\n"];
+    }
+
   task = [NSTask launchedTaskWithLaunchPath: path
 				  arguments: nil];
   if (task != nil)


### PR DESCRIPTION
`[NSTask launchPathForTool: @"make_services"]; can return nil when the tool is not found. In this case, [NSTask launchedTaskWithLaunchPath] would raise a NSInvalidArgumentException with error message "NSTask - no launch path set" which is not very descriptive.