### PR TITLE
NSScroller: clamp the value below zero as well as above one

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2026-07-12 Todd White <todd.white@thalion.global>
 
+	* Source/NSScroller.m (-[NSScroller setFloatValue:knobProportion:]):
+	Clamp the value into [0,1] before the redisplay marker is set, so a
+	value of -1 (which matched the marker and was skipped by setDoubleValue:)
+	clamps to 0 as OS X does.
+	* Tests/gui/NSScroller/clampFloatValue.m:
+	* Tests/gui/NSScroller/TestInfo:
+	New test for the value clamping.
+
+2026-07-12 Todd White <todd.white@thalion.global>
+
 	* Tests/gui/NSTableHeaderCell/headerCell.m:
 	* Tests/gui/NSTableHeaderCell/TestInfo:
 	Add tests for NSTableHeaderCell: the defaults from initTextCell:, the

--- a/Source/NSScroller.m
+++ b/Source/NSScroller.m
@@ -641,6 +641,18 @@ static float	buttonsOffset = 1.0; // buttonsWidth = sw - 2*buttonsOffset
 
 - (void) setFloatValue: (float)aFloat knobProportion: (CGFloat)ratio
 {
+  /* Clamp into [0,1] before the _doubleValue = -1 redisplay marker below:
+     an aFloat of -1 would otherwise match that marker and -setDoubleValue:
+     would skip it as an unchanged value.  */
+  if (aFloat < 0.0)
+    {
+      aFloat = 0.0;
+    }
+  else if (aFloat > 1.0)
+    {
+      aFloat = 1.0;
+    }
+
   if (_hitPart == NSScrollerNoPart)
     {
       [self setKnobProportion: ratio];

--- a/Tests/gui/NSScroller/clampFloatValue.m
+++ b/Tests/gui/NSScroller/clampFloatValue.m
@@ -1,0 +1,55 @@
+/* -[NSScroller setFloatValue:knobProportion:] clamps the value into [0,1] in
+   both directions, matching OS X.  A value of -1 is a regression case: it
+   collides with the internal redisplay marker, so it must still clamp to 0. */
+#include "Testing.h"
+
+#include <math.h>
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSScroller.h>
+
+static BOOL
+eq(CGFloat a, CGFloat b)
+{
+  return fabs((double)(a - b)) < 0.0001;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSScroller clamp float value")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  {
+    NSScroller *s = AUTORELEASE([[NSScroller alloc]
+      initWithFrame: NSMakeRect(0, 0, 15, 200)]);
+
+    [s setFloatValue: -1.0 knobProportion: 0.25];
+    pass(eq([s floatValue], 0.0), "a value of -1 clamps to 0");
+    [s setFloatValue: -0.5 knobProportion: 0.25];
+    pass(eq([s floatValue], 0.0), "a value below 0 clamps to 0");
+    [s setFloatValue: 2.0 knobProportion: 0.25];
+    pass(eq([s floatValue], 1.0), "a value above 1 clamps to 1");
+    [s setFloatValue: 0.3 knobProportion: 0.25];
+    pass(eq([s floatValue], 0.3), "a value within range is kept");
+  }
+
+  END_SET("NSScroller clamp float value")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSScroller setFloatValue:knobProportion:]` clamped a value above 1 but
not below 0.  To force a redisplay it sets `_doubleValue` to -1 before
calling `-setFloatValue:` (hence `-setDoubleValue:`), whose "no change"
guard then mistook an input of -1 for that marker and returned early,
skipping its own clamping -- so `setFloatValue: -1` left the value at -1.
Clamp the value into [0,1] up front, so -1 reaches 0 as OS X does.
Verified on a macOS runner: setting -1 gives 0.

Adds a test for the value clamping.
