### PR TITLE
NSLayoutConstraint: add the missing setConstant: setter

### DIFF
--- a/Headers/AppKit/NSLayoutConstraint.h
+++ b/Headers/AppKit/NSLayoutConstraint.h
@@ -158,6 +158,7 @@ APPKIT_EXPORT_CLASS
 - (CGFloat) multiplier;
 
 - (CGFloat) constant;
+- (void) setConstant: (CGFloat)constant;
 
 - (NSLayoutAnchor *) firstAnchor;
 

--- a/Source/NSLayoutConstraint.m
+++ b/Source/NSLayoutConstraint.m
@@ -412,6 +412,11 @@ static NSMutableArray *activeConstraints = nil;
   return _constant;
 }
 
+- (void) setConstant: (CGFloat)constant
+{
+  _constant = constant;
+}
+
 - (NSLayoutAnchor *) firstAnchor
 {
   return _firstAnchor;

--- a/Tests/gui/NSLayoutConstraint/setConstant.m
+++ b/Tests/gui/NSLayoutConstraint/setConstant.m
@@ -1,0 +1,53 @@
+/* NSLayoutConstraint -setConstant: changes the constant, as AppKit allows. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSView.h>
+#include <AppKit/NSLayoutConstraint.h>
+
+/* Declared so the test compiles whether or not the setter is present yet; the
+   respondsToSelector: check is what actually verifies it. */
+@interface NSLayoutConstraint (Compat)
+- (void) setConstant: (CGFloat)constant;
+@end
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSView *v1, *v2;
+  NSLayoutConstraint *c;
+
+  START_SET("NSLayoutConstraint setConstant")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  v1 = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+  v2 = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 40, 40)]);
+  [v1 addSubview: v2];
+  c = [NSLayoutConstraint constraintWithItem: v1
+                                   attribute: NSLayoutAttributeWidth
+                                   relatedBy: NSLayoutRelationEqual
+                                      toItem: v2
+                                   attribute: NSLayoutAttributeWidth
+                                  multiplier: 1.0
+                                    constant: 5.0];
+  pass([c respondsToSelector: @selector(setConstant:)], "responds to -setConstant:");
+  if ([c respondsToSelector: @selector(setConstant:)])
+    {
+      [c setConstant: 42.0];
+      pass([c constant] == 42.0, "-setConstant: changes the constant");
+    }
+
+  END_SET("NSLayoutConstraint setConstant")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
GNUstep's NSLayoutConstraint exposed `constant` as a read-only accessor. AppKit lets you change it through `-setConstant:` (Auto Layout code routinely adjusts a constraint's constant at runtime). Add the setter; the `_constant` ivar already exists.
