### PR TITLE
NSView: keep -setFrameSize: bounds finite when the frame collapsed to zero

### DIFF
--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -1286,8 +1286,16 @@ static NSSize _computeScale(NSSize fs, NSSize bs)
         {
           if (_boundsMatrix == nil)
             {
-              CGFloat sx = _bounds.size.width  / _frame.size.width;
-              CGFloat sy = _bounds.size.height / _frame.size.height;
+              /* Preserve the bounds/frame scale across the resize.  Guard
+               * against a zero current frame dimension (e.g. a rotated view
+               * previously collapsed to zero width or height) so the scale
+               * does not become infinite/NaN; fall back to 1:1 as the
+               * unrotated branch below does.
+               */
+              CGFloat sx = (_frame.size.width == 0.0)
+                ? 1.0 : _bounds.size.width  / _frame.size.width;
+              CGFloat sy = (_frame.size.height == 0.0)
+                ? 1.0 : _bounds.size.height / _frame.size.height;
               
               newFrame.size = newSize;
 	      [self _setFrameAndClearAutoresizingError: newFrame];

--- a/Tests/gui/NSView/NSView_setFrameSize_zero.m
+++ b/Tests/gui/NSView/NSView_setFrameSize_zero.m
@@ -1,0 +1,36 @@
+/* Regression test for -[NSView setFrameSize:] on a rotated view whose frame
+ * has been collapsed to a zero dimension.
+ *
+ * A rotated view has _is_rotated_or_scaled_from_base set but keeps
+ * _boundsMatrix nil, so -setFrameSize: recomputes the bounds by scaling with
+ * (bounds / current frame).  Collapsing the width to zero and then expanding
+ * it again divided by that zero width, leaving the bounds width infinite/NaN.
+ */
+#include "Testing.h"
+
+#include <math.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/NSView.h>
+
+int
+main(int argc, char **argv)
+{
+  START_SET("NSView setFrameSize zero-dimension rotated")
+  ENTER_POOL
+  NSView	*view;
+  NSSize	bounds;
+
+  view = [[NSView alloc] initWithFrame: NSMakeRect(0.0, 0.0, 100.0, 100.0)];
+  [view setFrameRotation: 30.0];
+  [view setFrameSize: NSMakeSize(0.0, 100.0)];		/* collapse width */
+  [view setFrameSize: NSMakeSize(100.0, 100.0)];	/* expand again */
+
+  bounds = [view bounds].size;
+  PASS(isfinite(bounds.width) && isfinite(bounds.height),
+    "-setFrameSize: keeps a rotated view's bounds finite across a zero width")
+  [view release];
+
+  LEAVE_POOL
+  END_SET("NSView setFrameSize zero-dimension rotated")
+  return 0;
+}


### PR DESCRIPTION
## Summary

A rotated view sets `_is_rotated_or_scaled_from_base` but keeps `_boundsMatrix` nil, so `-[NSView setFrameSize:]` takes the branch that recomputes the bounds by scaling with the ratio of the current bounds to the current frame size:

```objc
CGFloat sx = _bounds.size.width  / _frame.size.width;
CGFloat sy = _bounds.size.height / _frame.size.height;
```

If the current frame width or height is `0` — for example a rotated view that was previously collapsed to zero width and is now being expanded again — that division yields an infinite/`NaN` scale, which propagates into `_bounds`, leaving the view's bounds non-finite.

The fix guards the zero case and falls back to a 1:1 scale, matching what the unrotated branch below already does.

## Reproduction

```objc
NSView *v = [[NSView alloc] initWithFrame: NSMakeRect(0, 0, 100, 100)];
[v setFrameRotation: 30.0];
[v setFrameSize: NSMakeSize(0.0, 100.0)];   // collapse width
[v setFrameSize: NSMakeSize(100.0, 100.0)]; // expand again
// [v bounds].size.width is -nan before the fix, 100 after
```

## Validation (Ubuntu 24.04, clang 18, gnustep-gui built from this tree)

- After the fix the sequence above ends with finite bounds (`100 x 100`).
- Against the unpatched tree the bounds width is `-nan` and the new regression test fails.

A new regression test is added at `Tests/gui/NSView/NSView_setFrameSize_zero.m`.
