### PR TITLE
highlightTableViewSelection: Always use default selection color if not set.

### DIFF
--- a/Source/GSThemeDrawing.m
+++ b/Source/GSThemeDrawing.m
@@ -3310,18 +3310,10 @@ static NSDictionary *titleTextAttributes[3] = {nil, nil, nil};
 
     if (selectionColor == nil)
       {
-	// Switch to the alternate color of the backgroundColor is white.
-	if([backgroundColor isEqual: [NSColor whiteColor]])
-	  {
-	    selectionColor = [NSColor colorWithCalibratedRed: 0.86
-						       green: 0.92
-							blue: 0.99
-						       alpha: 1.0];
-	  }
-	else
-	  {
-	    selectionColor = [NSColor whiteColor];
-	  }
+	selectionColor = [NSColor colorWithCalibratedRed: 0.86
+						   green: 0.92
+						    blue: 0.99
+						   alpha: 1.0];
       }
     [selectionColor set];
   }


### PR DESCRIPTION
The current implementation will attempt to assign a default value for selectionColor if backgroundColor is white.  There's two issues with that:

1. `backgroundColor` is likely in the `NSNamedColorSpace`,  whereas it is being compared to `[NSColor whiteColor]`, which is in the `NSCalibratedWhiteColorSpace`. That comparision will always return false.
2. Users will probably expect the selected item to be highlighted in a different color even if the background color is not white.  For example, the consider a scenario where the default background color is white, and the alternate background color is grey.  It makes sense to always highlight the selected row in blue.  This aligns with the behavior when `highlightedTableRowBackgroundColor` is defined.