### PR TITLE
NSToolbarItem: default the tag to -1

### DIFF
--- a/Source/NSToolbarItem.m
+++ b/Source/NSToolbarItem.m
@@ -1230,6 +1230,7 @@ NSString *GSMovableToolbarItemPboardType = @"GSMovableToolbarItemPboardType";
           // Set the backview to an GSToolbarButton, will get reset to a 
           // GSToolbarBackView when setView: gets called.
 	  [self setView: nil];
+          _tag = -1;
         }        
     }
   

--- a/Tests/gui/NSToolbarItem/tag.m
+++ b/Tests/gui/NSToolbarItem/tag.m
@@ -1,0 +1,30 @@
+/* A default NSToolbarItem tag is -1, as AppKit does. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSToolbarItem.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSToolbarItem *item;
+
+  START_SET("NSToolbarItem tag")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  item = AUTORELEASE([[NSToolbarItem alloc] initWithItemIdentifier: @"t"]);
+  pass([item tag] == -1, "default tag is -1");
+
+  END_SET("NSToolbarItem tag")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A fresh NSToolbarItem reported a `tag` of 0; AppKit uses -1. Default the tag to -1 in `-initWithItemIdentifier:`.
