### PR TITLE
Make NSMenu->_aWindow protected, it is referenced by the Windows UX Theme

### DIFF
--- a/Headers/AppKit/NSMenu.h
+++ b/Headers/AppKit/NSMenu.h
@@ -410,8 +410,10 @@ APPKIT_EXPORT_CLASS
 		unsigned int unused: 25;
   } _menu;
 
-@private
+@protected
   NSWindow *_aWindow;
+
+@private
   NSWindow *_bWindow;
   NSMenu *_oldAttachedMenu;
   int     _oldHiglightedIndex;


### PR DESCRIPTION
`NSMenu->_aWindow` is used by the WinUXTheme here: https://github.com/gnustep/plugins-themes-WinUXTheme/blob/1d9a37136b8dfc6dcea811ef28defbe52f954d0d/WinUXTheme.m#L54 , so mark it as `@protected`.

This pops up when compiling with clang, which actually enforces those visibility attributes (whereas gcc would just make everything publicly visible).