### PR TITLE
NSTextFieldCell: Decode placeholder string

### DIFF
--- a/Source/NSTextFieldCell.m
+++ b/Source/NSTextFieldCell.m
@@ -359,6 +359,11 @@
           [self setBezelStyle: [aDecoder decodeIntForKey: 
                                              @"NSTextBezelStyle"]];
         }
+      if ([aDecoder containsValueForKey: @"NSPlaceholderString"])
+        {
+          [self setPlaceholderString: [aDecoder decodeObjectForKey: 
+                                             @"NSPlaceholderString"]];
+        }
     }
   else
     {


### PR DESCRIPTION
Support decoding the `placeholderString`  value from Xib files. For example, consider the following snippet:

```xml
<textFieldCell [...] placeholderString="Default">
</textFieldCell>
```

In the current implementation, the value of `placeholderString` was not being deserialized.