### PR TITLE
Fix handling of custom classes for XIB v5.  This corrects an issue in…

### DIFF
--- a/Source/GSXibKeyedUnarchiver.m
+++ b/Source/GSXibKeyedUnarchiver.m
@@ -310,6 +310,7 @@
   objects = [[NSMutableDictionary alloc] init];
   stack = [[NSMutableArray alloc] init];
   decoded = [[NSMutableDictionary alloc] init];
+  _customClasses= [[NSMutableDictionary alloc] init];
 }
 
 - (id) initForReadingWithData: (NSData*)data
@@ -318,17 +319,15 @@
   NSXMLParser *theParser;
   NSData *theData = data;
 
-  // Dictionary which contains custom class information for Gorm/IB.
-  _customClasses = [[NSMutableDictionary alloc] init];
+  // Initialize...
+  [self _initCommon];
 
+  // Prepare the XIB data for parsing...
   theData = [self _preProcessXib: data];
   if (theData == nil)
     {
       return nil;
     }
-
-  // Initialize...
-  [self _initCommon];
 
   theParser = [[NSXMLParser alloc] initWithData: theData];
   [theParser setDelegate: self];


### PR DESCRIPTION
This fixes an issue in Gorm as well.   Previously custom classes were not being handled properly and causing a crash when loading a xib and saving as a gorm.   This fix helps to avert that issue.