### PR TITLE
NSToolbarItem: return an empty paletteLabel instead of nil by default

### DIFF
--- a/Source/NSToolbarItem.m
+++ b/Source/NSToolbarItem.m
@@ -1309,7 +1309,14 @@ NSString *GSMovableToolbarItemPboardType = @"GSMovableToolbarItemPboardType";
 
 - (NSString *) paletteLabel
 {
-  return _paletteLabel;
+  if (nil != _paletteLabel)
+    {
+      return _paletteLabel;
+    }
+  else
+    {
+      return @"";
+    }
 }
 
 - (void) setAction: (SEL)action

--- a/Tests/gui/NSToolbarItem/paletteLabel.m
+++ b/Tests/gui/NSToolbarItem/paletteLabel.m
@@ -1,0 +1,32 @@
+/* A default NSToolbarItem paletteLabel is the empty string, as AppKit does. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSToolbarItem.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSToolbarItem *item;
+
+  START_SET("NSToolbarItem paletteLabel")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  item = AUTORELEASE([[NSToolbarItem alloc] initWithItemIdentifier: @"p"]);
+  pass([[item paletteLabel] isEqualToString: @""],
+       "default paletteLabel is the empty string");
+
+  END_SET("NSToolbarItem paletteLabel")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-paletteLabel` returned nil for a fresh item; AppKit returns the empty string, the same way `-label` already does. Return `@""` when no palette label has been set.
