### PR TITLE
Add support for IBOutletCollection

### DIFF
--- a/Headers/AppKit/NSNibDeclarations.h
+++ b/Headers/AppKit/NSNibDeclarations.h
@@ -54,6 +54,9 @@
 #if !defined(IBAction)
 #define IBAction void
 #endif
+#if !defined(IBOutletCollection)
+#define IBOutletCollection(ClassName)
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
This article is best I found, describing, what IBOutletCollection is about: https://nshipster.com/ibaction-iboutlet-iboutletcollection/
It eases maintaining a larger list of similar outlets in the code side.

To use it in code, to define a collection, it would look alike:
@property (nonatomic, strong) IBOutletCollection(NSButton) NSArray *buttons;

This is to support IBOutletCollection usage in Gorm, see: https://github.com/gnustep/apps-gorm/issues/59