### PR TITLE
NSMatrix: selectCellAtRow:column: selects a single cell in list mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2026-07-12 Todd White <todd.white@thalion.global>
 
+	* Source/NSMatrix.m (-[NSMatrix selectCellAtRow:column:]): Deselect the
+	existing selection in list mode before selecting the cell, so the method
+	selects a single cell as OS X does.  Mouse dragging, which uses other
+	methods, still extends the selection.
+	* Tests/gui/NSMatrix/listSingleSelect.m:
+	* Tests/gui/NSMatrix/TestInfo:
+	New test for the single selection.
+
+2026-07-12 Todd White <todd.white@thalion.global>
+
 	* Tests/gui/NSTableHeaderCell/headerCell.m:
 	* Tests/gui/NSTableHeaderCell/TestInfo:
 	Add tests for NSTableHeaderCell: the defaults from initTextCell:, the

--- a/Source/NSMatrix.m
+++ b/Source/NSMatrix.m
@@ -1267,6 +1267,10 @@ static SEL getSel;
 
   if (aCell)
     {
+      if (_mode == NSListModeMatrix)
+	{
+	  [self deselectAllCells];
+	}
       [self _selectCell: aCell atRow: row column: column];
       [self selectTextAtRow: row column: column];
     }

--- a/Tests/gui/NSMatrix/listSingleSelect.m
+++ b/Tests/gui/NSMatrix/listSingleSelect.m
@@ -1,0 +1,50 @@
+/* -[NSMatrix selectCellAtRow:column:] selects a single cell, deselecting
+   any others, even in list mode, as OS X does.  (Mouse dragging, which
+   uses other methods, still extends the selection.) */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSMatrix.h>
+#include <AppKit/NSButtonCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSMatrix list single selection")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  {
+    NSButtonCell *proto = AUTORELEASE([[NSButtonCell alloc] init]);
+    NSMatrix *m = AUTORELEASE([[NSMatrix alloc] initWithFrame: NSMakeRect(0, 0, 100, 100)
+                                             mode: NSListModeMatrix
+                                        prototype: proto
+                                     numberOfRows: 2
+                                  numberOfColumns: 2]);
+
+    [m selectCellAtRow: 0 column: 1];
+    [m selectCellAtRow: 1 column: 0];
+    pass([[m selectedCells] count] == 1,
+      "selectCellAtRow:column: keeps a single selection in list mode");
+    pass([m selectedRow] == 1 && [m selectedColumn] == 0,
+      "the last selected cell is the selected one");
+  }
+
+  END_SET("NSMatrix list single selection")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
In list mode, `-[NSMatrix selectCellAtRow:column:]` added the cell to the
selection instead of replacing it, so calling it twice left two cells
selected.  OS X selects a single cell (deselecting the others) in list
mode as well as radio mode.  Deselect the existing selection in list mode
before selecting the cell.  Mouse dragging, which extends the selection,
uses other methods and is unaffected.  Verified on a macOS runner: two
`selectCellAtRow:column:` calls leave one cell selected.

Adds a test for the single selection.
