### PR TITLE
Fix for view shifting over in NSCollectionView

### DIFF
--- a/Source/NSCollectionView.m
+++ b/Source/NSCollectionView.m
@@ -1906,6 +1906,14 @@ static NSString *_placeholderItem = nil;
 
   cf.size = ps;
   _frame = cf;
+
+  // Make certain that the view origin is reset properly...
+  id sv = [self superview];
+  if ([sv respondsToSelector: @selector(constrainScrollPoint:)])
+    {
+      NSPoint p = [sv constrainScrollPoint: NSZeroPoint];
+      [sv setBoundsOrigin: p]; // all views respond to this...
+    }
 }
 
 - (void) reloadData


### PR DESCRIPTION
This fix should address the issue where the NSCollectionView is slightly shifted to the right.   It addresses this by recalculating the origin and resetting it properly.   I am not sure if there is an earlier miscalculation.  For now this fixes the issue.

Addresses https://github.com/gnustep/libs-gui/issues/402