### PR TITLE
NSSecureTextFieldCell: echo bullets by default

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2026-07-12 Todd White <todd.white@thalion.global>
 
+	* Source/NSSecureTextField.m (-[NSSecureTextFieldCell initTextCell:]):
+	Default echosBullets to YES so a freshly created cell echoes bullets,
+	matching NSSecureTextField and Apple. The flag was left at NO because
+	no initialiser set it.
+	* Tests/gui/NSSecureTextField/echosBulletsDefault.m:
+	* Tests/gui/NSSecureTextField/TestInfo:
+	New test for the default.
+
+2026-07-12 Todd White <todd.white@thalion.global>
+
 	* Tests/gui/NSTableHeaderCell/headerCell.m:
 	* Tests/gui/NSTableHeaderCell/TestInfo:
 	Add tests for NSTableHeaderCell: the defaults from initTextCell:, the

--- a/Source/NSSecureTextField.m
+++ b/Source/NSSecureTextField.m
@@ -135,6 +135,16 @@
     }
 }
 
+- (id) initTextCell: (NSString *)aString
+{
+  self = [super initTextCell: aString];
+  if (self != nil)
+    {
+      _echosBullets = YES;
+    }
+  return self;
+}
+
 - (BOOL) echosBullets
 {
   return _echosBullets;

--- a/Tests/gui/NSSecureTextField/echosBulletsDefault.m
+++ b/Tests/gui/NSSecureTextField/echosBulletsDefault.m
@@ -1,0 +1,39 @@
+/* A freshly created NSSecureTextFieldCell echoes bullets by default, the
+   same as NSSecureTextField and Apple's NSSecureTextFieldCell (a
+   standalone cell reports echosBullets == YES on macOS).  The cell touches
+   the font backend, so the set is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSecureTextField.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSSecureTextFieldCell default echosBullets")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+       SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  pass([AUTORELEASE([[NSSecureTextFieldCell alloc] init]) echosBullets] == YES,
+       "a freshly created secure cell echoes bullets by default");
+  pass([AUTORELEASE([[NSSecureTextFieldCell alloc] initTextCell: @""]) echosBullets] == YES,
+       "a secure cell from initTextCell: echoes bullets by default");
+
+  END_SET("NSSecureTextFieldCell default echosBullets")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A freshly created NSSecureTextFieldCell left echosBullets at NO because no
initialiser set the ivar.  A cell used on its own therefore drew nothing
where it should have drawn bullets; only NSSecureTextField hid this by
setting the flag itself.

Default echosBullets to YES in -initTextCell:, matching NSSecureTextField
and Apple.  Verified on a macOS runner: a standalone
[[NSSecureTextFieldCell alloc] init] reports echosBullets == YES there.

Adds a test for the default.
