### PR TITLE
Add APPKIT_EXPORT_CLASS, APPKIT_EXPORT annotations

### DIFF
--- a/Headers/Additions/GNUstepGUI/GSHbox.h
+++ b/Headers/Additions/GNUstepGUI/GSHbox.h
@@ -169,6 +169,7 @@
 
   </unit>
 */
+APPKIT_EXPORT_CLASS
 @interface GSHbox: GSTable
 {
   BOOL _haveViews;

--- a/Headers/Additions/GNUstepGUI/GSPrintOperation.h
+++ b/Headers/Additions/GNUstepGUI/GSPrintOperation.h
@@ -44,7 +44,7 @@
 @class NSView;
 @class NSPrintInfo;
 
-
+APPKIT_EXPORT_CLASS
 @interface GSPrintOperation: NSPrintOperation
 {
 }

--- a/Headers/Additions/GNUstepGUI/GSTable.h
+++ b/Headers/Additions/GNUstepGUI/GSTable.h
@@ -171,6 +171,7 @@
   </section>
   </unit>
 */
+APPKIT_EXPORT_CLASS
 @interface GSTable: NSView
 {
   int _numberOfRows;

--- a/Source/GSGuiPrivate.h
+++ b/Source/GSGuiPrivate.h
@@ -32,6 +32,7 @@
 
 #import <Foundation/NSBundle.h>
 #import <Foundation/NSCoder.h>
+#import "AppKit/AppKitDefines.h"
 #include "GNUstepBase/GSConfig.h"
 #include <math.h>
 
@@ -40,7 +41,7 @@
  * Should be only used inside the gnustep-gui library.  Implemented
  * in Source/NSApplication.m
  */
-NSBundle *GSGuiBundle (void);
+APPKIT_EXPORT NSBundle *GSGuiBundle (void);
 
 /*
  * Localize a message of the gnustep-gui library.  


### PR DESCRIPTION
Some GS* classes and methods are used by the ColorPicker or Printing bundles.  That means that they are referenced from an external module.  For this module to be able to resolve these symbols, on Windows, they need to be exported.

This commit adds `APPKIT_EXPORT_CLASS` and `APPKIT_EXPORT` annotations, allowing ColorPickers and Printing bundles to compile on Windows using a native (non-mingw) toolchain.