### PR TITLE
Just call update on all submenus instead of ones that are visible

### DIFF
--- a/Source/NSMenu.m
+++ b/Source/NSMenu.m
@@ -916,31 +916,6 @@ static BOOL menuBarVisible = YES;
   return _menu.autoenable;
 }
 
-- (void) _updateSubmenu
-{
-  if ([self _isVisible])
-    {
-      // Update the menu items when the menu is visible...
-      [self update];
-    }
-  else
-    {
-      // ...else only progress to submenus
-      NSUInteger i;
-      NSUInteger count = [_items count];
-
-      for (i = 0; i < count; i++)
-        {
-          NSMenuItem *item = [_items objectAtIndex: i];
-          
-          if ([item hasSubmenu])
-            {
-              [[item submenu] _updateSubmenu];
-            }
-        }
-    }
-}
-
 - (void) _updateMenuWithDelegate
 {
   if ([_delegate respondsToSelector: @selector(menuNeedsUpdate:)])

--- a/Source/NSMenu.m
+++ b/Source/NSMenu.m
@@ -1068,7 +1068,7 @@ static BOOL menuBarVisible = YES;
 
 	      if ([item hasSubmenu])
                 {
-                  [[item submenu] _updateSubmenu];
+                  [[item submenu] update];
                 }
 
               [self _autoenableItem: item];


### PR DESCRIPTION
In Windows qualifying update on visible means a lot of menus don't get updated. This just updates all the menu items.

The current `_updateSubmenu` method calls `update` if it is visible but otherwise goes through the submenu items and then calls `_updateSubmenu` on those. So just calling `update` will do the same thing but without testing for `_isVisible`.