### PR TITLE
NSGradient: fix inverted interpolatedColorAtLocation:

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2026-07-03 Todd White <todd.white@thalion.global>
+
+	* Source/NSGradient.m (-[NSGradient interpolatedColorAtLocation:]):
+	Measure the blend fraction from the lower stop rather than the upper
+	one.  As written the interpolated colour was mirrored within each
+	segment -- correct only at the stops and the exact midpoint -- so a
+	location nearer one stop returned the colour of the other.
+	* Tests/gui/NSGradient/basic.m:
+	* Tests/gui/NSGradient/TestInfo:
+	New tests for construction, the colour stops and the location
+	interpolation.
+
 2026-06-27 DTW-Thalion <todd.white@thalion.global>
 
 	* Source/GSTable.m (-[GSTable initWithCoder:]): Validate the row and

--- a/Source/NSGradient.m
+++ b/Source/NSGradient.m
@@ -241,7 +241,7 @@ relativeCenterPosition: (NSPoint)relativeCenterPoint
         {
           NSColor *c1 = [_colors objectAtIndex: i - 1];
           NSColor *c2 = [_colors objectAtIndex: i];
-          float fraction = (_locations[i] - location) / (_locations[i] - _locations[i - 1]);
+          float fraction = (location - _locations[i - 1]) / (_locations[i] - _locations[i - 1]);
           
           // FIXME: Works only for RGB colours and does not respect the colour space
           return [c1 blendedColorWithFraction: fraction

--- a/Tests/gui/NSGradient/basic.m
+++ b/Tests/gui/NSGradient/basic.m
@@ -1,0 +1,119 @@
+/* Coverage for NSGradient: construction, colour stops and the location
+ * interpolation (interpolatedColorAtLocation:).
+ */
+#include "Testing.h"
+#include <math.h>
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <AppKit/NSColor.h>
+#include <AppKit/NSGradient.h>
+
+#define EQ(a, b) (fabs((double)(a) - (double)(b)) < 0.0001)
+
+static NSColor *
+rgb(CGFloat r, CGFloat g, CGFloat b)
+{
+  return [NSColor colorWithCalibratedRed: r green: g blue: b alpha: 1.0];
+}
+
+int main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSColor	*red = rgb(1, 0, 0);
+  NSColor	*green = rgb(0, 1, 0);
+  NSColor	*blue = rgb(0, 0, 1);
+
+  START_SET("construction and colour stops")
+    NSGradient	*g = [[NSGradient alloc] initWithStartingColor: red
+						   endingColor: blue];
+    NSColor	*c = nil;
+    CGFloat	loc = -1;
+
+    PASS(g != nil, "a two-colour gradient is created");
+    PASS(2 == [g numberOfColorStops], "it has two colour stops");
+    PASS([g colorSpace] != nil, "it reports a colour space");
+
+    [g getColor: &c location: &loc atIndex: 0];
+    PASS([c isEqual: red] && EQ(loc, 0.0),
+      "the first stop is the starting colour at location 0");
+    [g getColor: &c location: &loc atIndex: 1];
+    PASS([c isEqual: blue] && EQ(loc, 1.0),
+      "the last stop is the ending colour at location 1");
+  END_SET("construction and colour stops")
+
+  START_SET("initWithColors evenly spaces the stops")
+    NSGradient	*g = [[NSGradient alloc] initWithColors:
+      [NSArray arrayWithObjects: red, green, blue, nil]];
+    CGFloat	loc = -1;
+
+    PASS(3 == [g numberOfColorStops], "three colours give three stops");
+    [g getColor: NULL location: &loc atIndex: 0];
+    PASS(EQ(loc, 0.0), "first of three stops is at 0");
+    [g getColor: NULL location: &loc atIndex: 1];
+    PASS(EQ(loc, 0.5), "middle of three stops is at 0.5");
+    [g getColor: NULL location: &loc atIndex: 2];
+    PASS(EQ(loc, 1.0), "last of three stops is at 1");
+  END_SET("initWithColors evenly spaces the stops")
+
+  START_SET("interpolatedColorAtLocation endpoints")
+    NSGradient	*g = [[NSGradient alloc] initWithStartingColor: red
+						   endingColor: blue];
+
+    PASS([[g interpolatedColorAtLocation: 0.0] isEqual: red],
+      "location 0 is the starting colour");
+    PASS([[g interpolatedColorAtLocation: 1.0] isEqual: blue],
+      "location 1 is the ending colour");
+    PASS([[g interpolatedColorAtLocation: -1.0] isEqual: red],
+      "a location below the range clamps to the starting colour");
+    PASS([[g interpolatedColorAtLocation: 2.0] isEqual: blue],
+      "a location above the range clamps to the ending colour");
+  END_SET("interpolatedColorAtLocation endpoints")
+
+  START_SET("interpolatedColorAtLocation interpolates toward the nearer stop")
+    NSGradient	*g = [[NSGradient alloc] initWithStartingColor: red
+						   endingColor: blue];
+    NSColor	*c;
+
+    c = [g interpolatedColorAtLocation: 0.25];
+    PASS(EQ([c redComponent], 0.75) && EQ([c blueComponent], 0.25),
+      "a quarter of the way is three-quarters the starting colour");
+
+    c = [g interpolatedColorAtLocation: 0.5];
+    PASS(EQ([c redComponent], 0.5) && EQ([c blueComponent], 0.5),
+      "the middle is an even mix");
+
+    c = [g interpolatedColorAtLocation: 0.75];
+    PASS(EQ([c redComponent], 0.25) && EQ([c blueComponent], 0.75),
+      "three-quarters of the way is three-quarters the ending colour");
+  END_SET("interpolatedColorAtLocation interpolates toward the nearer stop")
+
+  START_SET("interpolatedColorAtLocation across three stops")
+    NSGradient	*g = [[NSGradient alloc] initWithColors:
+      [NSArray arrayWithObjects: red, green, blue, nil]];
+    NSColor	*c;
+
+    c = [g interpolatedColorAtLocation: 0.5];
+    PASS(EQ([c redComponent], 0.0) && EQ([c greenComponent], 1.0)
+      && EQ([c blueComponent], 0.0),
+      "the middle stop's own location returns that stop's colour");
+
+    c = [g interpolatedColorAtLocation: 0.25];
+    PASS(EQ([c redComponent], 0.5) && EQ([c greenComponent], 0.5)
+      && EQ([c blueComponent], 0.0),
+      "a quarter of the way is halfway between the first two stops");
+  END_SET("interpolatedColorAtLocation across three stops")
+
+  START_SET("copy")
+    NSGradient	*g = [[NSGradient alloc] initWithStartingColor: red
+						   endingColor: blue];
+    NSGradient	*c = [g copy];
+
+    PASS(c != nil && c != g, "copy is a distinct object");
+    PASS(2 == [c numberOfColorStops], "copy preserves the stop count");
+    PASS([[c interpolatedColorAtLocation: 0.25] redComponent] > 0.7,
+      "copy interpolates like the original");
+  END_SET("copy")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSGradient interpolatedColorAtLocation:]` measured the blend fraction from the *upper* stop of a segment rather than the lower one:

```objc
float fraction = (_locations[i] - location) / (_locations[i] - _locations[i - 1]);
return [c1 blendedColorWithFraction: fraction ofColor: c2];   // c1 = lower stop, c2 = upper
```

Since `blendedColorWithFraction:0` is the receiver (`c1`) and `:1` is the other colour (`c2`), at `location == locations[i-1]` the fraction is 1 and it returns `c2` — the wrong stop. The result is mirrored within each segment; it happened to be correct only exactly at the stops and at the midpoint of a two-stop gradient. For a red→blue gradient, `interpolatedColorAtLocation: 0.25` returned three-quarters blue instead of three-quarters red.

Measuring the fraction from the lower stop fixes it:

```objc
float fraction = (location - _locations[i - 1]) / (_locations[i] - _locations[i - 1]);
```

Adds `Tests/gui/NSGradient` (there were no NSGradient tests) covering construction, colour stops, and the location interpolation; the interpolation assertions fail before this change and pass after. 21 assertions.
