### PR TITLE
Modal display not on top for some platforms

### DIFF
--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -1785,6 +1785,7 @@ static BOOL _isAutolaunchChecked = NO;
 	  /*
 	   * Try to handle events for this session, discarding others.
 	   */
+    	  [theSession->window orderFrontRegardless];
 	  code = [self runModalSession: theSession];
 	  if (code == NSRunContinuesResponse)
 	    {

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -1677,7 +1677,7 @@ static BOOL _isAutolaunchChecked = NO;
           [theWindow center];
       [theWindow setLevel: NSModalPanelWindowLevel];
     }
-  [theWindow orderFrontRegardless];
+  
   if ([self isActive] == YES)
     {
       if ([theWindow canBecomeKeyWindow] == YES)
@@ -1689,6 +1689,7 @@ static BOOL _isAutolaunchChecked = NO;
 	  [theWindow makeMainWindow];
 	}
     }
+  [theWindow orderFrontRegardless];
 
   return theSession;
 }

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -1785,7 +1785,6 @@ static BOOL _isAutolaunchChecked = NO;
 	  /*
 	   * Try to handle events for this session, discarding others.
 	   */
-    	  [theSession->window orderFrontRegardless];
 	  code = [self runModalSession: theSession];
 	  if (code == NSRunContinuesResponse)
 	    {


### PR DESCRIPTION
The problem we have seen is that on some platforms (such as Redhat 8) modal windows, specifically NSAlert, are not reliably appearing above the other windows.

By moving the `orderFrontRegardless` call to a little later in the `beginModalSessionForWindow:` method, this appears to reliably display on top as expected.