### PR TITLE
GSMemoryPanel: Only call GSDebug* in debug mode

### DIFF
--- a/Source/GSMemoryPanel.m
+++ b/Source/GSMemoryPanel.m
@@ -191,7 +191,9 @@ static GSMemoryPanel *sharedGSMemoryPanel = nil;
   NSButton *button;
 
   /* Activate debugging of allocation. */
+#ifndef	NDEBUG
   GSDebugAllocationActive (YES);
+#endif
 
   hbox = [GSHbox new];
   [hbox setDefaultMinXMargin: 5];
@@ -359,6 +361,7 @@ static GSMemoryPanel *sharedGSMemoryPanel = nil;
 
 - (void) update: (id)sender
 {
+#ifndef NDEBUG
   Class *classList = GSDebugAllocationClassList ();
   Class *pointer;
   GSMemoryPanelEntry *entry;
@@ -388,6 +391,7 @@ static GSMemoryPanel *sharedGSMemoryPanel = nil;
   NSZoneFree(NSDefaultMallocZone(), classList);
 
   [array sortUsingSelector: orderingBy];
+#endif
 
   [table reloadData];
 }


### PR DESCRIPTION
The GSDebug* methods are conditional on NDEBUG not being defined; so do not attempt to call these methods if this variable is not set.

The current implementation causes a build warning/error:

```
error: call to undeclared function 'GSDebugAllocationActive'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```