### PR TITLE
Update bounds on NSClipView in setFrame only when frame value has changed

### DIFF
--- a/Source/NSClipView.m
+++ b/Source/NSClipView.m
@@ -565,9 +565,24 @@ static inline NSRect integralRect (NSRect rect, NSView *view)
 
 - (void) setFrame: (NSRect)rect
 {
+  BOOL changedOrigin = NO;
+  BOOL changedSize = NO;
+  if (NSEqualPoints(_frame.origin, rect.origin) == NO)
+    {
+      changedOrigin = YES;
+    }
+  if (NSEqualSizes(_frame.size, rect.size) == NO)
+    {
+      changedSize = YES;
+    }
   [super setFrame: rect];
-  [self setBoundsOrigin: [self constrainScrollPoint: _bounds.origin]];
-  [_super_view reflectScrolledClipView: self];
+
+  if (changedOrigin || changedSize) 
+    {
+      NSPoint proposedPoint = [self constrainScrollPoint: _bounds.origin];
+      [self setBoundsOrigin: proposedPoint];
+      [_super_view reflectScrolledClipView: self];
+    }
 }
 
 - (void) translateOriginToPoint: (NSPoint)aPoint


### PR DESCRIPTION
We are seeing a loop occur where the NSTextFieldCell calls _drawEditorWithFrame:inView: which then calls setFrame: on the NSClipView which then sets the boundsOrigin on the NSClipView based on contrainScrollPoint:. The problem is the constrainScrollPoint: causes the origin to shift by 0.5, so then needsDisplay is set on the clip view, which triggers another draw, and then constrainsScrollPoint: shifts the origin back by 0.5, so it does it again, and again...

The frame being set, however, is the same every time. So this just checks if the frame is actually a new frame, and if not it treats the call as no-op, which is what the super call to setFrame: does.