### PR TITLE
Fix: NSPathControl -isEditable / -setEditable:

### DIFF
--- a/Headers/AppKit/NSPathControl.h
+++ b/Headers/AppKit/NSPathControl.h
@@ -48,6 +48,7 @@ APPKIT_EXPORT_CLASS
   NSDragOperation _localMask;
   NSDragOperation _remoteMask;
   NSTrackingRectTag _trackingTag;
+  BOOL _editable;
 }
 
 - (void) setPathStyle: (NSPathStyle)style;
@@ -86,7 +87,10 @@ APPKIT_EXPORT_CLASS
 
 - (NSString *) placeholderString;
 - (void) setPlaceholderString: (NSString *)string;
- 
+
+- (BOOL) isEditable;
+- (void) setEditable: (BOOL)flag;
+
 @end
 
 @protocol NSPathControlDelegate

--- a/Source/NSPathControl.m
+++ b/Source/NSPathControl.m
@@ -79,15 +79,16 @@ static Class pathCellClass;
                                       assumeInside: YES];
 }
 
-- (instancetype) init
+- (instancetype) initWithFrame: (NSRect)frameRect
 {
-  self = [super init];
+  self = [super initWithFrame: frameRect];
   if (self != nil)
     {
       [self setPathStyle: NSPathStyleStandard];
       [self setURL: nil];
       [self setDelegate: nil];
       [self setAllowedTypes: [NSArray arrayWithObject: NSFilenamesPboardType]];
+      _editable = YES;
     }
   return self;
 }
@@ -270,6 +271,16 @@ static Class pathCellClass;
 {
   [_cell setPlaceholderString: string];
   [self setNeedsDisplay];
+}
+
+- (BOOL) isEditable
+{
+  return _editable;
+}
+
+- (void) setEditable: (BOOL)flag
+{
+  _editable = flag;
 }
 
 - (NSColor *) backgroundColor

--- a/Tests/gui/NSPathControl/editable.m
+++ b/Tests/gui/NSPathControl/editable.m
@@ -1,0 +1,38 @@
+/* -[NSPathControl isEditable] defaults to YES and -setEditable: round-trips,
+   matching AppKit. */
+#import "Testing.h"
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSPathControl.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSPathControl editable")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NSPathControl *pc =
+      [[NSPathControl alloc] initWithFrame: NSMakeRect(0, 0, 200, 30)];
+
+  PASS([pc isEditable] == YES, "-isEditable defaults to YES");
+
+  [pc setEditable: NO];
+  PASS([pc isEditable] == NO, "-setEditable: NO round-trips");
+
+  [pc setEditable: YES];
+  PASS([pc isEditable] == YES, "-setEditable: YES round-trips");
+
+  RELEASE(pc);
+
+  END_SET("NSPathControl editable")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
AppKit provides `-[NSPathControl isEditable]` (default YES) and `-setEditable:`; GNUstep had neither. This adds the accessors with a backing ivar defaulting to YES.

Verified against AppKit on macOS. Includes a test that fails before the change and passes after.