### PR TITLE
Fix the GUI interface version (restore code which was, presumably accidentally, removed a while back)

### DIFF
--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -29,6 +29,9 @@ include $(GNUSTEP_MAKEFILES)/common.make
 include ../Version
 include ../config.make
 
+# Interface version changes with each minor release
+libgnustep-gui_INTERFACE_VERSION=${GNUSTEP_GUI_MAJOR_VERSION}.${GNUSTEP_GUI_MINOR_VERSION}
+
 srcdir = .
 PACKAGE_NAME = gnustep-gui
 LIBRARY_VAR = GNUSTEP_GUI


### PR DESCRIPTION
Re-instate the gui interface version setting to specify the version for linking the library in order to maintain ABI compatibility. Without this, apps linked to one version of the GUI library will try to use more recent (but incompatible) versions.