### PR TITLE
conditional removal of NSWindowDidResizeNotification to only _viewBased, attempt to fix crash

### DIFF
--- a/Source/NSTableView.m
+++ b/Source/NSTableView.m
@@ -2119,9 +2119,12 @@ static void computeNewSelection
 	  object: self];
     }
   // Remove window resize observer
-  [nc removeObserver: self
-                name: NSWindowDidResizeNotification
-              object: nil];
+  if (_viewBased)
+    {
+      [nc removeObserver: self
+		    name: NSWindowDidResizeNotification
+		  object: nil];
+    }
   TEST_RELEASE (_autosaveName);
   if (_numberOfColumns > 0)
     {


### PR DESCRIPTION
crude fix for https://github.com/gnustep/libs-gui/issues/435  open for discussion

I suppose this is only a workaround for #435 because AddressManager is not using view-based Tables, but what if? Why is removing a notification which perhaps is was not set such a big issue?