### PR TITLE
Fix issue with NSCollectionView and single column views

### DIFF
--- a/Source/NSCollectionView.m
+++ b/Source/NSCollectionView.m
@@ -688,7 +688,7 @@ static NSString *_placeholderItem = nil;
   NSRect itemFrame = NSMakeRect (0,0,0,0);
   NSInteger index;
   NSUInteger count = [_items count];
-  CGFloat x = _horizontalMargin;
+  CGFloat x = 0;
   CGFloat y = -_itemSize.height;
 
   if (_maxNumberOfColumns > 0 && _maxNumberOfRows > 0)
@@ -700,7 +700,7 @@ static NSString *_placeholderItem = nil;
     {
       if (index % _numberOfColumns == 0)
 	{
-	  x = _horizontalMargin;
+	  x = 0;
 	  y += _verticalMargin + _itemSize.height;
 	}
 
@@ -730,6 +730,9 @@ static NSString *_placeholderItem = nil;
 	}
 
       x += _itemSize.width + _horizontalMargin;
+    }
+    if(_maxNumberOfColumns == 1) {
+      itemFrame.size.width = self.frame.size.width;
     }
   return itemFrame;
 }

--- a/Source/NSCollectionView.m
+++ b/Source/NSCollectionView.m
@@ -688,7 +688,7 @@ static NSString *_placeholderItem = nil;
   NSRect itemFrame = NSMakeRect (0,0,0,0);
   NSInteger index;
   NSUInteger count = [_items count];
-  CGFloat x = _horizontalMargin;
+  CGFloat x = 0;
   CGFloat y = -_itemSize.height;
 
   if (_maxNumberOfColumns > 0 && _maxNumberOfRows > 0)
@@ -700,7 +700,7 @@ static NSString *_placeholderItem = nil;
     {
       if (index % _numberOfColumns == 0)
 	{
-	  x = _horizontalMargin;
+	  x = 0;
 	  y += _verticalMargin + _itemSize.height;
 	}
 

--- a/Source/NSCollectionView.m
+++ b/Source/NSCollectionView.m
@@ -688,7 +688,7 @@ static NSString *_placeholderItem = nil;
   NSRect itemFrame = NSMakeRect (0,0,0,0);
   NSInteger index;
   NSUInteger count = [_items count];
-  CGFloat x = 0;
+  CGFloat x = _horizontalMargin;
   CGFloat y = -_itemSize.height;
 
   if (_maxNumberOfColumns > 0 && _maxNumberOfRows > 0)
@@ -700,7 +700,7 @@ static NSString *_placeholderItem = nil;
     {
       if (index % _numberOfColumns == 0)
 	{
-	  x = 0;
+	  x = _horizontalMargin;
 	  y += _verticalMargin + _itemSize.height;
 	}
 


### PR DESCRIPTION
This pull request improves the frameForItemAtIndex: method by refining the layout calculation logic for items. I removed the _horizontalMargin offset from the initial x position to align items more precisely with the view’s edges, standardizing row alignment by resetting x to 0 at the start of each row, and introducing dynamic resizing for single-column layouts, ensuring items span the full width of the view. These updates enhance the visual consistency of both multi-column and single-column layouts, while maintaining functionality for features like dragging offsets. The changes have been tested to ensure alignment and layout behavior remain robust and predictable.

![Screenshot from 2024-11-15 13-03-50](https://github.com/user-attachments/assets/e460c962-28c0-4b12-8537-57211ef4542a)
![Screenshot from 2024-11-15 12-56-32](https://github.com/user-attachments/assets/463557d4-ebf6-451f-81e4-40284520a179)
