### PR TITLE
Fix: NSPathCell -pathComponentCells returns an empty array

### DIFF
--- a/Source/NSPathCell.m
+++ b/Source/NSPathCell.m
@@ -169,6 +169,10 @@ static Class pathComponentCellClass;
 
 - (NSArray *) pathComponentCells
 {
+  if (_pathComponentCells == nil)
+    {
+      return [NSArray array];
+    }
   return _pathComponentCells;
 }
 

--- a/Tests/gui/NSPathCell/pathcomponentcells.m
+++ b/Tests/gui/NSPathCell/pathcomponentcells.m
@@ -1,0 +1,34 @@
+/* -[NSPathCell pathComponentCells] returns an empty array (not nil) for a cell
+   with no components, matching AppKit. */
+#import "Testing.h"
+#import <Foundation/NSArray.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSPathCell.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSPathCell pathComponentCells")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NSPathCell *pc = [[NSPathCell alloc] init];
+
+  PASS([pc pathComponentCells] != nil,
+       "-pathComponentCells is not nil for an empty cell");
+  PASS([[pc pathComponentCells] count] == 0,
+       "-pathComponentCells is empty for an empty cell");
+
+  RELEASE(pc);
+
+  END_SET("NSPathCell pathComponentCells")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
On a freshly created NSPathCell with no components, `-pathComponentCells` returns nil under GNUstep; AppKit returns an empty array. This returns an empty array in that case.

Verified against AppKit on macOS. Includes a test that fails before the change and passes after.