### PR TITLE
NSTextFieldCell: default text colour is the control text colour

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,14 @@
 2026-07-12 Todd White <todd.white@thalion.global>
 
+	* Source/NSTextFieldCell.m (-[NSTextFieldCell initTextCell:]): Use the
+	control text colour for the default text colour, as OS X does, rather
+	than the generic text colour.
+	* Tests/gui/NSTextFieldCell/defaultTextColor.m:
+	* Tests/gui/NSTextFieldCell/TestInfo:
+	New test for the default text colour.
+
+2026-07-12 Todd White <todd.white@thalion.global>
+
 	* Tests/gui/NSTableHeaderCell/headerCell.m:
 	* Tests/gui/NSTableHeaderCell/TestInfo:
 	Add tests for NSTableHeaderCell: the defaults from initTextCell:, the

--- a/Source/NSTextFieldCell.m
+++ b/Source/NSTextFieldCell.m
@@ -64,7 +64,7 @@
   if (self == nil)
     return self;
 
-  ASSIGN(_text_color, [NSColor textColor]);
+  ASSIGN(_text_color, [NSColor controlTextColor]);
   ASSIGN(_background_color, [NSColor textBackgroundColor]);
 //  _textfieldcell_draws_background = NO;
   _action_mask = NSKeyUpMask | NSKeyDownMask;

--- a/Tests/gui/NSTextFieldCell/defaultTextColor.m
+++ b/Tests/gui/NSTextFieldCell/defaultTextColor.m
@@ -1,0 +1,41 @@
+/* A text field cell is a control, so its default text colour is the
+   control text colour, as on OS X (its default text colour is
+   controlTextColor, not the generic textColor). */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSColor.h>
+#include <AppKit/NSTextFieldCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSTextFieldCell default text colour")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  {
+    NSTextFieldCell *cell = AUTORELEASE([[NSTextFieldCell alloc] initTextCell: @""]);
+
+    pass([[cell textColor] isEqual: [NSColor controlTextColor]],
+      "the default text colour is the control text colour");
+  }
+
+  END_SET("NSTextFieldCell default text colour")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSTextFieldCell initTextCell:]` set the default text colour to the
generic `[NSColor textColor]`.  A text field is a control, and OS X uses
`controlTextColor` as the default text colour of an NSTextFieldCell.  Use
`controlTextColor` to match.  Verified on a macOS runner: a fresh
NSTextFieldCell reports `controlTextColor`, not `textColor`.

Adds a test for the default text colour.
