### PR TITLE
NSLevelIndicatorCell: default to the discrete-capacity style

### DIFF
--- a/Source/NSLevelIndicatorCell.m
+++ b/Source/NSLevelIndicatorCell.m
@@ -39,7 +39,7 @@
 
 - (id) init
 {
-  return [self initWithLevelIndicatorStyle: NSRatingLevelIndicatorStyle];
+  return [self initWithLevelIndicatorStyle: NSDiscreteCapacityLevelIndicatorStyle];
 }
 
 - (id) initWithLevelIndicatorStyle: (NSLevelIndicatorStyle)style

--- a/Tests/gui/NSLevelIndicatorCell/initStyle.m
+++ b/Tests/gui/NSLevelIndicatorCell/initStyle.m
@@ -1,0 +1,32 @@
+/* A default NSLevelIndicatorCell uses the discrete-capacity style, as AppKit
+   does. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSLevelIndicatorCell.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSLevelIndicatorCell *cell;
+
+  START_SET("NSLevelIndicatorCell initStyle")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  cell = AUTORELEASE([[NSLevelIndicatorCell alloc] init]);
+  pass([cell style] == NSDiscreteCapacityLevelIndicatorStyle,
+       "a default level indicator cell uses the discrete-capacity style");
+
+  END_SET("NSLevelIndicatorCell initStyle")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-init` created a rating-style cell. AppKit's default level indicator cell uses the discrete-capacity style; the default max value is 5 either way.
