### PR TITLE
tiff.m: Only include unistd.h if it exists

### DIFF
--- a/Source/tiff.m
+++ b/Source/tiff.m
@@ -73,7 +73,7 @@
 #include <string.h>
 #if defined(HAVE_UNISTD_H)
 #include <unistd.h>		/* for L_SET, etc definitions */
-#endif /* !HAVE_UNISTD_H */
+#endif /* HAVE_UNISTD_H */
 
 #if !defined(TIFF_VERSION_CLASSIC)
 // This only got added in version 4 of libtiff, but TIFFLIB_VERSION is unusable to differentiate here

--- a/Source/tiff.m
+++ b/Source/tiff.m
@@ -71,9 +71,9 @@
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
-#ifndef __WIN32__
+#if defined(HAVE_UNISTD_H)
 #include <unistd.h>		/* for L_SET, etc definitions */
-#endif /* !__WIN32__ */
+#endif /* !HAVE_UNISTD_H */
 
 #if !defined(TIFF_VERSION_CLASSIC)
 // This only got added in version 4 of libtiff, but TIFFLIB_VERSION is unusable to differentiate here


### PR DESCRIPTION
Most notably, Windows doesn't ship with unistd.h.  Generalize the current guard (`__WIN32__`) so it works on all Windows configurations (in my case, native Clang/LLVM on Windows, not using the MSYS2 toolchain).

https://web.archive.org/web/20140625123925/http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system summarizes the different preprocessor variables, `__WIN32__` isn't _always_ defined on Windows.