### PR TITLE
remove shouldFinish to allow outer loop to handle cleanup

### DIFF
--- a/Source/NSMenuView.m
+++ b/Source/NSMenuView.m
@@ -1834,7 +1834,6 @@ static float menuBarHeight = 0.0;
 	  type = [event type];
     if (type == NSLeftMouseUp || type == NSRightMouseUp || type == NSOtherMouseUp)
       {
-          shouldFinish = YES;
           break;  // Exit the loop to proceed to StopPeriodicEvents
       }
 	  if (type == NSAppKitDefined)


### PR DESCRIPTION
  Remove shouldFinish assignment on mouse-up in inner event loop                                                                                                            

In the inner do/while loop that drains NSAppKitDefined events after a mouse-up is received, there was a redundant shouldFinish = YES assignment immediately before a  break. We didn't need this because shouldFinish is already set to yes in the outer loop whenever a mouse-up event is seen and setting it in the inner loop actually caused the outer loop exit prematurely before it does its cleanup. 