### PR TITLE
Make white as default selection highlight color for NSTableView

### DIFF
--- a/Source/GSThemeDrawing.m
+++ b/Source/GSThemeDrawing.m
@@ -3319,9 +3319,9 @@ static NSDictionary *titleTextAttributes[3] = {nil, nil, nil};
 
     if (selectionColor == nil)
       {
-	selectionColor = [NSColor colorWithCalibratedRed: 0.86
-						   green: 0.92
-						    blue: 0.99
+	selectionColor = [NSColor colorWithCalibratedRed: 1.0
+						   green: 1.0
+						    blue: 1.0
 						   alpha: 1.0];
       }
     [selectionColor set];


### PR DESCRIPTION
Currently default highlight color is light blue which is not correct for default theme.