### PR TITLE
NSTabViewItem: start the label off as the empty string

### DIFF
--- a/Source/NSTabViewItem.m
+++ b/Source/NSTabViewItem.m
@@ -121,7 +121,14 @@
 
 - (NSString *) label
 {
-  return _label;
+  if (nil != _label)
+    {
+      return _label;
+    }
+  else
+    {
+      return @"";
+    }
 }
 
 - (NSSize) sizeOfLabel: (BOOL)shouldTruncateLabel

--- a/Tests/gui/NSTabViewItem/labelDefault.m
+++ b/Tests/gui/NSTabViewItem/labelDefault.m
@@ -1,0 +1,32 @@
+/* A default NSTabViewItem label is the empty string, as AppKit does. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTabViewItem.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTabViewItem *item;
+
+  START_SET("NSTabViewItem labelDefault")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  item = AUTORELEASE([[NSTabViewItem alloc] initWithIdentifier: @"l"]);
+  pass([[item label] isEqualToString: @""],
+       "default label is the empty string");
+
+  END_SET("NSTabViewItem labelDefault")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A new item's label was nil, where AppKit's is the empty string. The initialiser
sets it now, rather than the getter answering for it.

Setting it in the initialiser is not only tidier here, it is the behaviour
AppKit has. Checked on a macOS runner:

    NSTabViewItem   default: empty   after setLabel:nil: nil
    NSToolbarItem   default: empty   after setLabel:nil: empty

So a tab view item's label can go back to nil once it has been set, and only
starts out empty. Answering for it in the getter would have kept the empty
string forever, which is not what AppKit does. The test covers the round-trip
and the nil.

-initWithIdentifier: is the initialiser plain -init and the keyed decode both
go through, so an item made any of those ways starts the same.
