### PR TITLE
Fix issue with nsmenu items blocking the GUI

### DIFF
--- a/Source/NSMenuView.m
+++ b/Source/NSMenuView.m
@@ -1832,6 +1832,11 @@ static float menuBarHeight = 0.0;
 					inMode: NSEventTrackingRunLoopMode
 				       dequeue: YES];
 	  type = [event type];
+    if (type == NSLeftMouseUp || type == NSRightMouseUp || type == NSOtherMouseUp)
+      {
+          shouldFinish = YES;
+          break;  // Exit the loop to proceed to StopPeriodicEvents
+      }
 	  if (type == NSAppKitDefined)
 	    {
 	      [[event window] sendEvent: event];


### PR DESCRIPTION
This MR fixes an issue where when you click item an NSMenuView item you have a frozen UI until you double click a second time, ending the loop. 