### PR TITLE
gui: find the auxiliary files when GNUSTEP_MAKEFILES is unset

### DIFF
--- a/configure
+++ b/configure
@@ -2477,7 +2477,11 @@ as_fn_append ac_header_c_list " unistd.h unistd_h HAVE_UNISTD_H"
 ac_aux_files="config.guess config.sub"
 
 # Locations in which to look for auxiliary files.
-ac_aux_dir_candidates="$GNUSTEP_MAKEFILES"
+ac_aux_dir_candidates="`if test -z "$GNUSTEP_MAKEFILES"; then
+  gnustep-config --variable=GNUSTEP_MAKEFILES 2>&5
+else
+  echo $GNUSTEP_MAKEFILES
+fi`"
 
 # Search for a directory containing all of the required auxiliary files,
 # $ac_aux_files, from the $PATH-style list $ac_aux_dir_candidates.

--- a/configure.ac
+++ b/configure.ac
@@ -41,8 +41,15 @@ fi
 
 #--------------------------------------------------------------------
 # Use config.guess, config.sub and install-sh provided by gnustep-make
+# Evaluation order of the configure script means we can not depend on
+# GNUSTEP_MAKEFILES being set for simple variable substitution, so we
+# execute a bit of shell code to dynamically get the directory.
 #--------------------------------------------------------------------
-AC_CONFIG_AUX_DIR($GNUSTEP_MAKEFILES)
+AC_CONFIG_AUX_DIR([`if test -z "$GNUSTEP_MAKEFILES"; then
+  gnustep-config --variable=GNUSTEP_MAKEFILES 2>&5
+else
+  echo $GNUSTEP_MAKEFILES
+fi`])
 
 AC_CONFIG_HEADERS([Headers/Additions/GNUstepGUI/config.h])
 


### PR DESCRIPTION
`configure` passed the `GNUSTEP_MAKEFILES` variable straight to `AC_CONFIG_AUX_DIR`, but the generated `configure` searches for `config.guess` and `config.sub` before the shell code that sets `GNUSTEP_MAKEFILES` from `gnustep-config` runs. With `GNUSTEP_MAKEFILES` unset in the environment, `configure` failed with `cannot find required auxiliary files`.

Resolve the makefiles directory inline in the `AC_CONFIG_AUX_DIR` argument, the way gnustep-base already does, so the auxiliary files are found whether or not `GNUSTEP_MAKEFILES` is set. The generated `configure` is updated to match (rather than regenerated, since it was produced with a different autoconf version than is available here; the inline argument text matches gnustep-base's shipped `configure`).

This is the same fix as gnustep/libs-back#54 for the identical problem in libs-back.

Verified: with `GNUSTEP_MAKEFILES` unset, the current `configure` fails with the auxiliary-files error, and with this change it completes and creates `config.make`. The normal case with `GNUSTEP_MAKEFILES` set is unaffected.
