### PR TITLE
NSLevelIndicatorCell: add the AppKit levelIndicatorStyle getter

### DIFF
--- a/Headers/AppKit/NSLevelIndicatorCell.h
+++ b/Headers/AppKit/NSLevelIndicatorCell.h
@@ -72,6 +72,7 @@ APPKIT_EXPORT_CLASS
 
 
 - (NSLevelIndicatorStyle)style;
+- (NSLevelIndicatorStyle)levelIndicatorStyle;
 - (void)setLevelIndicatorStyle:(NSLevelIndicatorStyle)style;
 - (NSInteger)numberOfMajorTickMarks;
 - (void)setNumberOfMajorTickMarks:(NSInteger)count;

--- a/Source/NSLevelIndicatorCell.m
+++ b/Source/NSLevelIndicatorCell.m
@@ -79,7 +79,12 @@
 
 - (NSLevelIndicatorStyle) style
 {
-  return _style; 
+  return _style;
+}
+
+- (NSLevelIndicatorStyle) levelIndicatorStyle
+{
+  return _style;
 }
 
 

--- a/Tests/gui/NSLevelIndicatorCell/levelIndicatorStyle.m
+++ b/Tests/gui/NSLevelIndicatorCell/levelIndicatorStyle.m
@@ -1,0 +1,44 @@
+/* NSLevelIndicatorCell answers -levelIndicatorStyle (AppKit's name for the
+   style getter) and returns the style set with -setLevelIndicatorStyle:. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSLevelIndicatorCell.h>
+
+/* Declared so the test compiles whether or not the getter is present yet; the
+   respondsToSelector: check is what actually verifies it. */
+@interface NSLevelIndicatorCell (Compat)
+- (NSLevelIndicatorStyle) levelIndicatorStyle;
+@end
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSLevelIndicatorCell *cell;
+
+  START_SET("NSLevelIndicatorCell levelIndicatorStyle")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  cell = AUTORELEASE([[NSLevelIndicatorCell alloc] init]);
+  pass([cell respondsToSelector: @selector(levelIndicatorStyle)],
+       "responds to -levelIndicatorStyle");
+  if ([cell respondsToSelector: @selector(levelIndicatorStyle)])
+    {
+      [cell setLevelIndicatorStyle: NSContinuousCapacityLevelIndicatorStyle];
+      pass([cell levelIndicatorStyle] == NSContinuousCapacityLevelIndicatorStyle,
+           "-levelIndicatorStyle returns the style set with -setLevelIndicatorStyle:");
+    }
+
+  END_SET("NSLevelIndicatorCell levelIndicatorStyle")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
AppKit's getter for the style is `-levelIndicatorStyle`; GNUstep only had the non-AppKit `-style`. Add `-levelIndicatorStyle` (keeping `-style`).
