### PR TITLE
Fix NSImageView intercepting mouse events when not editable

### DIFF
--- a/Source/NSImageView.m
+++ b/Source/NSImageView.m
@@ -308,6 +308,12 @@ static Class imageCellClass;
 
 - (void) mouseDown: (NSEvent*)theEvent
 {
+  if (![self isEditable])
+    {
+      [[self nextResponder] mouseDown:theEvent];
+      return;
+    }
+
   if ([self initiatesDrag])
     {
       NSPasteboard *pboard;

--- a/Source/NSImageView.m
+++ b/Source/NSImageView.m
@@ -308,11 +308,6 @@ static Class imageCellClass;
 
 - (void) mouseDown: (NSEvent*)theEvent
 {
-  if (![self isEditable])
-    {
-      [[self nextResponder] mouseDown:theEvent];
-      return;
-    }
 
   if ([self initiatesDrag])
     {
@@ -346,7 +341,15 @@ static Class imageCellClass;
 	    }
 	}
     }
-  [super mouseDown: theEvent];
+    
+  if (![self isEditable] && [self nextResponder] != nil)
+    {
+      [[self nextResponder] mouseDown:theEvent];
+    }
+  else
+    {
+      [super mouseDown: theEvent];
+    }
 }
 
 - (NSDragOperation) draggingSourceOperationMaskForLocal: (BOOL)isLocal

--- a/Source/NSImageView.m
+++ b/Source/NSImageView.m
@@ -308,7 +308,6 @@ static Class imageCellClass;
 
 - (void) mouseDown: (NSEvent*)theEvent
 {
-
   if ([self initiatesDrag])
     {
       NSPasteboard *pboard;


### PR DESCRIPTION
This adds a condition to the mouseDown: event for NSImageView. Basically, if the image view is not editable, it invokes the mouseDown: method on the nextResponder for the ImageView.

This is necessary, because as it currently works, the imageView will intercept any mouse clicks on the image view, even though it is not editable and should be transparent to mouse events. This means that if the image view is a subview of another view that you want to click on, such as an NSCollectionViewItem, the clicks will not register if you click on the image view.

One can also make the imageView not respond to mouse events by setting enabled to false, but that has side effects such as changing the appearance of the image.