### PR TITLE
Set editable property in NSCell default to false

### DIFF
--- a/Source/GSXib5KeyedUnarchiver.m
+++ b/Source/GSXib5KeyedUnarchiver.m
@@ -2395,8 +2395,7 @@ didStartElement: (NSString*)elementName
       mask.flags.highlighted              = [[attributes objectForKey: @"highlighted"] boolValue];
       mask.flags.disabled                 = ([attributes objectForKey: @"enabled"] ?
                                              [[attributes objectForKey: @"enabled"] boolValue] == NO : NO);
-      mask.flags.editable                 = ([attributes objectForKey: @"editable"] ?
-                                             [[attributes objectForKey: @"editable"] boolValue] : YES);
+      mask.flags.editable                 = [[attributes objectForKey: @"editable"] boolValue];
       mask.flags.vCentered                = [[attributes objectForKey: @"alignment"] isEqualToString: @"center"];
       mask.flags.hCentered                = [[attributes objectForKey: @"alignment"] isEqualToString: @"center"];
       mask.flags.bordered                 = [[borderStyle lowercaseString] containsString: @"border"];


### PR DESCRIPTION
Unarchiving a NSCell element from a xib will have the editable property set to false unless explicitly set to true. This is consistent with how Apple does it. A textFieldCell element that has been set to not be editable in XCode will not have an "editable" property. And this will be interpreted by Cocoa as a non-editable text label.
The previous version where cells had editable set to true by default was resulting in a bunch of text labels being editable in UI when they were not supposed to be.