### PR TITLE
NSBox: (re-)implement isOpaque; decode NSBorderColor2 and NSFillColor2

### DIFF
--- a/Headers/Additions/GNUstepGUI/GSTheme.h
+++ b/Headers/Additions/GNUstepGUI/GSTheme.h
@@ -1339,6 +1339,8 @@ APPKIT_EXPORT_CLASS
 		 clipRect: (NSRect)clipRect
 		   inView: (NSView *)view;
 
+- (BOOL) isBoxOpaque: (NSBox *)box;
+
 - (void) drawBoxInClipRect: (NSRect)clipRect
 		   boxType: (NSBoxType)boxType
 		borderType: (NSBorderType)borderType

--- a/Source/GSThemeDrawing.m
+++ b/Source/GSThemeDrawing.m
@@ -3475,6 +3475,18 @@ static NSDictionary *titleTextAttributes[3] = {nil, nil, nil};
     }
 }
 
+- (BOOL) isBoxOpaque: (NSBox *)box
+{
+  if ([box boxType] == NSBoxCustom)
+    {
+      return ![box isTransparent];
+    }
+  else
+    {
+      return YES;
+    }
+}
+
 - (void) drawBoxInClipRect: (NSRect)clipRect
 		   boxType: (NSBoxType)boxType
 		borderType: (NSBorderType)borderType

--- a/Source/NSBox.m
+++ b/Source/NSBox.m
@@ -464,18 +464,7 @@
 
 - (BOOL) isOpaque
 {
-  // FIXME: Depends on theme; if always returning NO is a performance hit
-  // we can check if GSTheme is going to draw an old-style opaque box
-  // or not.
-  return NO;
-  // if (_box_type == NSBoxCustom)
-  //   {
-  //     return !_transparent;
-  //   }
-  // else
-  //   {
-  //     return YES;
-  //   }
+  return [[GSTheme theme] isBoxOpaque: self];
 }
 
 - (NSColor*) fillColor


### PR DESCRIPTION
This (re-)implements logic where a box is marked as opaque if it is a custom box which is not transparent and adds the decoding of the `NSBorderColor2` and `NSFillColor2` attributes.

This fixes the rendering of custom boxes with a custom fill color; the current implementation would mark them as non-opaque and hence the fill color would not be rendered.

- The original implementation (from 1999) always returned `YES` (53bcb5024020fe85e370d9d49297aca4320d7768)
- A more complete implementation was backported from the Testplant branch in 2012 (e85b16bc05d5d513788c09b470fd09ad5f888882, by @fredkiefer, downstream commit 36e77b95f7921e9539fdc0c115fe4039fa573150)
- In 2013, a return value of `NO` was hardcoded (02bc49e2d5336e9092001e3d56cb43750a8466a3, by @ericwa)