### PR TITLE
Make PACKAGE_SCOPE @public on Win32

### DIFF
--- a/Headers/AppKit/AppKitDefines.h
+++ b/Headers/AppKit/AppKitDefines.h
@@ -72,7 +72,7 @@
 
 #endif
 
-#if defined(__clang__) && !defined(__MINGW32__)
+#if defined(__clang__) && !defined(__MINGW32__) && !defined(WIN32)
 #  define PACKAGE_SCOPE @package
 #else
 #  define PACKAGE_SCOPE @public


### PR DESCRIPTION
Like MinGW, the clang compiler doesn't properly support the @package scope on the (native) Windows platform.  Use the @public scope instead.