### PR TITLE
Make NSMenu Extensible

### DIFF
--- a/Headers/AppKit/NSMenu.h
+++ b/Headers/AppKit/NSMenu.h
@@ -410,7 +410,7 @@ APPKIT_EXPORT_CLASS
 		unsigned int unused: 25;
   } _menu;
 
-@private
+@protected
   NSWindow *_aWindow;
   NSWindow *_bWindow;
   NSMenu *_oldAttachedMenu;


### PR DESCRIPTION
Using newer versions of clang @protected is not accesible in extended classes, and https://github.com/gnustep/plugins-themes-WinUXTheme requires aWindow. Making them protected fixes this issue.