### PR TITLE
Update nsmapping.strings

### DIFF
--- a/Images/nsmapping.strings
+++ b/Images/nsmapping.strings
@@ -27,6 +27,7 @@ NSHighlightedRadioButton = GSRadioSelected;
 GNUstepMenuImage = GSApplicationMenuIcon;
 AppleMenuImage = GSApplicationMenuIcon;
 common_3DArrowRight = GSMenuArrow;
+common_3DArrowRightH = NSHighlightedMenuArrow;
 NSMenuArrow = GSMenuArrow;
 common_2DCheckMark = GSMenuSelected;
 NSMenuCheckmark = GSMenuSelected;


### PR DESCRIPTION
Fixed the visual menu/browser arrow glitch where it didn't change the image when highlighted. This file was missing the "common_3DArrowRightH = NSHighlightedMenuArrow;" line.