### PR TITLE
always reset _needsLayout in -layout and not only

### DIFF
--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -5172,6 +5172,8 @@ static NSView* findByTag(NSView *view, NSInteger aTag, NSUInteger *level)
 
 - (void) layout
 {
+  _needsLayout = NO;
+
   GSAutoLayoutEngine *engine = [self _layoutEngine];
   if (!engine)
     {
@@ -5307,7 +5309,6 @@ static NSView* findByTag(NSView *view, NSInteger aTag, NSUInteger *level)
   if (_needsLayout)
     {
       [self layout];
-      _needsLayout = NO;
     }
 
   NSArray *subviews = [self subviews];


### PR DESCRIPTION
-layoutSubtreeIfNeeded via layoutViewAndSubvies.

Apple states for -(void) layout:

Override this method if your custom view needs to perform custom layout not expressible using the constraint-based layout system. In this case you are responsible for setting needsLayout to true when something that impacts your custom layout changes.

Which seems to suggest that layout does the reset of needsLayout, since setting it is up to programmer.

Further interesting read:
https://developer.apple.com/library/archive/releasenotes/UserExperience/RNAutomaticLayout/#//apple_ref/doc/uid/TP40010631-CH1-SW14

You should override [layout](https://developer.apple.com/documentation/appkit/nsview/1526146-layout) only if you want to do custom layout. If you do, then you also need to invoke [setNeedsLayout:](https://developer.apple.com/documentation/appkit/nsview/1526912-needslayout) when something that feeds into your custom layout changes.

To reiterate: you never need to call setNeedsLayout: unless you override layout. Based on changes to constraints, the layout engine determines when layout is required.


Also it says you should not call layout, but suggests layoutSubtreeIfNeeded, I think the code is more compliant with this PR.