### PR TITLE
Fix alternateContents in NSButtonCell

### DIFF
--- a/Source/NSButtonCell.m
+++ b/Source/NSButtonCell.m
@@ -1752,7 +1752,19 @@
         }
       if ([aDecoder containsValueForKey: @"NSAlternateContents"])
         {
-          [self setAlternateTitle: [aDecoder decodeObjectForKey: @"NSAlternateContents"]];
+	  id alternateContents = [aDecoder decodeObjectForKey: @"NSAlternateContents"];
+          if ([alternateContents isKindOfClass:[NSString class]]) 
+	    {
+              [self setAlternateTitle:alternateContents];
+	    }
+          else if ([alternateContents isKindOfClass:[NSImage class]]) 
+	    {
+              [self setAlternateImage:alternateContents];
+	    }
+          else 
+	    {
+	      NSLog(@"Invalid class for NSAlternateContents: %@", [alternateContents class]);
+            }
         }
       if ([aDecoder containsValueForKey: @"NSButtonFlags"])
         {


### PR DESCRIPTION
GSXib5KeyedUnarchiver can place either an NSString or an NSImage for the key "NSAlternateContents". So this checks which one it is and sets either alternateTitle or alternateImage as appropriate. Previously, it was setting alternateTitle, which, if it were an NSImage, resulted in a crash.