### PR TITLE
NSToolbarItem: enable a new item by default

### DIFF
--- a/Source/NSToolbarItem.m
+++ b/Source/NSToolbarItem.m
@@ -1230,6 +1230,7 @@ NSString *GSMovableToolbarItemPboardType = @"GSMovableToolbarItemPboardType";
           // Set the backview to an GSToolbarButton, will get reset to a 
           // GSToolbarBackView when setView: gets called.
 	  [self setView: nil];
+          [self setEnabled: YES];
         }        
     }
   

--- a/Tests/gui/NSToolbarItem/enabled.m
+++ b/Tests/gui/NSToolbarItem/enabled.m
@@ -1,0 +1,30 @@
+/* A fresh NSToolbarItem is enabled by default, as AppKit does. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSToolbarItem.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSToolbarItem *item;
+
+  START_SET("NSToolbarItem enabled")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  item = AUTORELEASE([[NSToolbarItem alloc] initWithItemIdentifier: @"e"]);
+  pass([item isEnabled] == YES, "a fresh toolbar item is enabled by default");
+
+  END_SET("NSToolbarItem enabled")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A fresh NSToolbarItem was disabled: its `GSToolbarButton` back-view starts disabled and `-isEnabled` reads through to it. AppKit enables a new item by default. Enable it in `-initWithItemIdentifier:`.
