### PR TITLE
Fix: NSLayoutAnchor -constraintEqualToAnchor:constant: honours the constant

### DIFF
--- a/Source/NSLayoutAnchor.m
+++ b/Source/NSLayoutAnchor.m
@@ -72,7 +72,7 @@
                                          toItem: [anchor item]
                                       attribute: NSLayoutAttributeLeft
                                      multiplier: 1.0
-                                       constant: 0.0];
+                                       constant: c];
 }
 
 - (NSLayoutConstraint *) constraintGreaterThanOrEqualToAnchor: (NSLayoutAnchor *)anchor constant: (CGFloat)c

--- a/Tests/gui/NSLayoutAnchor/equalconstant.m
+++ b/Tests/gui/NSLayoutAnchor/equalconstant.m
@@ -1,0 +1,26 @@
+/* -[NSLayoutAnchor constraintEqualToAnchor:constant:] carries the constant
+   through to the resulting constraint, matching AppKit and its own
+   greater-than / less-than siblings. */
+#import "Testing.h"
+#import <AppKit/NSLayoutAnchor.h>
+#import <AppKit/NSLayoutConstraint.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  NSLayoutAnchor *a = AUTORELEASE([[NSLayoutAnchor alloc] init]);
+
+  NSLayoutConstraint *e = [a constraintEqualToAnchor: a constant: 10.0];
+  PASS([e constant] == 10.0,
+       "constraintEqualToAnchor:constant: carries the constant");
+
+  /* The greater-/less-than variants already carry it; check for parity. */
+  NSLayoutConstraint *g = [a constraintGreaterThanOrEqualToAnchor: a
+                                                         constant: 10.0];
+  PASS([g constant] == 10.0,
+       "constraintGreaterThanOrEqualToAnchor:constant: carries the constant");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSLayoutAnchor constraintEqualToAnchor:constant:]` passed a hardcoded `0.0` as the constant instead of the `c` argument, so the constant was silently dropped. Its `constraintGreaterThanOrEqualToAnchor:constant:` and `constraintLessThanOrEqualToAnchor:constant:` siblings already pass `c` through. This passes `c` through as well.

Verified against AppKit on macOS (a constraint built from an anchor with a constant carries that constant). Includes a test that fails before the change and passes after.