### PR TITLE
implement integerValue method in NSSliderCell

### DIFF
--- a/Source/NSSliderCell.m
+++ b/Source/NSSliderCell.m
@@ -658,6 +658,11 @@ double _doubleValueForMousePoint (NSPoint point, NSRect knobRect,
     }
 }
 
+- (NSInteger) integerValue
+{
+  return (NSInteger)_value;
+}
+
 - (id) objectValue
 {
   return [NSNumber numberWithDouble: _value];


### PR DESCRIPTION
When you call setIntegerValue: method on an NSSliderCell, it calls the superclass method in NSCell, which then calls setObjectValue:. The implementation of setObjectValue: in NSSliderCell sets the _value ivar. The problem is, when you call integerValue: it calls the superclass method in NSCell, which returns a value based on the _object_value ivar, which has not been set.
By implementing the integerValue: method directly in NSSliderCell, this will return the correct value.