### PR TITLE
Support tab renaming in terminal

### DIFF
--- a/Headers/Additions/GNUstepGUI/GSTheme.h
+++ b/Headers/Additions/GNUstepGUI/GSTheme.h
@@ -1266,10 +1266,11 @@ APPKIT_EXPORT_CLASS
 			   tabViewType: (NSTabViewType)type
 			       tabView: (NSTabView *)view;
 
-- (NSImage *)imageForTabPart: (GSTabPart)part type: (NSTabViewType)type;
+- (NSImage *) imageForTabPart: (GSTabPart)part
+			 type: (NSTabViewType)type;
 
 - (NSRect) tabViewBackgroundRectForBounds: (NSRect)aRect
-tabViewType: (NSTabViewType)type;
+			      tabViewType: (NSTabViewType)type;
 
 - (void) drawTabViewRect: (NSRect)rect
 		  inView: (NSView *)view

--- a/Headers/Additions/GNUstepGUI/GSTheme.h
+++ b/Headers/Additions/GNUstepGUI/GSTheme.h
@@ -1266,6 +1266,11 @@ APPKIT_EXPORT_CLASS
 			   tabViewType: (NSTabViewType)type
 			       tabView: (NSTabView *)view;
 
+- (NSImage *)imageForTabPart: (GSTabPart)part type: (NSTabViewType)type;
+
+- (NSRect) tabViewBackgroundRectForBounds: (NSRect)aRect
+tabViewType: (NSTabViewType)type;
+
 - (void) drawTabViewRect: (NSRect)rect
 		  inView: (NSView *)view
 	       withItems: (NSArray *)items


### PR DESCRIPTION
I have implemented a feature in Terminal.app. It allows to rename a tab.

[Screenshot](https://svgol.github.io/tab_renaming_in_teminal.html)

Its changes mainly consist form a modified copypasted version of -[GSTheme (Drawing) -drawTabViewRect:inView:withItems:selectedItem:] 
to calculate the renaming TextField's placement exactly under the selected tab.
But it requires GSTheme (Drawing) to export two methods that currently are 'privately' accessible.
This pull request exports these two methods allowing me to share my changes in Terminal.app