### PR TITLE
Add method that tells the app/backend that we are using a dark mode theme

### DIFF
--- a/Headers/Additions/GNUstepGUI/GSTheme.h
+++ b/Headers/Additions/GNUstepGUI/GSTheme.h
@@ -784,7 +784,7 @@ APPKIT_EXPORT_CLASS
 - (NSString*) license;
 
 /**
- * Returns YES if in dark mode, and NO, if not.  The reasoning behind this
+ * Returns YES if in dark mode, or NO, if not.  The reasoning behind this
  * is that some applications may display on the screen in dark mode, but
  * print with the colors reversed.  This method allows GUI and the backend
  * to understand when we are using a dark theme and render accordingly when

--- a/Headers/Additions/GNUstepGUI/GSTheme.h
+++ b/Headers/Additions/GNUstepGUI/GSTheme.h
@@ -783,6 +783,15 @@ APPKIT_EXPORT_CLASS
  */
 - (NSString*) license;
 
+/**
+ * Returns YES if in dark mode, and NO, if not.  The reasoning behind this
+ * is that some applications may display on the screen in dark mode, but
+ * print with the colors reversed.  This method allows GUI and the backend
+ * to understand when we are using a dark theme and render accordingly when
+ * printing.  The default is NO, as the default theme is not a dark theme.
+ */
+- (BOOL) isDarkMode;
+
 @end
 
 /**

--- a/Headers/Additions/GNUstepGUI/GSTheme.h
+++ b/Headers/Additions/GNUstepGUI/GSTheme.h
@@ -784,13 +784,39 @@ APPKIT_EXPORT_CLASS
 - (NSString*) license;
 
 /**
- * Returns YES if in dark mode, or NO, if not.  The reasoning behind this
- * is that some applications may display on the screen in dark mode, but
- * print with the colors reversed.  This method allows GUI and the backend
- * to understand when we are using a dark theme and render accordingly when
- * printing.  The default is NO, as the default theme is not a dark theme.
+ * Returns YES if Theme is able to display in Light NSAppearance
+ * For a theme supporting both Light and Dark modes, it should return both
+ * supportsLightAppearance and supportsDarkAppearance
+ * Light is the "default" of the GNUstep theme like Cocoa Aqua.
  */
-- (BOOL) isDarkMode;
+- (BOOL) supportsLightAppearance;
+
+/**
+ * Returns YES if Theme is able to display in Dark NSAppearance
+ * For a theme supporting both Light and Dark modes, it should return both
+ * supportsLightAppearance and supportsDarkAppearance
+ * Light is the default Aqua and GNUstep "classic", but a GNUstep can be dark only.
+ */
+- (BOOL) supportsDarkAppearance;
+
+/**
+ * Returns YES if displaying in Light NSAppearance (or non-Dark)
+ * Should match if theme is equivalent to Cocoa names like
+ * NSAppearanceNameAqua or NSAppearanceNameAccessibilityHighContrastAqua
+ *
+ * Being only Light and Dark supported, must be opposite of inDarkAppearance
+ */
+- (BOOL) inLightAppearance;
+
+/**
+ * Returns YES if displaying in dark NSAppearance
+ * Should match if theme is equivalent to Cocoa names like
+ * NSAppearanceNameDarkAqua or NSAppearanceNameAccessibilityHighContrastDarkAqua
+ *
+ * Being only Light and Dark supported, must be opposite of inLightAppearance
+ */
+- (BOOL) inDarkAppearance;
+
 
 @end
 

--- a/Source/GSTheme.m
+++ b/Source/GSTheme.m
@@ -1339,11 +1339,68 @@ typedef	struct {
   return [[self infoDictionary] objectForKey: @"GSThemeLicense"];
 }
 
-- (BOOL) isDarkMode
+- (BOOL) supportsLightAppearance
 {
-  return [[[self infoDictionary] objectForKey: @"GSThemeDarkMode"]
-	   isEqualToString: @"YES"];
+  NSString *val;
+  BOOL r;
+
+  r = YES; // default themes are light
+  val = [[self infoDictionary] objectForKey: @"GSThemeSupportsLightAppearance"];
+
+  if (val && [val isEqualToString: @"YES"])
+    r =  YES;
+
+  return r;
 }
+
+- (BOOL) supportsDarkAppearance
+{
+  NSString *val;
+  BOOL r;
+
+  r = NO; // default themes are light
+  val = [[self infoDictionary] objectForKey: @"GSThemeSupportsDarkAppearance"];
+
+  // Do we have the key or is it an old GSTheme?
+  if (val == nil)
+    {
+      // try heuristic on the theme name
+      if ([[self name] hasSuffix:@"Dark"])
+        {
+          r = YES;
+        }
+    }
+  else
+    {
+      if ([val isEqualToString: @"YES"])
+        {
+          r =  YES;
+        }
+    }
+
+  return r;
+}
+
+- (BOOL) inLightAppearance
+{
+  // NOTE: maybe we should cache this in an ivar
+  if (![self supportsLightAppearance] && [self supportsDarkAppearance])
+    {
+      return NO;
+    }
+  return YES;
+}
+
+- (BOOL) inDarkAppearance;
+{
+  // NOTE: maybe we should cache this in an ivar
+  if (![self supportsLightAppearance] && [self supportsDarkAppearance])
+    {
+      return YES;
+    }
+  return NO;
+}
+
 
 @end
 

--- a/Source/GSTheme.m
+++ b/Source/GSTheme.m
@@ -1339,6 +1339,11 @@ typedef	struct {
   return [[self infoDictionary] objectForKey: @"GSThemeLicense"];
 }
 
+- (BOOL) isDarkMode
+{
+  return NO;
+}
+
 @end
 
 @implementation	GSTheme (Private)

--- a/Source/GSTheme.m
+++ b/Source/GSTheme.m
@@ -1341,7 +1341,8 @@ typedef	struct {
 
 - (BOOL) isDarkMode
 {
-  return NO;
+  return [[[self infoDictionary] objectForKey: @"GSThemeDarkMode"]
+	   isEqualToString: @"YES"];
 }
 
 @end


### PR DESCRIPTION
The purpose of this PR is to add a method to make the system aware that a theme using "dark mode" is being used.   This will assist in settings for editors and, particularly, with printing.