### PR TITLE
Improve decoding of keyEquivalentModifierMask in .xib files

### DIFF
--- a/Source/GSXib5KeyedUnarchiver.m
+++ b/Source/GSXib5KeyedUnarchiver.m
@@ -1382,21 +1382,9 @@ didStartElement: (NSString*)elementName
   id            object     = nil;
   NSDictionary *attributes = [[element elementForKey: @"keyEquivalentModifierMask"] attributes];
 
-  // ??? SKIP modifier mask processing if BASE64-UTF8 string being used ???
   if (attributes == nil)
     {
-      if (([element elementForKey: @"keyEquivalent"]) &&
-          ([[element elementForKey: @"keyEquivalent"] attributeForKey: @"base64-UTF8"]))
-      {
-        object = [NSNumber numberWithUnsignedInt: 0];
-      }
-    else
-      {
-        // Seems that Apple decided to omit this attribute IF certain default keys alone
-        // are applied.  If this key is present WITH NO setting then the following is
-        // used for the modifier mask...
-        object = [NSNumber numberWithUnsignedInt: NSCommandKeyMask];
-      }
+      return nil;
     }
   else
     {
@@ -2705,7 +2693,12 @@ didStartElement: (NSString*)elementName
         }
 
       // keyEquivalentModifierMask...
-      mask.value |= [[self decodeModifierMaskForElement: element] unsignedIntValue];
+      NSNumber* modifierMask = [self decodeModifierMaskForElement: element];
+
+      if (modifierMask != nil)
+        {
+          mask.value |= [modifierMask unsignedIntValue] << 8;
+        }      
 
       // Return value...
       value = [NSNumber numberWithUnsignedInteger: mask.value];

--- a/Source/NSMenuItem.m
+++ b/Source/NSMenuItem.m
@@ -650,7 +650,7 @@ static Class imageClass;
       NSString *action;
       NSString *key;
       BOOL isSeparator = NO;
-      int keyMask;
+      NSNumber *keyMask;
 
       if ([aDecoder containsValueForKey: @"NSIsSeparator"])
         {
@@ -703,10 +703,18 @@ static Class imageClass;
           [self setSubmenu: submenu];
         }
 
-      // Set the key mask regardless of whether it is present;
-      // i.e. set it to 0 if it is not present in the nib.
-      keyMask = [aDecoder decodeIntForKey: @"NSKeyEquivModMask"];
-      [self setKeyEquivalentModifierMask: keyMask];
+      // Set the key mask when it is present; or default to NSCommandKeyMask
+      // when not specified
+      keyMask = (NSNumber*)[aDecoder decodeObjectForKey: @"NSKeyEquivModMask"];
+
+      if (keyMask != nil)
+        {
+          [self setKeyEquivalentModifierMask: [keyMask intValue]];
+        }
+      else
+        {
+          [self setKeyEquivalentModifierMask: NSCommandKeyMask];
+        }
 
       if ([aDecoder containsValueForKey: @"NSMnemonicLoc"])
         {

--- a/Tests/gui/GSXib5KeyedUnarchiver/ButtonCell.xib
+++ b/Tests/gui/GSXib5KeyedUnarchiver/ButtonCell.xib
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication"/>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+
+        <matrix id="matrix">
+            <!-- GNUstep requires a prototype (leaving it out results in a segfault); macOS does not -->
+            <buttonCell key="prototype"/>
+            <cells>
+                <column>
+                    <buttonCell type="push" title="Cell" id="cell1">
+                        <modifierMask key="keyEquivalentModifierMask" shift="YES"/>
+                    </buttonCell>
+                    <buttonCell type="push" title="Cell" id="cell2">
+                        <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                    </buttonCell>
+                    <buttonCell type="push" title="Cell" id="cell3">
+                        <modifierMask key="keyEquivalentModifierMask" />
+                    </buttonCell>
+                    <buttonCell type="push" title="Cell" id="cell4"/>
+                </column>
+            </cells>
+        </matrix>
+
+        <window title="Demo" animationBehavior="default" id="QvC-M9-y7g"/>
+    </objects>
+</document>

--- a/Tests/gui/GSXib5KeyedUnarchiver/Menu.xib
+++ b/Tests/gui/GSXib5KeyedUnarchiver/Menu.xib
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication"/>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+            <items>
+                <menuItem title="Item 1" keyEquivalent="1" id="MenuItem1">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                </menuItem>
+                <menuItem title="Item 2" keyEquivalent="2" id="MenuItem2">
+                    <modifierMask key="keyEquivalentModifierMask" shift="YES"/>
+                </menuItem>
+                <menuItem title="Item 3" keyEquivalent="3" id="MenuItem3">
+                    <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                </menuItem>
+                <menuItem title="Item 4" keyEquivalent="4" id="MenuItem4">
+                    <modifierMask key="keyEquivalentModifierMask" option="YES"/>
+                </menuItem>
+                <menuItem title="Item 5" keyEquivalent="5" id="MenuItem5"/>
+                <menuItem title="Item 6" id="MenuItem6"/>
+                <!-- same tests, but now with keyEquivalent node -->
+                <menuItem title="Item 7" id="MenuItem7">
+                    <string key="keyEquivalent" base64-UTF8="YES">CA</string>
+                </menuItem>
+                <menuItem title="Item 8" id="MenuItem8">
+                    <string key="keyEquivalent" base64-UTF8="YES">CA</string>
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                </menuItem>
+                <menuItem title="Item 9" id="MenuItem9">
+                    <string key="keyEquivalent" base64-UTF8="YES">CA</string>
+                    <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                </menuItem>
+            </items>
+            <point key="canvasLocation" x="200" y="121"/>
+        </menu>
+        <window title="Demo" animationBehavior="default" id="QvC-M9-y7g"/>
+    </objects>
+</document>

--- a/Tests/gui/GSXib5KeyedUnarchiver/buttonCell.m
+++ b/Tests/gui/GSXib5KeyedUnarchiver/buttonCell.m
@@ -1,0 +1,58 @@
+#import "ObjectTesting.h"
+
+#import <Foundation/NSData.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSEvent.h>
+#import <AppKit/NSMatrix.h>
+#import <Additions/GNUstepGUI/GSXibKeyedUnarchiver.h>
+
+#define PASS_MODIFIER(index, expected) PASS([[cells objectAtIndex:index] keyEquivalentModifierMask] == expected, "Modifier mask 0x%x equals expected 0x%x", [[cells objectAtIndex:index] keyEquivalentModifierMask], expected);
+
+int main()
+{
+	START_SET("GSXib5KeyedUnarchiver NSButtonCell tests")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException ])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  NSData* data = [NSData dataWithContentsOfFile:@"ButtonCell.xib"];
+  GSXibKeyedUnarchiver* unarchiver = [GSXibKeyedUnarchiver unarchiverForReadingWithData:data];
+
+  NSArray *rootObjects;
+  rootObjects = [unarchiver decodeObjectForKey: @"IBDocument.RootObjects"];
+
+  NSMatrix* matrix;
+
+  for (id element in rootObjects) {
+      if ([element isKindOfClass:[NSMatrix class]]) {
+          matrix = (NSMatrix*)element;
+          break;
+      }
+  }
+
+  PASS(matrix != nil, "Top-level NSMatrix was found");
+
+  NSArray* cells = [matrix cells];
+
+  // <modifierMask key="keyEquivalentModifierMask" shift="YES"/> node
+  PASS_MODIFIER(0, NSShiftKeyMask);
+
+  // <modifierMask key="keyEquivalentModifierMask" command="YES"/> node
+  PASS_MODIFIER(1, NSCommandKeyMask);
+
+  // <modifierMask key="keyEquivalentModifierMask" />
+  PASS_MODIFIER(2, 0);
+
+  // Unlike NSMenuItem, the default for NSButtonCell is 0
+  PASS_MODIFIER(3, 0);
+  
+	END_SET("GSXib5KeyedUnarchiver NSButtonCell tests")
+}

--- a/Tests/gui/GSXib5KeyedUnarchiver/menu.m
+++ b/Tests/gui/GSXib5KeyedUnarchiver/menu.m
@@ -1,0 +1,64 @@
+#import "ObjectTesting.h"
+
+#import <Foundation/NSData.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSEvent.h>
+#import <Additions/GNUstepGUI/GSXibKeyedUnarchiver.h>
+
+#define PASS_MODIFIER(index, expected) PASS([[menu itemAtIndex:index] keyEquivalentModifierMask] == expected, "Modifier mask 0x%x equals expected 0x%x", [[menu itemAtIndex:index] keyEquivalentModifierMask], expected);
+
+int main()
+{
+	START_SET("GSXib5KeyedUnarchiver NSMenu tests")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException ])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  NSData* data = [NSData dataWithContentsOfFile:@"Menu.xib"];
+  GSXibKeyedUnarchiver* unarchiver = [GSXibKeyedUnarchiver unarchiverForReadingWithData:data];
+
+  NSArray *rootObjects;
+  rootObjects = [unarchiver decodeObjectForKey: @"IBDocument.RootObjects"];
+
+  NSMenu* menu;
+
+  for (id element in rootObjects) {
+      if ([element isKindOfClass:[NSMenu class]]) {
+          menu = (NSMenu*)element;
+          break;
+      }
+  }
+
+  PASS(menu != nil, "Top-level NSMenu was found");
+
+
+  // Empty <modifierMask key="keyEquivalentModifierMask"/> node
+  PASS_MODIFIER(0, 0);
+  // <modifierMask key="keyEquivalentModifierMask" shift="YES"/>
+  PASS_MODIFIER(1, NSShiftKeyMask);
+  // <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+  PASS_MODIFIER(2, NSCommandKeyMask);
+  // <modifierMask key="keyEquivalentModifierMask" option="YES"/>
+  PASS_MODIFIER(3, NSAlternateKeyMask);
+  // No modifierMask element
+  PASS_MODIFIER(4, NSCommandKeyMask);
+  // No modifierMask element and no keyEquivalent attribute
+  PASS_MODIFIER(5, NSCommandKeyMask);
+
+  // no modfierMask
+  PASS_MODIFIER(6, NSCommandKeyMask);
+  // empty modifierMask
+  PASS_MODIFIER(7, 0);
+  // explicit modifier mask
+  PASS_MODIFIER(8, NSCommandKeyMask);
+  
+	END_SET("GSXib5KeyedUnarchiver NSMenu tests")
+}


### PR DESCRIPTION
The `keyEquivalentModifierMask` modifier mask:
- Maps to `NSKeyEquivModMask` for `NSMenuItem`
- Is packed in the `ButtonFlags2` value for `NSButtonCell`

If a `keyEquivalentModifierMask` element is not present, a default value is used (`NSCommandKeyMask` for `NSMenuItem` and `0` for `NSButtonCell`).  The presence of a `keyEquivalent` element does not influence this behavior.

This commit:
1. Updates `[GSXib5KeyedUnarchiver decodeModifierMaskForElement]` to return a `NSNumber`, so that it can signal the absence of the `keyEquivalentModifierMask` element by returning `nil` and the presence of a `keyEquivalentModifierMask` with no modifier flags set by returning `0`
2. Updates `[GSXib5KeyedUnarchiver decodeButtonFlags2ForElement]` to shift the modifier mask left by 8 bits when storing it in the `NSButtonFlags2` value.
3. Adds unit tests to test for this behavior.

This brings the bavior in line with that observed on macOS.