### PR TITLE
NSDatePickerCell: default to the control text and background colours

### DIFF
--- a/Source/NSDatePickerCell.m
+++ b/Source/NSDatePickerCell.m
@@ -44,6 +44,8 @@
 
       [self setFormatter: formatter];
       RELEASE(formatter);
+      [self setTextColor: [NSColor controlTextColor]];
+      [self setBackgroundColor: [NSColor controlBackgroundColor]];
     }
 
   return self;

--- a/Tests/gui/NSDatePickerCell/defaultColors.m
+++ b/Tests/gui/NSDatePickerCell/defaultColors.m
@@ -1,0 +1,35 @@
+/* A default NSDatePickerCell uses the control text and control background
+   colours, as AppKit does. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSColor.h>
+#include <AppKit/NSDatePickerCell.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSDatePickerCell *cell;
+
+  START_SET("NSDatePickerCell defaultColors")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  cell = AUTORELEASE([[NSDatePickerCell alloc] init]);
+  pass([[cell textColor] isEqual: [NSColor controlTextColor]],
+       "default textColor is controlTextColor");
+  pass([[cell backgroundColor] isEqual: [NSColor controlBackgroundColor]],
+       "default backgroundColor is controlBackgroundColor");
+
+  END_SET("NSDatePickerCell defaultColors")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A default NSDatePickerCell had nil `textColor` and `backgroundColor`. AppKit uses `controlTextColor` and `controlBackgroundColor`. Set them in `-initTextCell:`.
