### PR TITLE
NSTableColumn: keep the resizable flag and resizing mask consistent

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,16 @@
 2026-07-12 Todd White <todd.white@thalion.global>
 
+	* Source/NSTableColumn.m (-[NSTableColumn setResizable:], -[NSTableColumn
+	setResizingMask:]): Keep the resizable flag and the resizing mask
+	consistent, as OS X does.  setResizable: now sets the mask to the
+	auto/user resizing combination or to no resizing, and setResizingMask:
+	updates the resizable flag from whether the mask allows any resizing.
+	* Tests/gui/NSTableColumn/resizableMask.m:
+	* Tests/gui/NSTableColumn/TestInfo:
+	New test for the resizable/mask relationship.
+
+2026-07-12 Todd White <todd.white@thalion.global>
+
 	* Tests/gui/NSTableHeaderCell/headerCell.m:
 	* Tests/gui/NSTableHeaderCell/TestInfo:
 	Add tests for NSTableHeaderCell: the defaults from initTextCell:, the

--- a/Source/NSTableColumn.m
+++ b/Source/NSTableColumn.m
@@ -296,15 +296,15 @@
 - (void) setResizable: (BOOL)flag
 {
   _is_resizable = flag;
-  // TODO: To match Cocoa behavior, should be replaced by
-  //if (flag)
-  //  {
-  //    [self setResizingMask: NSTableColumnAutoresizingMask | NSTableColumnUserResizingMask)];
-  //  }
-  //else
-  //  {
-  //    [self setResizingMask: NSTableColumnNoResizing];
-  //  }
+  if (flag)
+    {
+      _resizing_mask = NSTableColumnAutoresizingMask
+	| NSTableColumnUserResizingMask;
+    }
+  else
+    {
+      _resizing_mask = NSTableColumnNoResizing;
+    }
 }
 
 /**
@@ -313,16 +313,15 @@
 - (BOOL) isResizable
 {
   return _is_resizable;
-  // TODO: To match Cocoa behavior, should be replaced by
-  //return (BOOL)[self autoresizingMask];
 }
 
 /**
-Return the resizing mask that describes whether the column is resizable and how 
+Return the resizing mask that describes whether the column is resizable and how
 it resizes. */
 - (void) setResizingMask: (NSUInteger)resizingMask
 {
   _resizing_mask = resizingMask;
+  _is_resizable = (resizingMask != NSTableColumnNoResizing);
 }
 
 /**

--- a/Tests/gui/NSTableColumn/resizableMask.m
+++ b/Tests/gui/NSTableColumn/resizableMask.m
@@ -1,0 +1,58 @@
+/* An NSTableColumn's resizable flag and its resizing mask stay consistent,
+   as on OS X: setResizingMask: with no resizing makes the column not
+   resizable, and setResizable: sets the mask to the auto/user resizing
+   combination or to no resizing. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTableColumn.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSTableColumn resizable / mask")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  /* The resizing mask drives isResizable. */
+  {
+    NSTableColumn *col = AUTORELEASE([[NSTableColumn alloc] initWithIdentifier: @"c"]);
+
+    [col setResizingMask: NSTableColumnNoResizing];
+    pass([col isResizable] == NO, "a no-resizing mask makes the column not resizable");
+    [col setResizingMask: NSTableColumnUserResizingMask];
+    pass([col isResizable] == YES, "a user-resizing mask makes the column resizable");
+  }
+
+  /* setResizable: drives the mask. */
+  {
+    NSTableColumn *col = AUTORELEASE([[NSTableColumn alloc] initWithIdentifier: @"c"]);
+
+    [col setResizable: NO];
+    pass([col resizingMask] == NSTableColumnNoResizing
+      && [col isResizable] == NO,
+      "setResizable: NO clears the resizing mask");
+    [col setResizable: YES];
+    pass([col resizingMask] == (NSTableColumnAutoresizingMask | NSTableColumnUserResizingMask)
+      && [col isResizable] == YES,
+      "setResizable: YES sets the auto and user resizing mask");
+  }
+
+  END_SET("NSTableColumn resizable / mask")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSTableColumn isResizable]` and the resizing mask were independent:
`setResizingMask:` did not affect `isResizable`, and `setResizable:` did
not touch the mask (the existing code had a TODO noting this).  OS X keeps
the two consistent -- `isResizable` reflects whether the mask allows any
resizing, and `setResizable:` sets the mask.

Make `setResizable:` set the mask to the auto/user resizing combination
(YES) or to no resizing (NO), and `setResizingMask:` update the resizable
flag from whether the mask allows any resizing.  `isResizable` stays the
value serialised by the coder, which both setters now keep in step with
the mask.  Verified on a macOS runner across the four combinations.

Adds a test for the resizable/mask relationship.
