### PR TITLE
fix encoding/decoding data size bug (crasher)

### DIFF
--- a/Source/NSParagraphStyle.m
+++ b/Source/NSParagraphStyle.m
@@ -508,18 +508,9 @@ static NSParagraphStyle	*defaultStyle = nil;
           [aCoder decodeArrayOfObjCType: @encode(float)
                   count: count
                   at: locations];
-          if ([aCoder versionForClassName: @"NSParagraphStyle"] >= 3)
-            {
-              [aCoder decodeArrayOfObjCType: @encode(NSInteger)
-                  count: count
-                  at: types];
-	    }
-	  else
-            {
-              [aCoder decodeArrayOfObjCType: @encode(int)
-                  count: count
-                  at: types];
-	    }
+	  [aCoder decodeArrayOfObjCType: @encode(NSTextTabType)
+	      count: count
+	      at: types];
           for (i = 0; i < count; i++)
             {
               NSTextTab	*tab;
@@ -586,7 +577,7 @@ static NSParagraphStyle	*defaultStyle = nil;
           [aCoder encodeArrayOfObjCType: @encode(float)
                   count: count
                   at: locations];
-          [aCoder encodeArrayOfObjCType: @encode(NSInteger)
+          [aCoder encodeArrayOfObjCType: @encode(NSTextTabType)
                   count: count
                   at: types];
         }


### PR DESCRIPTION
The crashing issue was that  we were deserialising an array of NSInteger (host pointer length values) into an array of NSTextTabType (integer size values).  On any machine where an integer and a pointer are different lengths, this causes buffer overflow corrupting the stack.

Fundamentally, when serialising/deserialising using buffers of NSTextTabType the methods should be told what type to use by using @encode(NSTextTabType) or perhaps @encode(__typeof__(variable)) though the latter is compiler dependent.