### PR TITLE
NSTextTab: match macOS for decimal and terminator tabs

### DIFF
--- a/Source/NSParagraphStyle.m
+++ b/Source/NSParagraphStyle.m
@@ -52,7 +52,7 @@
             _alignment = NSCenterTextAlignment;
             break;
           case NSDecimalTabStopType:
-            _alignment = NSRightTextAlignment;
+            _alignment = NSNaturalTextAlignment;
             break;
         }
     }
@@ -72,14 +72,7 @@
 	type = NSLeftTabStopType; 
 	break;
       case NSRightTextAlignment:
-	if ([options objectForKey: NSTabColumnTerminatorsAttributeName] != nil)
-	  {
-	    type = NSDecimalTabStopType;
-	  }
-	else
-	  {
-	    type = NSRightTabStopType;
-	  }
+	type = NSRightTabStopType;
 	break;
       case NSCenterTextAlignment:
 	type = NSCenterTabStopType;

--- a/Tests/gui/NSTextTab/basic.m
+++ b/Tests/gui/NSTextTab/basic.m
@@ -1,5 +1,5 @@
 /* Coverage for NSTextTab: the type/alignment mappings in both directions,
- * the accessors, compare:, isEqual: and copying.
+ * the accessors, compare:, isEqual:, hash and copying.
  */
 #include "Testing.h"
 #include <math.h>
@@ -18,75 +18,84 @@ int main(int argc, char **argv)
   START_SET("initWithType:location: maps type to alignment")
     NSTextTab	*t;
 
-    t = [[[NSTextTab alloc] initWithType: NSLeftTabStopType
-				location: 50.0] autorelease];
+    t = AUTORELEASE([[NSTextTab alloc] initWithType: NSLeftTabStopType
+				location: 50.0]);
     PASS(EQ([t location], 50.0), "the location is stored");
     PASS(NSLeftTabStopType == [t tabStopType], "the tab stop type is stored");
     PASS(NSLeftTextAlignment == [t alignment],
       "a left tab has left alignment");
 
-    t = [[[NSTextTab alloc] initWithType: NSRightTabStopType
-				location: 10.0] autorelease];
+    t = AUTORELEASE([[NSTextTab alloc] initWithType: NSRightTabStopType
+				location: 10.0]);
     PASS(NSRightTextAlignment == [t alignment],
       "a right tab has right alignment");
 
-    t = [[[NSTextTab alloc] initWithType: NSCenterTabStopType
-				location: 10.0] autorelease];
+    t = AUTORELEASE([[NSTextTab alloc] initWithType: NSCenterTabStopType
+				location: 10.0]);
     PASS(NSCenterTextAlignment == [t alignment],
       "a center tab has center alignment");
 
-    t = [[[NSTextTab alloc] initWithType: NSDecimalTabStopType
-				location: 10.0] autorelease];
+    t = AUTORELEASE([[NSTextTab alloc] initWithType: NSDecimalTabStopType
+				location: 10.0]);
     PASS(NSDecimalTabStopType == [t tabStopType],
       "a decimal tab keeps the decimal type");
-    PASS(NSRightTextAlignment == [t alignment],
-      "a decimal tab aligns right");
+    PASS(NSNaturalTextAlignment == [t alignment],
+      "a decimal tab has natural alignment");
   END_SET("initWithType:location: maps type to alignment")
 
   START_SET("initWithTextAlignment:location:options: maps alignment to type")
     NSTextTab		*t;
     NSDictionary	*terminators;
 
-    t = [[[NSTextTab alloc] initWithTextAlignment: NSLeftTextAlignment
+    t = AUTORELEASE([[NSTextTab alloc] initWithTextAlignment: NSLeftTextAlignment
 					 location: 20.0
-					  options: nil] autorelease];
+					  options: nil]);
     PASS(NSLeftTabStopType == [t tabStopType]
       && NSLeftTextAlignment == [t alignment] && EQ([t location], 20.0),
       "a left-aligned tab is a left tab stop");
 
-    t = [[[NSTextTab alloc] initWithTextAlignment: NSCenterTextAlignment
+    t = AUTORELEASE([[NSTextTab alloc] initWithTextAlignment: NSCenterTextAlignment
 					 location: 20.0
-					  options: nil] autorelease];
+					  options: nil]);
     PASS(NSCenterTabStopType == [t tabStopType],
       "a center-aligned tab is a center tab stop");
 
-    t = [[[NSTextTab alloc] initWithTextAlignment: NSRightTextAlignment
+    t = AUTORELEASE([[NSTextTab alloc] initWithTextAlignment: NSRightTextAlignment
 					 location: 20.0
-					  options: nil] autorelease];
+					  options: nil]);
     PASS(NSRightTabStopType == [t tabStopType],
       "a right-aligned tab with no terminators is a right tab stop");
 
-    /* A right-aligned tab with column terminators is a decimal tab. */
+    t = AUTORELEASE([[NSTextTab alloc] initWithTextAlignment: NSJustifiedTextAlignment
+					 location: 20.0
+					  options: nil]);
+    PASS(NSLeftTabStopType == [t tabStopType],
+      "a justified tab is a left tab stop");
+    PASS(NSJustifiedTextAlignment == [t alignment],
+      "a justified tab keeps its alignment");
+
     terminators = [NSDictionary dictionaryWithObject:
       [NSCharacterSet characterSetWithCharactersInString: @"."]
       forKey: NSTabColumnTerminatorsAttributeName];
-    t = [[[NSTextTab alloc] initWithTextAlignment: NSRightTextAlignment
+    t = AUTORELEASE([[NSTextTab alloc] initWithTextAlignment: NSRightTextAlignment
 					 location: 20.0
-					  options: terminators] autorelease];
-    PASS(NSDecimalTabStopType == [t tabStopType],
-      "a right-aligned tab with terminators is a decimal tab stop");
+					  options: terminators]);
+    PASS(NSRightTabStopType == [t tabStopType],
+      "a right-aligned tab with terminators is still a right tab stop");
+    PASS(NSRightTextAlignment == [t alignment],
+      "a tab created with terminators keeps its alignment");
     PASS([t options] != nil && [[t options]
       objectForKey: NSTabColumnTerminatorsAttributeName] != nil,
       "the options are stored");
   END_SET("initWithTextAlignment:location:options: maps alignment to type")
 
   START_SET("compare: orders by location")
-    NSTextTab	*a = [[[NSTextTab alloc] initWithType: NSLeftTabStopType
-					     location: 10.0] autorelease];
-    NSTextTab	*b = [[[NSTextTab alloc] initWithType: NSLeftTabStopType
-					     location: 20.0] autorelease];
-    NSTextTab	*c = [[[NSTextTab alloc] initWithType: NSRightTabStopType
-					     location: 10.0] autorelease];
+    NSTextTab	*a = AUTORELEASE([[NSTextTab alloc] initWithType: NSLeftTabStopType
+					     location: 10.0]);
+    NSTextTab	*b = AUTORELEASE([[NSTextTab alloc] initWithType: NSLeftTabStopType
+					     location: 20.0]);
+    NSTextTab	*c = AUTORELEASE([[NSTextTab alloc] initWithType: NSRightTabStopType
+					     location: 10.0]);
 
     PASS(NSOrderedAscending == [a compare: b],
       "an earlier tab compares ascending");
@@ -98,14 +107,14 @@ int main(int argc, char **argv)
   END_SET("compare: orders by location")
 
   START_SET("isEqual: and hash")
-    NSTextTab	*a = [[[NSTextTab alloc] initWithType: NSLeftTabStopType
-					     location: 10.0] autorelease];
-    NSTextTab	*b = [[[NSTextTab alloc] initWithType: NSLeftTabStopType
-					     location: 10.0] autorelease];
-    NSTextTab	*c = [[[NSTextTab alloc] initWithType: NSRightTabStopType
-					     location: 10.0] autorelease];
-    NSTextTab	*d = [[[NSTextTab alloc] initWithType: NSLeftTabStopType
-					     location: 99.0] autorelease];
+    NSTextTab	*a = AUTORELEASE([[NSTextTab alloc] initWithType: NSLeftTabStopType
+					     location: 10.0]);
+    NSTextTab	*b = AUTORELEASE([[NSTextTab alloc] initWithType: NSLeftTabStopType
+					     location: 10.0]);
+    NSTextTab	*c = AUTORELEASE([[NSTextTab alloc] initWithType: NSRightTabStopType
+					     location: 10.0]);
+    NSTextTab	*d = AUTORELEASE([[NSTextTab alloc] initWithType: NSLeftTabStopType
+					     location: 99.0]);
 
     PASS([a isEqual: b], "tabs with the same type and location are equal");
     PASS([a hash] == [b hash], "equal tabs have the same hash");
@@ -117,13 +126,13 @@ int main(int argc, char **argv)
     NSDictionary	*terminators = [NSDictionary dictionaryWithObject:
       [NSCharacterSet characterSetWithCharactersInString: @"."]
       forKey: NSTabColumnTerminatorsAttributeName];
-    NSTextTab		*t = [[[NSTextTab alloc]
+    NSTextTab		*t = AUTORELEASE([[NSTextTab alloc]
       initWithTextAlignment: NSRightTextAlignment
 		   location: 33.0
-		    options: terminators] autorelease];
-    NSTextTab		*c = [[t copy] autorelease];
+		    options: terminators]);
+    NSTextTab		*c = AUTORELEASE([t copy]);
 
-    PASS(EQ([c location], 33.0) && NSDecimalTabStopType == [c tabStopType]
+    PASS(EQ([c location], 33.0) && NSRightTabStopType == [c tabStopType]
       && NSRightTextAlignment == [c alignment],
       "copy preserves location, type and alignment");
     PASS([c options] != nil, "copy preserves the options");


### PR DESCRIPTION
initWithType:location: derived NSRightTextAlignment for a decimal tab stop; AppKit returns NSNaturalTextAlignment. initWithTextAlignment:location:options: turned a right-aligned tab with a NSTabColumnTerminatorsAttributeName option into a decimal tab stop; AppKit keeps it a right tab stop and uses the terminators to align the column. This changes both to match, and updates the NSTextTab tests, which had asserted the old behaviour.

The typesetter positions tabs by location only, so tabStopType affects the ruler marker image and the deprecated accessor rather than layout.