### PR TITLE
NSDatePickerCell: clamp the date value to minDate and maxDate

### DIFF
--- a/Source/NSDatePickerCell.m
+++ b/Source/NSDatePickerCell.m
@@ -30,6 +30,7 @@
 */
 
 #import <Foundation/NSString.h>
+#import <Foundation/NSDate.h>
 #import <Foundation/NSDateFormatter.h>
 #import "AppKit/NSDatePickerCell.h"
 #import "AppKit/NSColor.h"
@@ -104,9 +105,26 @@
   return (NSDate *)[self objectValue];
 }
 
+- (NSDate *) _clampedDate: (NSDate *)date
+{
+  if (date == nil)
+    {
+      return date;
+    }
+  if (_minDate != nil && [date compare: _minDate] == NSOrderedAscending)
+    {
+      return _minDate;
+    }
+  if (_maxDate != nil && [date compare: _maxDate] == NSOrderedDescending)
+    {
+      return _maxDate;
+    }
+  return date;
+}
+
 - (void) setDateValue: (NSDate *)date
 {
-  [self setObjectValue: date];
+  [self setObjectValue: [self _clampedDate: date]];
 }
 
 - (id) delegate
@@ -147,6 +165,7 @@
 - (void) setMaxDate: (NSDate *)date
 {
   ASSIGN(_maxDate, date);
+  [self setObjectValue: [self _clampedDate: [self dateValue]]];
 }
 
 - (NSDate *) minDate
@@ -157,6 +176,7 @@
 - (void) setMinDate: (NSDate *)date
 {
   ASSIGN(_minDate, date);
+  [self setObjectValue: [self _clampedDate: [self dateValue]]];
 }
 
 - (NSColor *) textColor

--- a/Tests/gui/NSDatePickerCell/clamping.m
+++ b/Tests/gui/NSDatePickerCell/clamping.m
@@ -1,0 +1,57 @@
+/* NSDatePickerCell clamps its date value to [minDate, maxDate] when the value
+   is set and when the bounds later move past the value, as AppKit does. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSDate.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSDatePickerCell.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSDatePickerCell *cell;
+  NSDate *minD, *maxD;
+
+  START_SET("NSDatePickerCell clamping")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  minD = [NSDate dateWithTimeIntervalSinceReferenceDate: 0.0];
+  maxD = [NSDate dateWithTimeIntervalSinceReferenceDate: 1000000.0];
+
+  cell = AUTORELEASE([[NSDatePickerCell alloc] init]);
+  [cell setMinDate: minD];
+  [cell setMaxDate: maxD];
+  [cell setDateValue: [NSDate dateWithTimeIntervalSinceReferenceDate: -1000000.0]];
+  pass([[cell dateValue] isEqualToDate: minD],
+       "a date before minDate is clamped to minDate");
+  [cell setDateValue: [NSDate dateWithTimeIntervalSinceReferenceDate: 2000000.0]];
+  pass([[cell dateValue] isEqualToDate: maxD],
+       "a date after maxDate is clamped to maxDate");
+
+  cell = AUTORELEASE([[NSDatePickerCell alloc] init]);
+  [cell setDateValue: [NSDate dateWithTimeIntervalSinceReferenceDate: 500000.0]];
+  [cell setMinDate: [NSDate dateWithTimeIntervalSinceReferenceDate: 600000.0]];
+  pass([[cell dateValue] isEqualToDate:
+          [NSDate dateWithTimeIntervalSinceReferenceDate: 600000.0]],
+       "raising minDate past the value clamps the value up");
+
+  cell = AUTORELEASE([[NSDatePickerCell alloc] init]);
+  [cell setDateValue: [NSDate dateWithTimeIntervalSinceReferenceDate: 500000.0]];
+  [cell setMaxDate: [NSDate dateWithTimeIntervalSinceReferenceDate: 400000.0]];
+  pass([[cell dateValue] isEqualToDate:
+          [NSDate dateWithTimeIntervalSinceReferenceDate: 400000.0]],
+       "lowering maxDate past the value clamps the value down");
+
+  END_SET("NSDatePickerCell clamping")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSDatePickerCell stored the date value unchanged; AppKit clamps it to `[minDate, maxDate]` when it is set and re-clamps it when the bounds later move past it. Clamp in `-setDateValue:` and re-clamp in `-setMinDate:`/`-setMaxDate:`.
