### PR TITLE
Add changes to load prototype cells in xib files

### DIFF
--- a/Source/GSXib5KeyedUnarchiver.m
+++ b/Source/GSXib5KeyedUnarchiver.m
@@ -291,6 +291,7 @@ static NSArray      *XmlBoolDefaultYes  = nil;
                                            @"image", @"NSSegmentItemImage",
                                            @"editable", @"NSIsEditable",
                                            @"objectValues", @"NSPopUpListData",
+                                           @"prototypeCellViews", @"NSPrototypeCellViews",
                                            @"maxNumberOfRows", @"NSMaxNumberOfGridRows",
                                            @"maxNumberOfColumns", @"NSMaxNumberOfGridColumns",
                                            @"sortKey", @"NSKey",

--- a/Source/NSTableView.m
+++ b/Source/NSTableView.m
@@ -2205,6 +2205,10 @@ static void computeNewSelection
 - (void) addTableColumn: (NSTableColumn *)aColumn
 {
   [aColumn setTableView: self];
+  if ([[aColumn _prototypeCellViews] count] > 0)
+    {
+      [self _registerPrototypeViews: [aColumn _prototypeCellViews]];
+    }
   [_tableColumns addObject: aColumn];
   _numberOfColumns++;
   if (_numberOfColumns > 1)


### PR DESCRIPTION
Add changes to load prototype cells.  I tried to keep these changes minimal.  This fixes an issue where an app uses a prototype cell without a data source.