### PR TITLE
Fix issues with non-keyed encoding/decoding of NSPopUpButton

### DIFF
--- a/Source/NSPopUpButtonCell.m
+++ b/Source/NSPopUpButtonCell.m
@@ -654,7 +654,6 @@ static NSImage *_pbc_image[5];
       [_menuItem setImage: nil];
     }
 
-  //[super setMenuItem: item];
   ASSIGN(_menuItem, item);
 
   if ([_menuItem image] == nil)
@@ -1321,7 +1320,7 @@ static NSImage *_pbc_image[5];
     }
   else
     {
-      NSInteger flag;
+      NSInteger flag, pullsDown;
       id<NSMenuItem> selectedItem;
       int version = [aDecoder versionForClassName: 
                                   @"NSPopUpButtonCell"];
@@ -1336,8 +1335,7 @@ static NSImage *_pbc_image[5];
       [self setMenu: nil];
       [self setMenu: menu];
       selectedItem = [aDecoder decodeObject];
-      decode_NSInteger(aDecoder, &flag);
-      [self setPullsDown: flag];
+      decode_NSInteger(aDecoder, &pullsDown);
       decode_NSInteger(aDecoder, &flag);
       [self setPreferredEdge: flag];
       decode_NSInteger(aDecoder, &flag);
@@ -1347,6 +1345,7 @@ static NSImage *_pbc_image[5];
       decode_NSInteger(aDecoder, &flag);
       [self setArrowPosition: flag];
       [self setMenuItem: (NSMenuItem *)selectedItem];
+      [self setPullsDown: pullsDown];
 
       if (version < 2)
         {

--- a/Source/NSPopUpButtonCell.m
+++ b/Source/NSPopUpButtonCell.m
@@ -609,6 +609,7 @@ static NSImage *_pbc_image[5];
 
       if (_pbcFlags.preferredEdge == NSMaxYEdge)
         {
+	  NSLog(@"\tDOWN ARROW!!!!!!");
           return _pbc_image[1];
         }
       else if (_pbcFlags.preferredEdge == NSMaxXEdge)
@@ -1336,16 +1337,17 @@ static NSImage *_pbc_image[5];
       [self setMenu: menu];
       selectedItem = [aDecoder decodeObject];
       decode_NSInteger(aDecoder, &flag);
-      _pbcFlags.pullsDown = flag;
+      [self setPullsDown: flag];
       decode_NSInteger(aDecoder, &flag);
-      _pbcFlags.preferredEdge = flag;
+      [self setPreferredEdge: flag];
       decode_NSInteger(aDecoder, &flag);
-      _pbcFlags.usesItemFromMenu = flag;
+      [self setUsesItemFromMenu: flag];
       decode_NSInteger(aDecoder, &flag);
-      _pbcFlags.altersStateOfSelectedItem = flag;
+      [self setAltersStateOfSelectedItem: flag];
       decode_NSInteger(aDecoder, &flag);
-      _pbcFlags.arrowPosition = flag;
-      
+      [self setArrowPosition: flag];
+      [self setMenuItem: (NSMenuItem *)selectedItem];
+
       if (version < 2)
         {
           int i;
@@ -1371,6 +1373,22 @@ static NSImage *_pbc_image[5];
           [self setArrowPosition: NSPopUpArrowAtCenter];
         }
       [self selectItem: selectedItem];
+
+      NSEnumerator *menuItemEnumerator;
+      NSMenuItem *menuItem;
+
+      // FIXME: This special handling is needed bacause the NSClassSwapper
+      // might have replaced the cell, but the items still refere to it.
+      menuItemEnumerator = [[menu itemArray] objectEnumerator];
+
+      while ((menuItem = [menuItemEnumerator nextObject]) != nil)
+	{
+	  if (sel_isEqual([menuItem action], @selector(_popUpItemAction:))
+	      && ([menuItem target] != self))
+	    {
+	      [menuItem setTarget: self];
+	    }
+	}
     }
 
   return self;

--- a/Source/NSPopUpButtonCell.m
+++ b/Source/NSPopUpButtonCell.m
@@ -607,9 +607,10 @@ static NSImage *_pbc_image[5];
           return nil;
         }
 
+      NSLog(@"Arrow position = %d", [self arrowPosition]);
       if (_pbcFlags.preferredEdge == NSMaxYEdge)
         {
-	  NSLog(@"\tDOWN ARROW!!!!!!");
+	  NSLog(@"\tDOWN ARROW!!!!!! %d", [self arrowPosition]);
           return _pbc_image[1];
         }
       else if (_pbcFlags.preferredEdge == NSMaxXEdge)
@@ -1320,7 +1321,7 @@ static NSImage *_pbc_image[5];
     }
   else
     {
-      NSInteger flag, pullsDown;
+      NSInteger flag;
       id<NSMenuItem> selectedItem;
       int version = [aDecoder versionForClassName: 
                                   @"NSPopUpButtonCell"];
@@ -1335,6 +1336,18 @@ static NSImage *_pbc_image[5];
       [self setMenu: nil];
       [self setMenu: menu];
       selectedItem = [aDecoder decodeObject];
+      decode_NSInteger(aDecoder, &flag);
+      _pbcFlags.pullsDown = flag;
+      decode_NSInteger(aDecoder, &flag);
+      _pbcFlags.preferredEdge = flag;
+      decode_NSInteger(aDecoder, &flag);
+      _pbcFlags.usesItemFromMenu = flag;
+      decode_NSInteger(aDecoder, &flag);
+      _pbcFlags.altersStateOfSelectedItem = flag;
+      decode_NSInteger(aDecoder, &flag);
+      _pbcFlags.arrowPosition = flag;
+      /*
+      selectedItem = [aDecoder decodeObject];
       decode_NSInteger(aDecoder, &pullsDown);
       decode_NSInteger(aDecoder, &flag);
       [self setPreferredEdge: flag];
@@ -1344,8 +1357,16 @@ static NSImage *_pbc_image[5];
       [self setAltersStateOfSelectedItem: flag];
       decode_NSInteger(aDecoder, &flag);
       [self setArrowPosition: flag];
+      */
+      /*
+      if (_pbcFlags.pullsDown)
+	{
+	  [self setPreferredEdge: NSMinYEdge];
+	}
+      */
+      // [self setMenuItem: nil];
       [self setMenuItem: (NSMenuItem *)selectedItem];
-      [self setPullsDown: pullsDown];
+      // [self setPullsDown: pullsDown];
 
       if (version < 2)
         {


### PR DESCRIPTION
The pull down functionality of the NSPopUpButton appears to be broken when creating a gorm file.   This doesn't seem to be a problem when decoding a XIB file so.  I have narrowed it down to the non keyed encoding logic and incomplete support and set up in Gorm when creating the widget.