### PR TITLE
NSButtonCell: string value follows the state

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-07-12 Todd White <todd.white@thalion.global>
+
+	* Source/NSButtonCell.m (-[NSButtonCell stringValue]): Return the
+	string form of the state ("1", "0" or "-1").  An off cell gave "" and a
+	mixed cell "1"; both now match the state as OS X does.
+	* Tests/gui/NSButtonCell/stringValue.m:
+	New test for the string value in each state.
+
 2026-07-03 Todd White <todd.white@thalion.global>
 
 	* Tests/gui/NSTextTab/basic.m:

--- a/Source/NSButtonCell.m
+++ b/Source/NSButtonCell.m
@@ -853,7 +853,7 @@
 
 - (NSString *) stringValue
 {
-  return _cell.state ? @"1" : @"";
+  return [NSString stringWithFormat: @"%ld", (long)_cell.state];
 }
 
 - (void) setAttributedStringValue: (NSAttributedString *)attrString

--- a/Tests/gui/NSButtonCell/stringValue.m
+++ b/Tests/gui/NSButtonCell/stringValue.m
@@ -1,0 +1,44 @@
+/* An NSButtonCell has no separate value: its string value is the string
+   form of its state, so it is "1" when on, "0" when off and "-1" when
+   mixed (verified against OS X). */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSButtonCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSButtonCell *cell;
+
+  START_SET("NSButtonCell stringValue")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  cell = AUTORELEASE([[NSButtonCell alloc] init]);
+
+  [cell setState: NSOnState];
+  pass([[cell stringValue] isEqualToString: @"1"], "an on cell has string value 1");
+  [cell setState: NSOffState];
+  pass([[cell stringValue] isEqualToString: @"0"], "an off cell has string value 0");
+  [cell setAllowsMixedState: YES];
+  [cell setState: NSMixedState];
+  pass([[cell stringValue] isEqualToString: @"-1"], "a mixed cell has string value -1");
+
+  END_SET("NSButtonCell stringValue")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSButtonCell stringValue]` returned `_cell.state ? @"1" : @""`, so an
off cell gave the empty string and a mixed cell gave `"1"`.  A button
cell's value is its state, so the string value should be the string form
of the state.  Return that, giving `"1"` / `"0"` / `"-1"` for on / off /
mixed.  Verified on a macOS runner: NSButtonCell reports `"1"`, `"0"` and
`"-1"` for the three states.

Adds a test for the string value in each state.
