### PR TITLE
NSMatrix: no cell class when a prototype is used

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,14 @@
 2026-07-12 Todd White <todd.white@thalion.global>
 
+	* Source/NSMatrix.m (-[NSMatrix cellClass]): Return Nil when the matrix
+	uses a cell prototype, as OS X does, rather than the prototype cell's
+	class.
+	* Tests/gui/NSMatrix/cellClassPrototype.m:
+	* Tests/gui/NSMatrix/TestInfo:
+	New test for the cell class / prototype relationship.
+
+2026-07-12 Todd White <todd.white@thalion.global>
+
 	* Tests/gui/NSTableHeaderCell/headerCell.m:
 	* Tests/gui/NSTableHeaderCell/TestInfo:
 	Add tests for NSTableHeaderCell: the defaults from initTextCell:, the

--- a/Source/NSMatrix.m
+++ b/Source/NSMatrix.m
@@ -3009,6 +3009,11 @@ static SEL getSel;
  */
 - (Class) cellClass
 {
+  /* A matrix that uses a cell prototype has no cell class, as on OS X.  */
+  if (_cellPrototype != nil)
+    {
+      return Nil;
+    }
   return _cellClass;
 }
 

--- a/Tests/gui/NSMatrix/cellClassPrototype.m
+++ b/Tests/gui/NSMatrix/cellClassPrototype.m
@@ -1,0 +1,66 @@
+/* A matrix that uses a cell prototype has no cell class, as on OS X:
+   -cellClass returns Nil while a prototype is set, and returns the class
+   again once a cell class is set (which clears the prototype). */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSButtonCell.h>
+#include <AppKit/NSMatrix.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSMatrix cell class vs prototype")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  /* Built with a prototype: no cell class. */
+  {
+    NSButtonCell *proto = AUTORELEASE([[NSButtonCell alloc] init]);
+    NSMatrix *m = AUTORELEASE([[NSMatrix alloc] initWithFrame: NSMakeRect(0, 0, 100, 100)
+                                             mode: NSListModeMatrix
+                                        prototype: proto
+                                     numberOfRows: 1
+                                  numberOfColumns: 1]);
+
+    pass([m prototype] != nil, "the prototype is set");
+    pass([m cellClass] == Nil, "a matrix with a prototype has no cell class");
+  }
+
+  /* Setting a cell class clears the prototype and reports the class. */
+  {
+    NSMatrix *m = AUTORELEASE([[NSMatrix alloc] initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+
+    [m setCellClass: [NSButtonCell class]];
+    pass([m cellClass] == [NSButtonCell class], "setCellClass: reports the cell class");
+    pass([m prototype] == nil, "setCellClass: clears the prototype");
+  }
+
+  /* Setting a prototype on that matrix hides the cell class again. */
+  {
+    NSMatrix *m = AUTORELEASE([[NSMatrix alloc] initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+
+    [m setCellClass: [NSButtonCell class]];
+    [m setPrototype: AUTORELEASE([[NSButtonCell alloc] init])];
+    pass([m cellClass] == Nil, "setPrototype: makes the cell class Nil again");
+  }
+
+  END_SET("NSMatrix cell class vs prototype")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSMatrix cellClass]` returned the prototype cell's class when the
matrix was built with a prototype.  A matrix's cell class and its
prototype are alternatives, and OS X returns nil from `cellClass` while a
prototype is set.  Return `Nil` in that case.  The stored class is left
untouched (it is still what `setPrototype:` records for the archiver and
is unused for cell creation while a prototype is set), so the coder and
cell creation are unaffected.  Verified on a macOS runner: a
prototype-built matrix reports no cell class.

Adds a test for the cell class / prototype relationship.
