### PR TITLE
"Enter" icon in default button only for certain NSInterfaceStyles

### DIFF
--- a/Source/GSHelpManagerPanel.m
+++ b/Source/GSHelpManagerPanel.m
@@ -101,8 +101,13 @@ static GSHelpManagerPanel* _GSsharedGSHelpPanel;
     [button setTitle: NSLocalizedString(@"OK", @"")];
     [button setKeyEquivalent: @"\r"];
     [button setImagePosition: NSImageRight];
-    [button setImage: [NSImage imageNamed: @"common_ret"]];
-    [button setAlternateImage: [NSImage imageNamed: @"common_retH"]];
+  NSInterfaceStyle interfaceStyle = NSInterfaceStyleForKey(@"NSInterfaceStyle", nil);
+  if (interfaceStyle == NSNextStepInterfaceStyle
+      || interfaceStyle == GSWindowMakerInterfaceStyle)
+    {
+      [button setImage: [NSImage imageNamed: @"common_ret"]];
+      [button setAlternateImage: [NSImage imageNamed: @"common_retH"]];
+    }
 	  [button setTarget: self];
 	  [button setAction: @selector(buttonAction:)];		
 

--- a/Source/GSThemeDrawing.m
+++ b/Source/GSThemeDrawing.m
@@ -102,22 +102,27 @@
 - (void) setKeyEquivalent: (NSString *)key 
             forButtonCell: (NSButtonCell *)cell
 {
-  if([cell image] == nil && ([key isEqualToString:@"\r"] ||
-			     [key isEqualToString:@"\n"]))
-    { 
-      [cell setImagePosition: NSImageRight];
-      [cell setImage: [NSImage imageNamed:@"common_ret"]];
-      [cell setAlternateImage: [NSImage imageNamed:@"common_retH"]];
-    }
-  else if([key isEqualToString:@"\r"] == NO &&
-	  [key isEqualToString:@"\n"] == NO)
+  NSInterfaceStyle interfaceStyle = NSInterfaceStyleForKey(@"NSInterfaceStyle", nil);
+  if (interfaceStyle == NSNextStepInterfaceStyle
+      || interfaceStyle == GSWindowMakerInterfaceStyle)
     {
-      NSImage *cellImage = [cell image];
-      if(cellImage == [NSImage imageNamed:@"common_ret"])
-	{
-	  [cell setImage: nil];
-	  [cell setAlternateImage: nil];
-	}
+      if([cell image] == nil && ([key isEqualToString:@"\r"] ||
+                                 [key isEqualToString:@"\n"]))
+        { 
+          [cell setImagePosition: NSImageRight];
+          [cell setImage: [NSImage imageNamed:@"common_ret"]];
+          [cell setAlternateImage: [NSImage imageNamed:@"common_retH"]];
+        }
+      else if([key isEqualToString:@"\r"] == NO &&
+              [key isEqualToString:@"\n"] == NO)
+        {
+          NSImage *cellImage = [cell image];
+          if(cellImage == [NSImage imageNamed:@"common_ret"])
+            {
+              [cell setImage: nil];
+              [cell setAlternateImage: nil];
+            }
+        }
     }
 }
 

--- a/Source/NSAlert.m
+++ b/Source/NSAlert.m
@@ -502,8 +502,13 @@ setKeyEquivalent(NSButton *button)
   [defButton setHighlightsBy: NSPushInCellMask | NSChangeGrayCellMask 
                               | NSContentsCellMask];
   [defButton setImagePosition: NSImageRight];
-  [defButton setImage: [NSImage imageNamed: @"common_ret"]];
-  [defButton setAlternateImage: [NSImage imageNamed: @"common_retH"]];
+  NSInterfaceStyle interfaceStyle = NSInterfaceStyleForKey(@"NSInterfaceStyle", nil);
+  if (interfaceStyle == NSNextStepInterfaceStyle
+      || interfaceStyle == GSWindowMakerInterfaceStyle)
+    {
+      [defButton setImage: [NSImage imageNamed: @"common_ret"]];
+      [defButton setAlternateImage: [NSImage imageNamed: @"common_retH"]];
+    }
   
   altButton = [self _makeButtonWithRect: rect tag: NSAlertAlternateReturn];
   othButton = [self _makeButtonWithRect: rect tag: NSAlertOtherReturn];

--- a/Source/NSSavePanel.m
+++ b/Source/NSSavePanel.m
@@ -333,9 +333,14 @@ setPath(NSBrowser *browser, NSString *path)
   _okButton = [[NSButton alloc] initWithFrame: r]; 
   [_okButton setBordered: YES];
   [_okButton setTitle:  _(@"OK")];
-  [_okButton setImagePosition: NSImageRight]; 
-  [_okButton setImage: [NSImage imageNamed: @"common_ret"]];
-  [_okButton setAlternateImage: [NSImage imageNamed: @"common_retH"]];
+  [_okButton setImagePosition: NSImageRight];
+  NSInterfaceStyle interfaceStyle = NSInterfaceStyleForKey(@"NSInterfaceStyle", nil);
+  if (interfaceStyle == NSNextStepInterfaceStyle
+      || interfaceStyle == GSWindowMakerInterfaceStyle)
+    {
+      [_okButton setImage: [NSImage imageNamed: @"common_ret"]];
+      [_okButton setAlternateImage: [NSImage imageNamed: @"common_retH"]];
+    }
   [_okButton setTarget: self];
   [_okButton setAction: @selector(ok:)];
   [_okButton setEnabled: NO];

--- a/Source/NSSpellChecker.m
+++ b/Source/NSSpellChecker.m
@@ -709,8 +709,13 @@ inSpellDocumentWithTag:(int)tag
   [_correctButton setKeyEquivalent: @"c"];
   [_correctButton setKeyEquivalentModifierMask: NSCommandKeyMask];
   [_correctButton setImagePosition: NSImageRight];
-  [_correctButton setImage: [NSImage imageNamed: @"common_ret"]];
-  [_correctButton setAlternateImage: [NSImage imageNamed: @"common_retH"]];
+  NSInterfaceStyle interfaceStyle = NSInterfaceStyleForKey(@"NSInterfaceStyle", nil);
+  if (interfaceStyle == NSNextStepInterfaceStyle
+      || interfaceStyle == GSWindowMakerInterfaceStyle)
+    {
+      [_correctButton setImage: [NSImage imageNamed: @"common_ret"]];
+      [_correctButton setAlternateImage: [NSImage imageNamed: @"common_retH"]];
+    }
   [_spellPanel makeFirstResponder: _correctButton];
   [_spellPanel setBecomesKeyOnlyIfNeeded: YES];
   [_spellPanel setFloatingPanel: YES];


### PR DESCRIPTION
Show "Enter" icon in default button only if `NSInterfaceStyle` is  `NSNextStepInterfaceStyle` or `GSWindowMakerInterfaceStyle`.

That icon looks alien in other interface styles such as `NSMacintoshInterfaceStyle`:

<img width="154" height="84" alt="image" src="https://github.com/user-attachments/assets/db395040-5aa3-4bcb-9219-6cd535735bc7" />

Reference:
* https://github.com/gershwin-desktop/gershwin-rik-theme/issues/4