### PR TITLE
Do not crash if lpr is not available

### DIFF
--- a/Printing/GSLPR/GSLPRPrintOperation.m
+++ b/Printing/GSLPR/GSLPRPrintOperation.m
@@ -129,6 +129,8 @@
   {
     NSString *errmsg = [NSString stringWithFormat: _(@"Spooling failed: %@"), [localException reason]];
     NSRunAlertPanel(@"Printing Error", errmsg, @"OK", nil, nil);
+    status = errmsg;
+    [[self printPanel] _setStatusStringValue: status];
     AUTORELEASE(task);
     return NO;
   }


### PR DESCRIPTION
Add error handling for the case when `lpr`cannot be found on the `$PATH`.