### PR TITLE
Generate pkg-config configuration file for libs-gui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ gnustep-gui-debug.spec
 gui.make
 Headers/Additions/GNUstepGUI/GSVersion.h
 Source/config.h
+Source/gnustep-gui.pc
 Source/Info-gnustep.plist
 Tests/gui/*/GNUmakefile
 Tools/speech/GSSpeechServer.app

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -701,6 +701,9 @@ libgui-resources_RESOURCE_FILES = Info-gnustep.plist
 # Extra DLL exports file
 libgnustep-gui_DLL_DEF = libgnustep-gui.def
 
+# pkg-config file
+libgnustep-gui_PKGCONFIG_FILES = "gnustep-gui.pc"
+
 include GNUmakefile.preamble
 
 include $(GNUSTEP_MAKEFILES)/library.make

--- a/Source/gnustep-gui.pc.in
+++ b/Source/gnustep-gui.pc.in
@@ -1,0 +1,6 @@
+Name: gnustep-gui
+Description: The GNUstep gui library is a library of graphical user interface classes written completely in the Objective-C language; the classes are based upon Apple's Cocoa framework (which came from the OpenStep specification).
+Version: @GNUSTEP_GUI_VERSION@
+URL: https://github.com/gnustep/libs-gui/
+Libs: @GUILIBS@
+Cflags:  @GUIFLAGS@

--- a/configure
+++ b/configure
@@ -628,6 +628,8 @@ GNUSTEP_GUI_SUBMINOR_VERSION
 GNUSTEP_GUI_MINOR_VERSION
 GNUSTEP_GUI_MAJOR_VERSION
 GNUSTEP_GUI_VERSION
+GUILIBS
+GUIFLAGS
 WARN_FLAGS
 BUILD_GSCUPS
 GSCUPS_DATADIR
@@ -6025,6 +6027,14 @@ fi
 
 
 #--------------------------------------------------------------------
+# Get the Cflags and Libs values for gnustep-gui.pc
+#--------------------------------------------------------------------
+GUIFLAGS=`gnustep-config --objc-flags`
+
+GUILIBS=`gnustep-config --gui-libs`
+
+
+#--------------------------------------------------------------------
 # Record the version
 #--------------------------------------------------------------------
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the version of gnustep-gui we are compiling" >&5
@@ -6051,7 +6061,7 @@ CONFIG_SYSTEM_LIB_DIR="$CONFIG_SYSTEM_LIB_DIR $GRAPHIC_LFLAGS"
 #--------------------------------------------------------------------
 
 
-ac_config_files="$ac_config_files config.make gui.make Headers/Additions/GNUstepGUI/GSVersion.h"
+ac_config_files="$ac_config_files config.make gui.make Source/gnustep-gui.pc Headers/Additions/GNUstepGUI/GSVersion.h"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -6745,6 +6755,7 @@ do
     "Headers/Additions/GNUstepGUI/config.h") CONFIG_HEADERS="$CONFIG_HEADERS Headers/Additions/GNUstepGUI/config.h" ;;
     "config.make") CONFIG_FILES="$CONFIG_FILES config.make" ;;
     "gui.make") CONFIG_FILES="$CONFIG_FILES gui.make" ;;
+    "Source/gnustep-gui.pc") CONFIG_FILES="$CONFIG_FILES Source/gnustep-gui.pc" ;;
     "Headers/Additions/GNUstepGUI/GSVersion.h") CONFIG_FILES="$CONFIG_FILES Headers/Additions/GNUstepGUI/GSVersion.h" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;

--- a/configure.ac
+++ b/configure.ac
@@ -640,6 +640,12 @@ fi
 AC_SUBST(WARN_FLAGS)
 
 #--------------------------------------------------------------------
+# Get the Cflags and Libs values for gnustep-gui.pc
+#--------------------------------------------------------------------
+AC_SUBST(GUIFLAGS, `gnustep-config --objc-flags`)
+AC_SUBST(GUILIBS, `gnustep-config --gui-libs`)
+
+#--------------------------------------------------------------------
 # Record the version
 #--------------------------------------------------------------------
 AC_MSG_CHECKING(for the version of gnustep-gui we are compiling)
@@ -678,5 +684,5 @@ static double rint(double a)     \
 #endif
 ])
 
-AC_CONFIG_FILES([config.make gui.make Headers/Additions/GNUstepGUI/GSVersion.h])
+AC_CONFIG_FILES([config.make gui.make Source/gnustep-gui.pc Headers/Additions/GNUstepGUI/GSVersion.h])
 AC_OUTPUT


### PR DESCRIPTION
This PR updates the libs-gui build process to generate a gnustep…-gui.pc file which is installed in /lib/pkgconfig and contains the GNUstep gui version number, the libraries to link (equivalent to gnustep-config --gui-libs) with and the C flags to use (equivalent to gnustep-config --objc-flags).

This can be useful when linking with libs-gui in projects which don't use the GNUstep build system.

Equivalent of https://github.com/gnustep/libs-base/pull/382 for libs-gui

pkg-config support was apparently added to tools-make about 8 years ago: https://github.com/gnustep/tools-make/commit/b3c4eb94ca3fd65cc88f6412fc9ad5dbc95781ef