### PR TITLE
NSTextList: match macOS for the square and box markers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,11 @@
 	mixed cell "1"; both now match the state as OS X does.
 	* Tests/gui/NSButtonCell/stringValue.m:
 	New test for the string value in each state.
+	* Source/NSTextList.m (-[NSTextList markerForItemNumber:]): Use the
+	small black and white square characters for the {square} and {box}
+	markers, matching AppKit, instead of the full-size squares.
+	* Tests/gui/NSTextList/basic.m: Check the {circle}, {square}, {box},
+	{hyphen} and {diamond} glyph markers.
 
 2026-07-03 Todd White <todd.white@thalion.global>
 

--- a/Source/NSTextList.m
+++ b/Source/NSTextList.m
@@ -64,13 +64,13 @@
 - (NSString *) markerForItemNumber: (int)item
 {
   NSMutableString *s = [_markerFormat mutableCopy];
-  unichar box = 0x25A1;
+  unichar box = 0x25AB;
   unichar check = 0x2713;
   unichar circle = 0x25E6;
   unichar diamond = 0x25C6;
   unichar disc = 0x2022;
   unichar hyphen = 0x2043;
-  unichar square = 0x25A0;
+  unichar square = 0x25AA;
 
   // FIXME: Needs optimisation and roman numbers
   // FIXME: Take _startingItemNumber into account.

--- a/Tests/gui/NSTextList/basic.m
+++ b/Tests/gui/NSTextList/basic.m
@@ -69,12 +69,27 @@ int main(int argc, char **argv)
 
   START_SET("glyph markers are independent of the item number")
     NSString	*disc = marker(@"{disc}", 1);
+    NSString	*circle = marker(@"{circle}", 1);
+    NSString	*square = marker(@"{square}", 1);
+    NSString	*box = marker(@"{box}", 1);
+    NSString	*hyphen = marker(@"{hyphen}", 1);
     NSString	*check = marker(@"{check}", 7);
+    NSString	*diamond = marker(@"{diamond}", 1);
 
     PASS(1 == [disc length] && 0x2022 == [disc characterAtIndex: 0],
       "{disc} is the bullet character");
+    PASS(1 == [circle length] && 0x25E6 == [circle characterAtIndex: 0],
+      "{circle} is the white bullet character");
+    PASS(1 == [square length] && 0x25AA == [square characterAtIndex: 0],
+      "{square} is the small black square character");
+    PASS(1 == [box length] && 0x25AB == [box characterAtIndex: 0],
+      "{box} is the small white square character");
+    PASS(1 == [hyphen length] && 0x2043 == [hyphen characterAtIndex: 0],
+      "{hyphen} is the hyphen bullet character");
     PASS(1 == [check length] && 0x2713 == [check characterAtIndex: 0],
       "{check} is the check character");
+    PASS(1 == [diamond length] && 0x25C6 == [diamond characterAtIndex: 0],
+      "{diamond} is the black diamond character");
   END_SET("glyph markers are independent of the item number")
 
   START_SET("copy")


### PR DESCRIPTION
markerForItemNumber: substituted the full-size square characters for the {square} and {box} markers: U+25A0 BLACK SQUARE and U+25A1 WHITE SQUARE. AppKit uses the small variants U+25AA BLACK SMALL SQUARE and U+25AB WHITE SMALL SQUARE, which are the right size for a list marker. This switches to those.

The existing NSTextList tests already cover {disc} and {check}; this adds the remaining glyph markers ({circle}, {square}, {box}, {hyphen}, {diamond}).