### PR TITLE
Revert to defaultParagraphStyle tab stops from 10 years ago

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,8 @@
-2024-05-12  Adam Fox <adam.fox@keysight.com>
+2024-05-13  Adam Fox <adam.fox@keysight.com>
 
-	* Source/NSParagraphStyle.m (+defaultParagraphStyle): Restore
-	tabs in default paragraph style and move it to -init.
+	* Source/NSParagraphStyle.m (-init): Apply the old default
+	tab stop behavior from +defaultParagraphStyle to -init,
+	and therefore also to +defaultParagraphStyle.
 
 2024-03-18 Fred Kiefer <FredKiefer@gmx.de>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-05-12  Adam Fox <adam.fox@keysight.com>
+
+	* Source/NSParagraphStyle.m (+defaultParagraphStyle): Restore
+	tabs in default paragraph style and move it to -init.
+
 2024-03-18 Fred Kiefer <FredKiefer@gmx.de>
 
 	* Source/NSTextView.m: Add support for NSFilenamenPboardType.

--- a/Source/NSParagraphStyle.m
+++ b/Source/NSParagraphStyle.m
@@ -300,7 +300,7 @@ static NSParagraphStyle	*defaultStyle = nil;
 
           tab = [[NSTextTab alloc] initWithType: NSLeftTabStopType
                                    location: (i + 1) * 28.0];
-          [style->_tabStops addObject: tab];
+          [_tabStops addObject: tab];
           RELEASE(tab);
         }
     }

--- a/Source/NSParagraphStyle.m
+++ b/Source/NSParagraphStyle.m
@@ -214,7 +214,6 @@ static NSParagraphStyle	*defaultStyle = nil;
   if (defaultStyle == nil)
     {
       NSParagraphStyle	*style = [[self alloc] init];
-      /*
       int		i;
 
       for (i = 0; i < 12; i++)
@@ -226,7 +225,6 @@ static NSParagraphStyle	*defaultStyle = nil;
           [style->_tabStops addObject: tab];
           RELEASE(tab);
         }
-      */
       defaultStyle = style;
     }
   return defaultStyle;

--- a/Source/NSParagraphStyle.m
+++ b/Source/NSParagraphStyle.m
@@ -214,17 +214,6 @@ static NSParagraphStyle	*defaultStyle = nil;
   if (defaultStyle == nil)
     {
       NSParagraphStyle	*style = [[self alloc] init];
-      int		i;
-
-      for (i = 0; i < 12; i++)
-        {
-          NSTextTab	*tab;
-
-          tab = [[NSTextTab alloc] initWithType: NSLeftTabStopType
-                                   location: (i + 1) * 28.0];
-          [style->_tabStops addObject: tab];
-          RELEASE(tab);
-        }
       defaultStyle = style;
     }
   return defaultStyle;
@@ -290,6 +279,8 @@ static NSParagraphStyle	*defaultStyle = nil;
 {
   if ((self = [super init]))
     {
+      int i;
+    
       _alignment = NSNaturalTextAlignment;
       //_firstLineHeadIndent = 0.0;
       //_headIndent = 0.0;
@@ -302,6 +293,16 @@ static NSParagraphStyle	*defaultStyle = nil;
       _baseDirection = NSWritingDirectionNaturalDirection;
       _tabStops = [[NSMutableArray allocWithZone: [self zone]] 
                       initWithCapacity: 12];
+
+      for (i = 0; i < 12; i++)
+        {
+          NSTextTab *tab;
+
+          tab = [[NSTextTab alloc] initWithType: NSLeftTabStopType
+                                   location: (i + 1) * 28.0];
+          [style->_tabStops addObject: tab];
+          RELEASE(tab);
+        }
     }
   return self;
 }


### PR DESCRIPTION
As we are trying to move away from using our own custom forks and branches of GNUstep, we discovered this discrepancy between the main fork/branch and ours, and without this block of code, the tab stops on GNUstep platforms now have approximately twice as wide tab stops.  Looking back at [the commit that commented this block out 10 years ago](https://github.com/gnustep/libs-gui/commit/47dc5486848644580ab62678b35373c29738fa67), looks like the reason was:

```
Comment out tabs in default paragraph style as Apple doesn't seem to have them.
```

So, one way or another, we need to fix this in our product, and it seems there is a visual discrepancy between Apple and GNUstep.  We can fix it in our product by going through all the places we're currently leveraging the defaultParagraphStyle and using a custom style instead, but we wanted to figure out what the general consensus is here before doing that.