### PR TITLE
NSGraphicsContext: Suppress incompatible pointer type warning

### DIFF
--- a/Source/NSGraphicsContext.m
+++ b/Source/NSGraphicsContext.m
@@ -346,12 +346,12 @@ NSGraphicsContext	*GSCurrentContext(void)
        * be protected from other threads.
        */
       [contextLock lock];
-      methods = [[classMethodTable objectForKey: [self class]] pointerValue];
+      methods = [[classMethodTable objectForKey: (id<NSCopying>)[self class]] pointerValue];
       if (methods == 0)
         {
           methods = [[self class] _initializeMethodTable];
           [classMethodTable setObject: [NSValue valueWithPointer: methods]
-                            forKey: [self class]];
+                            forKey: (id<NSCopying>)[self class]];
         }
       [contextLock unlock];
     }


### PR DESCRIPTION
Fixes the following warnings:

```
NSGraphicsContext.m:349:50: warning: incompatible pointer types sending 'Class' to parameter of type 'id<NSCopying>' [-Wincompatible-pointer-types]
      methods = [[classMethodTable objectForKey: [self class]] pointerValue];
                                                 ^~~~~~~~~~~~
/usr/local/include/Foundation/NSDictionary.h:115:26: note: passing argument to parameter 'aKey' here
  (GS_GENERIC_TYPE(KeyT))aKey;                          // Primitive
                         ^
NSGraphicsContext.m:354:37: warning: incompatible pointer types sending 'Class' to parameter of type 'id<NSCopying>' [-Wincompatible-pointer-types]
                            forKey: [self class]];
                                    ^~~~~~~~~~~~
```