### PR TITLE
GSTextStorage: Add function prototypes

### DIFF
--- a/Source/GSTextStorage.m
+++ b/Source/GSTextStorage.m
@@ -345,11 +345,11 @@ static SEL oatSel;
 static SEL remSel;
 
 static IMP	infImp;
-static void	(*addImp)();
-static unsigned (*cntImp)();
-static void	(*insImp)();
+static void	(*addImp)(NSMutableArray*, SEL, NSObject*);
+static unsigned (*cntImp)(NSMutableArray*, SEL);
+static void	(*insImp)(NSMutableArray*, SEL, NSObject*, NSUInteger);
 static IMP	oatImp;
-static void	(*remImp)();
+static void	(*remImp)(NSMutableArray*, SEL, NSUInteger);
 
 #define	NEWINFO(Z,O,L)	((*infImp)(infCls, infSel, (Z), (O), (L)))
 #define	ADDOBJECT(O)	((*addImp)(_infoArray, addSel, (O)))


### PR DESCRIPTION
Add a function prototype for:
- `addImp` (`(void)addObject:(ObjectType)anObject`)
- `insImp` (`(void)insertObject:(ObjectType)anObject atIndex:(NSUInteger)index`)
- `remImp` (`(void)removeObject:(ObjectType)anObject`)
-  cntImp (`count`)

Fixes warning: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]