### PR TITLE
Change to decoding of EquivalentKeyModifierFlags

### DIFF
--- a/Source/NSButtonCell.m
+++ b/Source/NSButtonCell.m
@@ -1641,7 +1641,7 @@
       // style and border.
       bFlags2 |= [self showsBorderOnlyWhileMouseInside] ? 0x8 : 0;
       bFlags2 |= (([self bezelStyle] & 0x7) | (([self bezelStyle] & 0x18) << 2));
-      bFlags2 |= [self keyEquivalentModifierMask] << 8;
+      bFlags2 |= [self keyEquivalentModifierMask] & NSDeviceIndependentModifierFlagsMask;
 
       switch ([self imageScaling])
 	{
@@ -1805,7 +1805,7 @@
           bFlags2 = [aDecoder decodeIntForKey: @"NSButtonFlags2"];
           [self setShowsBorderOnlyWhileMouseInside: (bFlags2 & 0x8)];
           [self setBezelStyle: (bFlags2 & 0x7) | ((bFlags2 & 0x20) >> 2)];
-          [self setKeyEquivalentModifierMask: ((bFlags2 >> 8) & 
+          [self setKeyEquivalentModifierMask: (bFlags2 & 
                                                NSDeviceIndependentModifierFlagsMask)];
 
 	  switch ((bFlags2 >> 6) & 3)


### PR DESCRIPTION
In the existing code, when the keyEquivalentModifierMask is shifted right by 8 bits when decoding, and shifted left by 8 bits when encoding. I can see no reason for this. 

Furthermore, when attempting to decode a standard xib, this eliminates the standard modifier keys that are used. For example, if "command" is present in the xib, the mask is ored with NSCommandKeyMask, which is 0x10 0000. But then when initializing with this encoder, this is shifted right by 8 bits, producing 0x00 1000, and then anded with NSDeviceIndependentModifierFlagsMask (0xffff 0000) resulting in 0. So the command key modifier is lost.

Like I said, I think this 8 bit shift is simply a mistake, and should be removed.