### PR TITLE
Make PACKAGE_SCOPE @public on MinGW

### DIFF
--- a/Headers/AppKit/AppKitDefines.h
+++ b/Headers/AppKit/AppKitDefines.h
@@ -72,7 +72,7 @@
 
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__MINGW32__)
 #  define PACKAGE_SCOPE @package
 #else
 #  define PACKAGE_SCOPE @public


### PR DESCRIPTION
The clang compiler actually enforces visibility on MinGW (by not exporting the instance variable offsets); there isn't a functional equivalent of `@package` on Windows.

Without this patch, compiling libs-gui fails like this:

```
Linking bundle libgmodel ...
ld.lld: error: undefined symbol: __objc_ivar_offset_NSView._sub_views.☺
>>> referenced by ./obj/libgmodel.obj/GMAppKit.m.o:(.refptr.__objc_ivar_offset_NSView._sub_views.☺)
```
