### PR TITLE
NSPopUpButtonCell: keep the correct selection when removing an item

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,19 @@
 2026-07-12 Todd White <todd.white@thalion.global>
 
+	* Source/NSPopUpButtonCell.m (-[NSPopUpButtonCell removeItemAtIndex:]):
+	Keep the correct selection when removing an item, as OS X does.  When
+	the selected item is removed, select the first remaining item rather
+	than leaving the popup with no selection.  When another item is
+	removed, re-select the item that was selected: removing an item posts a
+	notification that re-syncs the selection from the menu view's
+	highlighted index, which does not track the removed item, so the
+	selection would otherwise move to a different item.
+	* Tests/gui/NSPopUpButtonCell/removeSelected.m:
+	* Tests/gui/NSPopUpButtonCell/TestInfo:
+	New test for the selection after removing an item.
+
+2026-07-12 Todd White <todd.white@thalion.global>
+
 	* Tests/gui/NSTableHeaderCell/headerCell.m:
 	* Tests/gui/NSTableHeaderCell/TestInfo:
 	Add tests for NSTableHeaderCell: the defaults from initTextCell:, the

--- a/Source/NSPopUpButtonCell.m
+++ b/Source/NSPopUpButtonCell.m
@@ -460,12 +460,33 @@ static NSImage *_pbc_image[5];
  */
 - (void) removeItemAtIndex: (NSInteger)index
 {
-  if (index == [self indexOfSelectedItem])
+  BOOL removingSelected = (index == [self indexOfSelectedItem]);
+  id <NSMenuItem> keepSelected = removingSelected ? nil : _selectedItem;
+
+  if (removingSelected)
     {
       [self selectItem: nil];
     }
 
   [_menu removeItemAtIndex: index];
+
+  if (removingSelected)
+    {
+      /* When the selected item is removed, select the first remaining item
+         rather than leaving the popup with no selection, as OS X does.  */
+      if ([_menu numberOfItems] > 0)
+        {
+          [self selectItemAtIndex: 0];
+        }
+    }
+  else if (keepSelected != nil)
+    {
+      /* Removing an item posts a notification that re-syncs the selection
+         from the menu view's highlighted index, which does not track the
+         removed item; re-select the item that was selected so the selection
+         stays on it, as OS X does.  */
+      [self selectItem: keepSelected];
+    }
 }
 
 /**

--- a/Tests/gui/NSPopUpButtonCell/removeSelected.m
+++ b/Tests/gui/NSPopUpButtonCell/removeSelected.m
@@ -1,0 +1,89 @@
+/* Removing an item from an NSPopUpButtonCell keeps the correct selection,
+   as OS X does: removing the selected item selects the first remaining item
+   (or clears the selection when the list becomes empty), and removing a
+   different item leaves the selection on the item that was selected. */
+#include "Testing.h"
+
+#include <Foundation/NSArray.h>
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSMenuItem.h>
+#include <AppKit/NSPopUpButtonCell.h>
+
+static NSPopUpButtonCell *
+popup(void)
+{
+  NSPopUpButtonCell *c = AUTORELEASE([[NSPopUpButtonCell alloc] initTextCell: @"" pullsDown: NO]);
+
+  [c addItemsWithTitles: [NSArray arrayWithObjects: @"a", @"b", @"c", @"d", nil]];
+  return c;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSPopUpButtonCell remove selected")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  /* Removing the selected middle item selects the first item. */
+  {
+    NSPopUpButtonCell *c = popup();
+
+    [c selectItemAtIndex: 1];
+    [c removeItemAtIndex: 1];
+    pass([c indexOfSelectedItem] == 0
+      && [[c titleOfSelectedItem] isEqualToString: @"a"],
+      "removing the selected middle item selects the first item");
+  }
+
+  /* Removing the selected last item also selects the first item. */
+  {
+    NSPopUpButtonCell *c = popup();
+
+    [c selectItemAtIndex: 3];
+    [c removeItemAtIndex: 3];
+    pass([c indexOfSelectedItem] == 0
+      && [[c titleOfSelectedItem] isEqualToString: @"a"],
+      "removing the selected last item selects the first item");
+  }
+
+  /* Removing the only item clears the selection. */
+  {
+    NSPopUpButtonCell *c = AUTORELEASE([[NSPopUpButtonCell alloc] initTextCell: @"" pullsDown: NO]);
+
+    [c addItemWithTitle: @"only"];
+    [c removeItemAtIndex: 0];
+    pass([c numberOfItems] == 0 && [c indexOfSelectedItem] == -1,
+      "removing the only item clears the selection");
+  }
+
+  /* Removing an item before the selection leaves the selection on the same
+     item, whose index shifts down. */
+  {
+    NSPopUpButtonCell *c = popup();
+
+    [c selectItemAtIndex: 2];      /* c */
+    [c removeItemAtIndex: 0];       /* -> b c d */
+    pass([c indexOfSelectedItem] == 1
+      && [[c titleOfSelectedItem] isEqualToString: @"c"],
+      "removing an earlier item keeps the selection on the same item");
+  }
+
+  END_SET("NSPopUpButtonCell remove selected")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSPopUpButtonCell removeItemAtIndex:]` mishandled the selection in two
ways:

1. When the selected item was removed, the popup was left with no
selection.  OS X selects the first remaining item (and clears the
selection only when the list becomes empty).

2. When a different item *before* the selection was removed, the removal
posts a notification that re-syncs the selection from the menu view's
highlighted index — which does not track the removed item — so the
selection slid to a different item.  OS X keeps the selection on the same
item (its index just shifts down).

Select the first item when the selected item is removed, and otherwise
re-select the item that was selected.  Verified on a macOS runner across
all four cases (remove selected middle/last, remove an earlier item,
remove the only item).

Adds a test for the selection after removing an item.
