### PR TITLE
Fix computation for _overrideCLASSMethod_foo in GSTheme.m

### DIFF
--- a/Source/GSTheme.m
+++ b/Source/GSTheme.m
@@ -942,8 +942,8 @@ typedef	struct {
 	      mth = [[GSThemeMethod new] autorelease];
 	      types = method_getTypeEncoding(method);
 	      mth->imp = method_getImplementation(method);
-	      memcpy(buf, name + 9, (ptr - name) + 9);
-	      buf[(ptr - name) + 9] = '\0';
+	      memcpy(buf, name + 9, (ptr - name) - 9);
+	      buf[(ptr - name) - 9] = '\0';
 	      mth->cls = objc_lookUpClass(buf);
 	      if (mth->cls == 0)
 		{


### PR DESCRIPTION
  - start of string is (name+9)
  - 'ptr' is the end of the desired substring, so the length should be (ptr - (name + 9))  which is (ptr - name) - 9)

Looks like there was an implementation prior to 2010 that used this arithmetic.

Uncovered when I began a holiday project to update Rik.theme to compile with clang.
Test this modification with the updated theme here
   https://github.com/mclarenlabs/rik.theme

The theme still has many NSLog statements in it logging the overrides.  I will remove them
when this change is confirmed and the theme tested by someone else.  I've only tested with
clang on Debian12 so far, but it seems to be fine on a number of applications.  The animated
"Default" button is even working.

