### PR TITLE
GSColorSliderCell: Move to libs-gui

### DIFF
--- a/ColorPickers/GNUmakefile
+++ b/ColorPickers/GNUmakefile
@@ -34,7 +34,7 @@ BUNDLE_NAME = StandardPicker NamedPicker WheelPicker
 
 BUNDLE_INSTALL_DIR = $(GNUSTEP_LIBRARY)/ColorPickers
 
-ADDITIONAL_INCLUDE_DIRS += -I../Headers/Additions -I../Headers
+ADDITIONAL_INCLUDE_DIRS += -I../Headers/Additions -I../Headers -I../Source
 
 ADDITIONAL_LIB_DIRS += -L../Source/$(GNUSTEP_OBJ_DIR) -L../Models/$(GNUSTEP_OBJ_DIR)
 
@@ -43,10 +43,9 @@ StandardPicker_OBJC_FILES =  	GSStandardColorPicker.m \
 			     	GSRGBColorPicker.m \
 				GSCMYKColorPicker.m \
 				GSHSBColorPicker.m \
-				GSGrayColorPicker.m \
-				GSColorSliderCell.m
+				GSGrayColorPicker.m
 NamedPicker_OBJC_FILES =  GSNamedColorPicker.m
-WheelPicker_OBJC_FILES =  GSWheelColorPicker.m GSColorSliderCell.m
+WheelPicker_OBJC_FILES =  GSWheelColorPicker.m
 
 # The class to load
 StandardPicker_PRINCIPAL_CLASS = GSStandardColorPicker

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -373,7 +373,8 @@ GSCSLinearExpression.m \
 GSCSStrength.m \
 GSCSEditInfo.m \
 GSCSEditVariableManager.m \
-GSCSTableau.m
+GSCSTableau.m \
+GSColorSliderCell.m
 
 # Turn off NSMenuItem warning that NSMenuItem conforms to <NSObject>,
 # but does not implement <NSObject>'s methods itself (it inherits

--- a/Source/GSColorSliderCell.h
+++ b/Source/GSColorSliderCell.h
@@ -31,6 +31,7 @@
 
 #include <AppKit/NSSliderCell.h>
 
+APPKIT_EXPORT_CLASS
 @interface GSColorSliderCell : NSSliderCell
 {
   int mode;

--- a/Source/GSColorSliderCell.m
+++ b/Source/GSColorSliderCell.m
@@ -1,4 +1,4 @@
-/* GSStandardColorPicker.m
+/* GSColorSliderCell.m
 
    Copyright (C) 2007 Free Software Foundation, Inc.
 


### PR DESCRIPTION
This class is shared between the StandardPicker bundle and the WheelPicker bundles.  Exposing a class with the same name in two separate bundles results in undefined behavior.  Move this class to a shared module (libs-gui in this case) to resolve that.