### PR TITLE
Allow themes to override `[NSMenu _isVisible]`

### DIFF
--- a/Headers/Additions/GNUstepGUI/GSTheme.h
+++ b/Headers/Additions/GNUstepGUI/GSTheme.h
@@ -1569,6 +1569,12 @@ withRepeatedImage: (NSImage*)image
 - (void) organizeMenu: (NSMenu *)menu
 	 isHorizontal: (BOOL)horizontal;
 
+/**
+ * Used by the theme to override the proposed menu visibility.  The default
+ * implementation simply returns the proposed visibility unmodified.
+ */
+- (BOOL) proposedVisibility: (BOOL)visible
+	 forMenu: (NSMenu *) menu;
 @end 
 
 @interface GSTheme (OpenSavePanels)

--- a/Source/GSThemeMenu.m
+++ b/Source/GSThemeMenu.m
@@ -418,5 +418,11 @@
   [[menu menuRepresentation] update];
   [menu sizeToFit];
 }
+
+- (BOOL) proposedVisibility: (BOOL)visible
+	 forMenu: (NSMenu *) menu
+{
+  return visible;
+}
 @end
 

--- a/Source/NSMenu.m
+++ b/Source/NSMenu.m
@@ -383,7 +383,8 @@ static BOOL menuBarVisible = YES;
 
 - (BOOL) _isVisible
 {
-  return [_aWindow isVisible] || [_bWindow isVisible];
+  BOOL isVisible = [_aWindow isVisible] || [_bWindow isVisible];
+  return [[GSTheme theme] proposedVisibility: isVisible forMenu: self];
 }
 
 - (BOOL) _isMain


### PR DESCRIPTION
The default implementation of `[NSMenu]` uses `_aWindow` and `_bWindow` to determine the visibility of the menu.  Not all themes use these windows to build a menu.  For example, the WinUXTheme will use Win32 APIs to build a menu.

Allow themes to override the value of `[NSMenu _isVisible]` by introducing a `[GSTheme proposedVisibility: (BOOL)visible forMenu: (NSMenu *) menu]` method.  The default implementation simply returns the proposed visibility.