### PR TITLE
NSSliderCell: break tick ties towards the lower tick

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2026-07-12 Todd White <todd.white@thalion.global>
 
+	* Source/NSSliderCell.m (-[NSSliderCell closestTickMarkValueToValue:]):
+	Break exact halves towards the lower tick, matching OS X (2.5 snapped
+	to 3 rather than 2 with integer ticks).
+	* Tests/gui/NSSliderCell/tickRounding.m:
+	New test for the tie rounding.
+
+2026-07-12 Todd White <todd.white@thalion.global>
+
 	* Tests/gui/NSTableHeaderCell/headerCell.m:
 	* Tests/gui/NSTableHeaderCell/TestInfo:
 	Add tests for NSTableHeaderCell: the defaults from initTextCell:, the

--- a/Source/NSSliderCell.m
+++ b/Source/NSSliderCell.m
@@ -860,7 +860,9 @@ double _doubleValueForMousePoint (NSPoint point, NSRect knobRect,
 
   d = _maxValue - _minValue;
   f = ((aValue - _minValue)  * (effectiveTicks - 1)) / d;
-  f = ((GSRoundTowardsInfinity(f) * d) / (effectiveTicks - 1)) + _minValue;
+  /* Snap to the nearest tick, breaking ties towards the lower tick to
+     match OS X. */
+  f = ((-GSRoundTowardsInfinity(-f) * d) / (effectiveTicks - 1)) + _minValue;
 
   /* never return the maximum value, tested on Apple */
   if (_type == NSCircularSlider && (f >= _maxValue))

--- a/Tests/gui/NSSliderCell/tickRounding.m
+++ b/Tests/gui/NSSliderCell/tickRounding.m
@@ -1,0 +1,55 @@
+/* -[NSSliderCell closestTickMarkValueToValue:] snaps to the nearest tick,
+   breaking exact halves towards the lower tick, as OS X does (2.5 -> 2,
+   7.5 -> 7 with integer ticks). */
+#include "Testing.h"
+
+#include <math.h>
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSliderCell.h>
+
+static BOOL
+eq(double a, double b)
+{
+  return fabs(a - b) < 0.0001;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSSliderCell *cell;
+
+  START_SET("NSSliderCell tick rounding")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  cell = AUTORELEASE([[NSSliderCell alloc] init]);
+  [cell setMinValue: 0];
+  [cell setMaxValue: 10];
+  [cell setNumberOfTickMarks: 11];
+
+  pass(eq([cell closestTickMarkValueToValue: 3.4], 3.0),
+       "a value just below a tick snaps down");
+  pass(eq([cell closestTickMarkValueToValue: 3.6], 4.0),
+       "a value just above a tick snaps up");
+  pass(eq([cell closestTickMarkValueToValue: 2.5], 2.0),
+       "a halfway value snaps to the lower tick");
+  pass(eq([cell closestTickMarkValueToValue: 7.5], 7.0),
+       "another halfway value also snaps to the lower tick");
+
+  END_SET("NSSliderCell tick rounding")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSSliderCell closestTickMarkValueToValue:]` snapped exact halves to
the upper tick (2.5 -> 3 with integer ticks over 0..10).  OS X breaks
ties towards the lower tick (2.5 -> 2, 7.5 -> 7).  Snap ties down to
match, leaving `GSRoundTowardsInfinity` (shared with other classes)
untouched.  Verified on a macOS runner.

Adds a test for the tie rounding.
