### PR TITLE
NSLevelIndicatorCell: space tick marks evenly across the value range

### DIFF
--- a/Source/NSLevelIndicatorCell.m
+++ b/Source/NSLevelIndicatorCell.m
@@ -166,7 +166,12 @@
                    format: @"tick mark index invalid"];
     }
 
-  return _minValue + index * (_maxValue - _minValue) / _numberOfTickMarks;
+  if (_numberOfTickMarks == 1)
+    {
+      return (_minValue + _maxValue) / 2.0;
+    }
+
+  return _minValue + index * (_maxValue - _minValue) / (_numberOfTickMarks - 1);
 }
 
 - (NSRect) rectOfTickMarkAtIndex: (NSInteger)index

--- a/Tests/gui/NSLevelIndicatorCell/tickMarkValue.m
+++ b/Tests/gui/NSLevelIndicatorCell/tickMarkValue.m
@@ -1,0 +1,48 @@
+/* NSLevelIndicatorCell -tickMarkValueAtIndex: spaces the ticks evenly from
+   minValue at index 0 to maxValue at the last index (matching AppKit); a
+   single tick reports the midpoint of the range. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <math.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSLevelIndicatorCell.h>
+
+static BOOL eq(double a, double b) { return fabs(a - b) < 1e-9; }
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSLevelIndicatorCell *cell;
+
+  START_SET("NSLevelIndicatorCell tickMarkValue")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  cell = AUTORELEASE([[NSLevelIndicatorCell alloc] init]);
+  [cell setMinValue: 0.0];
+  [cell setMaxValue: 10.0];
+
+  [cell setNumberOfTickMarks: 11];
+  pass(eq([cell tickMarkValueAtIndex: 0], 0.0), "11 ticks: index 0 is minValue");
+  pass(eq([cell tickMarkValueAtIndex: 5], 5.0), "11 ticks: index 5 is the midpoint");
+  pass(eq([cell tickMarkValueAtIndex: 10], 10.0), "11 ticks: last index is maxValue");
+
+  [cell setNumberOfTickMarks: 2];
+  pass(eq([cell tickMarkValueAtIndex: 0], 0.0), "2 ticks: index 0 is minValue");
+  pass(eq([cell tickMarkValueAtIndex: 1], 10.0), "2 ticks: index 1 is maxValue");
+
+  [cell setNumberOfTickMarks: 1];
+  pass(eq([cell tickMarkValueAtIndex: 0], 5.0), "1 tick: reports the midpoint");
+
+  END_SET("NSLevelIndicatorCell tickMarkValue")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-tickMarkValueAtIndex:` divided the value range by the number of tick marks, so the last tick fell short of `maxValue` (11 ticks over 0..10 gave 9.09 at the last index instead of 10). Divide by `count - 1` so index 0 is `minValue` and the last index is `maxValue`, matching AppKit; a single tick reports the midpoint of the range.
