### PR TITLE
tests: add NSHelpManager tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2026-07-12 Todd White <todd.white@thalion.global>
 
+	* Tests/gui/NSHelpManager/basic.m:
+	* Tests/gui/NSHelpManager/TestInfo:
+	Add tests for NSHelpManager: the shared instance, the context help
+	set/get/remove round-trip and the context help mode flag.
+
+2026-07-12 Todd White <todd.white@thalion.global>
+
 	* Tests/gui/NSTextFieldCell/attributes.m:
 	* Tests/gui/NSTextFieldCell/TestInfo:
 	Add tests for NSTextFieldCell: the drawsBackground, bezel style,

--- a/Tests/gui/NSHelpManager/basic.m
+++ b/Tests/gui/NSHelpManager/basic.m
@@ -1,0 +1,55 @@
+/* Coverage for NSHelpManager: the shared instance, the context help
+ * set/get/remove round-trip, and the context help mode flag.  These are
+ * plain object operations and need no backend.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSHelpManager.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("shared instance")
+    NSHelpManager	*hm = [NSHelpManager sharedHelpManager];
+
+    PASS(hm != nil, "there is a shared help manager");
+    PASS(hm == [NSHelpManager sharedHelpManager],
+      "the shared help manager is the same object each time");
+  END_SET("shared instance")
+
+  START_SET("context help")
+    NSHelpManager	*hm = [NSHelpManager sharedHelpManager];
+    id			object = AUTORELEASE([[NSObject alloc] init]);
+    NSAttributedString	*help = AUTORELEASE([[NSAttributedString alloc]
+      initWithString: @"Help text"]);
+
+    PASS([hm contextHelpForObject: object] == nil,
+      "an object with no registered help returns nil");
+
+    [hm setContextHelp: help forObject: object];
+    PASS([[hm contextHelpForObject: object] isEqual: help],
+      "setContextHelp:forObject: stores the help for the object");
+
+    [hm removeContextHelpForObject: object];
+    PASS([hm contextHelpForObject: object] == nil,
+      "removeContextHelpForObject: removes the help");
+  END_SET("context help")
+
+  START_SET("context help mode")
+    PASS([NSHelpManager isContextHelpModeActive] == NO,
+      "context help mode is inactive by default");
+
+    [NSHelpManager setContextHelpModeActive: YES];
+    PASS([NSHelpManager isContextHelpModeActive] == YES,
+      "setContextHelpModeActive: turns the mode on");
+
+    [NSHelpManager setContextHelpModeActive: NO];
+    PASS([NSHelpManager isContextHelpModeActive] == NO,
+      "setContextHelpModeActive: turns the mode off");
+  END_SET("context help mode")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Coverage for NSHelpManager: the shared instance, setContextHelp:forObject: / contextHelpForObject: / removeContextHelpForObject: round-trip, and the isContextHelpModeActive / setContextHelpModeActive: mode flag.

Behaviour checked against Cocoa on macOS; all match, so this is tests only.