### PR TITLE
NSLayoutConstraint: add the identifier accessors

### DIFF
--- a/Headers/AppKit/NSLayoutConstraint.h
+++ b/Headers/AppKit/NSLayoutConstraint.h
@@ -122,6 +122,7 @@ APPKIT_EXPORT_CLASS
   CGFloat _multiplier;
   CGFloat _constant;
   NSLayoutPriority _priority;
+  NSString *_identifier;
 }
 
 + (NSArray *)constraintsWithVisualFormat: (NSString *)fmt 
@@ -158,6 +159,9 @@ APPKIT_EXPORT_CLASS
 - (CGFloat) multiplier;
 
 - (CGFloat) constant;
+
+- (NSString *) identifier;
+- (void) setIdentifier: (NSString *)identifier;
 
 - (NSLayoutAnchor *) firstAnchor;
 

--- a/Source/NSLayoutConstraint.m
+++ b/Source/NSLayoutConstraint.m
@@ -412,6 +412,16 @@ static NSMutableArray *activeConstraints = nil;
   return _constant;
 }
 
+- (NSString *) identifier
+{
+  return _identifier;
+}
+
+- (void) setIdentifier: (NSString *)identifier
+{
+  ASSIGN(_identifier, identifier);
+}
+
 - (NSLayoutAnchor *) firstAnchor
 {
   return _firstAnchor;
@@ -574,6 +584,7 @@ static NSMutableArray *activeConstraints = nil;
 - (void) dealloc
 {
   [NSLayoutConstraint _removeConstraint: self];
+  RELEASE(_identifier);
   [super dealloc];
 }
 

--- a/Tests/gui/NSLayoutConstraint/identifier.m
+++ b/Tests/gui/NSLayoutConstraint/identifier.m
@@ -1,0 +1,57 @@
+/* NSLayoutConstraint has an identifier that defaults to nil and round-trips
+   through -setIdentifier:, as AppKit does. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSView.h>
+#include <AppKit/NSLayoutConstraint.h>
+
+@interface NSLayoutConstraint (Compat)
+- (NSString *) identifier;
+- (void) setIdentifier: (NSString *)identifier;
+@end
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSView *v1, *v2;
+  NSLayoutConstraint *c;
+
+  START_SET("NSLayoutConstraint identifier")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  v1 = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+  v2 = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 40, 40)]);
+  [v1 addSubview: v2];
+  c = [NSLayoutConstraint constraintWithItem: v1
+                                   attribute: NSLayoutAttributeWidth
+                                   relatedBy: NSLayoutRelationEqual
+                                      toItem: v2
+                                   attribute: NSLayoutAttributeWidth
+                                  multiplier: 1.0
+                                    constant: 5.0];
+  pass([c respondsToSelector: @selector(identifier)], "responds to -identifier");
+  pass([c respondsToSelector: @selector(setIdentifier:)],
+       "responds to -setIdentifier:");
+  if ([c respondsToSelector: @selector(setIdentifier:)])
+    {
+      pass([c identifier] == nil, "default identifier is nil");
+      [c setIdentifier: @"myC"];
+      pass([[c identifier] isEqualToString: @"myC"], "identifier round-trips");
+    }
+
+  END_SET("NSLayoutConstraint identifier")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSLayoutConstraint had no `identifier`. AppKit gives a constraint an identifier (default nil) used for debugging and Interface Builder. Add the `identifier` / `setIdentifier:` accessors.
