### PR TITLE
NSParagraphStyle: setTabStops: keeps the given order

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2026-07-12 Todd White <todd.white@thalion.global>
 
+	* Source/NSParagraphStyle.m (-[NSMutableParagraphStyle setTabStops:]):
+	Keep the tab stops in the order given rather than sorting them, as OS X
+	does.  addTabStop: still inserts a single stop in sorted position.
+	* Tests/gui/NSParagraphStyle/tabStopOrder.m:
+	New test for the preserved order.
+
+2026-07-12 Todd White <todd.white@thalion.global>
+
 	* Tests/gui/NSTableHeaderCell/headerCell.m:
 	* Tests/gui/NSTableHeaderCell/TestInfo:
 	Add tests for NSTableHeaderCell: the defaults from initTextCell:, the

--- a/Source/NSParagraphStyle.m
+++ b/Source/NSParagraphStyle.m
@@ -809,7 +809,6 @@ static NSParagraphStyle	*defaultStyle = nil;
     {
       [_tabStops removeAllObjects];
       [_tabStops addObjectsFromArray: array];
-      [_tabStops sortUsingSelector: @selector(compare:)];
     }
 }
 

--- a/Tests/gui/NSParagraphStyle/tabStopOrder.m
+++ b/Tests/gui/NSParagraphStyle/tabStopOrder.m
@@ -1,0 +1,46 @@
+/* -[NSMutableParagraphStyle setTabStops:] keeps the tab stops in the order
+   given, as OS X does; it does not reorder them.  (-addTabStop: still
+   inserts a single stop in sorted position.) */
+#include "Testing.h"
+
+#include <math.h>
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+
+#include <AppKit/NSParagraphStyle.h>
+#include <AppKit/NSText.h>
+
+static CGFloat
+locAt(NSParagraphStyle *p, NSUInteger i)
+{
+  return [[[p tabStops] objectAtIndex: i] location];
+}
+
+static NSTextTab *
+tab(CGFloat loc)
+{
+  return AUTORELEASE([[NSTextTab alloc] initWithType: NSLeftTabStopType
+                                            location: loc]);
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSParagraphStyle tab stop order")
+
+  {
+    NSMutableParagraphStyle *p = AUTORELEASE([[NSMutableParagraphStyle alloc] init]);
+
+    [p setTabStops: [NSArray arrayWithObjects: tab(300), tab(100), tab(200), nil]];
+    pass([[p tabStops] count] == 3, "setTabStops: keeps all of the stops");
+    pass(locAt(p, 0) == 300.0 && locAt(p, 1) == 100.0 && locAt(p, 2) == 200.0,
+      "setTabStops: keeps the stops in the order given");
+  }
+
+  END_SET("NSParagraphStyle tab stop order")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSMutableParagraphStyle setTabStops:]` sorted the given stops by
location.  OS X keeps them in the order supplied (it is the caller's
responsibility to order them).  Store the stops as given.  `-addTabStop:`
still inserts a single stop in sorted position, which also matches OS X.
Verified on a macOS runner: setTabStops with (300, 100, 200) reports that
same order.

Adds a test for the preserved order.
