### PR TITLE
NSComboBoxCell: completedString: returns nil on no match

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,14 @@
 2026-07-12 Todd White <todd.white@thalion.global>
 
+	* Source/NSComboBoxCell.m (-[NSComboBoxCell completedString:]): Return
+	nil when no item completes the substring, as OS X does, rather than
+	echoing the substring back.
+	* Tests/gui/NSComboBoxCell/completedStringNoMatch.m:
+	* Tests/gui/NSComboBoxCell/TestInfo:
+	New test for the no-match case.
+
+2026-07-12 Todd White <todd.white@thalion.global>
+
 	* Tests/gui/NSTableHeaderCell/headerCell.m:
 	* Tests/gui/NSTableHeaderCell/TestInfo:
 	Add tests for NSTableHeaderCell: the defaults from initTextCell:, the

--- a/Source/NSComboBoxCell.m
+++ b/Source/NSComboBoxCell.m
@@ -1292,8 +1292,8 @@ static GSComboWindow *gsWindow = nil;
 	    return str;
         }
     }
-  
-  return substring;
+
+  return nil;
 }
 
 /** 

--- a/Tests/gui/NSComboBoxCell/completedStringNoMatch.m
+++ b/Tests/gui/NSComboBoxCell/completedStringNoMatch.m
@@ -1,0 +1,44 @@
+/* -[NSComboBoxCell completedString:] returns nil when no item completes the
+   substring, as OS X does, rather than echoing the substring back. */
+#include "Testing.h"
+
+#include <Foundation/NSArray.h>
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSComboBoxCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSComboBoxCell completedString: no match")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  {
+    NSComboBoxCell *cell = AUTORELEASE([[NSComboBoxCell alloc] initTextCell: @""]);
+
+    [cell addItemsWithObjectValues:
+      ([NSArray arrayWithObjects: @"Apple", @"Apricot", @"Banana", nil])];
+    pass([cell completedString: @"xyz"] == nil,
+      "completedString: returns nil when no item completes the substring");
+    pass([[cell completedString: @"Ap"] isEqualToString: @"Apple"],
+      "completedString: still returns a matching completion");
+  }
+
+  END_SET("NSComboBoxCell completedString: no match")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSComboBoxCell completedString:]` returned the substring itself when no
item in the list completed it.  OS X returns nil in that case, which is
how a caller distinguishes "no completion" from "the text is already a
complete item".  Return nil when nothing matches.  The two internal
callers already handle a nil result.  Verified on a macOS runner:
completedString: for a non-matching prefix returns nil.

Adds a test for the no-match case.
