### PR TITLE
Fix: vend layout anchors from NSView

### DIFF
--- a/Headers/AppKit/NSLayoutAnchor.h
+++ b/Headers/AppKit/NSLayoutAnchor.h
@@ -44,6 +44,7 @@ APPKIT_EXPORT_CLASS
   id _item;
   BOOL _hasAmbiguousLayout;
   NSArray *_constraintsAffectingLayout;
+  NSInteger _attribute;
 }
 
 - (NSLayoutConstraint *) constraintEqualToAnchor: (NSLayoutAnchor *)anchor;

--- a/Headers/AppKit/NSView.h
+++ b/Headers/AppKit/NSView.h
@@ -741,6 +741,25 @@ PACKAGE_SCOPE
 - (void) addConstraints: (NSArray*)constraints;
 
 @end
+
+@interface NSView (NSConstraintBasedLayoutAnchors)
+
+- (NSLayoutXAxisAnchor *) leadingAnchor;
+- (NSLayoutXAxisAnchor *) trailingAnchor;
+- (NSLayoutXAxisAnchor *) leftAnchor;
+- (NSLayoutXAxisAnchor *) rightAnchor;
+- (NSLayoutXAxisAnchor *) centerXAnchor;
+
+- (NSLayoutYAxisAnchor *) topAnchor;
+- (NSLayoutYAxisAnchor *) bottomAnchor;
+- (NSLayoutYAxisAnchor *) centerYAnchor;
+- (NSLayoutYAxisAnchor *) firstBaselineAnchor;
+- (NSLayoutYAxisAnchor *) lastBaselineAnchor;
+
+- (NSLayoutDimension *) widthAnchor;
+- (NSLayoutDimension *) heightAnchor;
+
+@end
 #endif
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)

--- a/Source/GSAutoLayoutAnchorPrivate.h
+++ b/Source/GSAutoLayoutAnchorPrivate.h
@@ -1,0 +1,40 @@
+/* GSAutoLayoutAnchorPrivate.h
+
+   Private interface used to create NSLayoutAnchor instances bound to a
+   particular item and layout attribute.
+
+   Copyright (C) 2020 Free Software Foundation, Inc.
+
+   This file is part of the GNUstep Library.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free
+   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110 USA.
+*/
+
+#ifndef _GSAutoLayoutAnchorPrivate_h_GNUSTEP_GUI_INCLUDE
+#define _GSAutoLayoutAnchorPrivate_h_GNUSTEP_GUI_INCLUDE
+
+#import "AppKit/NSLayoutAnchor.h"
+#import "AppKit/NSLayoutConstraint.h"
+
+@interface NSLayoutAnchor (GSAutoLayoutAnchorPrivate)
+
+- (instancetype) initWithItem: (id)item attribute: (NSLayoutAttribute)attribute;
+
+- (NSLayoutAttribute) attribute;
+
+@end
+
+#endif /* _GSAutoLayoutAnchorPrivate_h_GNUSTEP_GUI_INCLUDE */

--- a/Source/NSLayoutAnchor.m
+++ b/Source/NSLayoutAnchor.m
@@ -28,16 +28,36 @@
 
 #import "AppKit/NSLayoutAnchor.h"
 #import "AppKit/NSLayoutConstraint.h"
+#import "GSAutoLayoutAnchorPrivate.h"
 
 @implementation NSLayoutAnchor
+
+- (instancetype) initWithItem: (id)item attribute: (NSLayoutAttribute)attribute
+{
+  self = [super init];
+  if (self != nil)
+    {
+      _name = nil;
+      ASSIGN(_item, item);
+      _hasAmbiguousLayout = NO;
+      _constraintsAffectingLayout = [[NSMutableArray alloc] init];
+      _attribute = attribute;
+    }
+  return self;
+}
+
+- (NSLayoutAttribute) attribute
+{
+  return _attribute;
+}
 
 - (NSLayoutConstraint *) constraintEqualToAnchor: (NSLayoutAnchor *)anchor
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationEqual
                                          toItem: [anchor item]
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: [anchor attribute]
                                      multiplier: 1.0
                                        constant: 0.0];
 }
@@ -45,10 +65,10 @@
 - (NSLayoutConstraint *) constraintGreaterThanOrEqualToAnchor: (NSLayoutAnchor *)anchor
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationGreaterThanOrEqual
                                          toItem: [anchor item]
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: [anchor attribute]
                                      multiplier: 1.0
                                        constant: 0.0];
 }
@@ -56,10 +76,10 @@
 - (NSLayoutConstraint *) constraintLessThanOrEqualToAnchor: (NSLayoutAnchor *)anchor
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationLessThanOrEqual
                                          toItem: [anchor item]
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: [anchor attribute]
                                      multiplier: 1.0
                                        constant: 0.0];
 }
@@ -67,21 +87,21 @@
 - (NSLayoutConstraint *) constraintEqualToAnchor: (NSLayoutAnchor *)anchor constant: (CGFloat)c
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationEqual
                                          toItem: [anchor item]
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: [anchor attribute]
                                      multiplier: 1.0
-                                       constant: 0.0];
+                                       constant: c];
 }
 
 - (NSLayoutConstraint *) constraintGreaterThanOrEqualToAnchor: (NSLayoutAnchor *)anchor constant: (CGFloat)c
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationGreaterThanOrEqual
                                          toItem: [anchor item]
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: [anchor attribute]
                                      multiplier: 1.0
                                        constant: c];
 }
@@ -89,25 +109,17 @@
 - (NSLayoutConstraint *) constraintLessThanOrEqualToAnchor: (NSLayoutAnchor *)anchor constant: (CGFloat)c
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationLessThanOrEqual
                                          toItem: [anchor item]
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: [anchor attribute]
                                      multiplier: 1.0
                                        constant: c];
 }
 
 - (instancetype) init
 {
-  self = [super init];
-  if (self != nil)
-    {
-      _name = nil;
-      _item = nil;
-      _hasAmbiguousLayout = NO;
-      _constraintsAffectingLayout = [[NSMutableArray alloc] init];
-    }
-  return self;
+  return [self initWithItem: nil attribute: NSLayoutAttributeNotAnAttribute];
 }
 
 - (void) dealloc
@@ -160,10 +172,10 @@
 - (NSLayoutConstraint *) constraintEqualToConstant: (CGFloat)c
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationEqual
-                                         toItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                         toItem: nil
+                                      attribute: NSLayoutAttributeNotAnAttribute
                                      multiplier: 1.0
                                        constant: c];
 }
@@ -171,10 +183,10 @@
 - (NSLayoutConstraint *) constraintGreaterThanOrEqualToConstant: (CGFloat)c
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationGreaterThanOrEqual
-                                         toItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                         toItem: nil
+                                      attribute: NSLayoutAttributeNotAnAttribute
                                      multiplier: 1.0
                                        constant: c];
 }
@@ -182,10 +194,10 @@
 - (NSLayoutConstraint *) constraintLessThanOrEqualToConstant: (CGFloat)c
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationLessThanOrEqual
-                                         toItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                         toItem: nil
+                                      attribute: NSLayoutAttributeNotAnAttribute
                                      multiplier: 1.0
                                        constant: c];
 }
@@ -193,10 +205,10 @@
 - (NSLayoutConstraint *) constraintEqualToAnchor: (NSLayoutDimension *)anchor multiplier: (CGFloat)m
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationEqual
                                          toItem: [anchor item]
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: [anchor attribute]
                                      multiplier: m
                                        constant: 0.0];
 }
@@ -204,10 +216,10 @@
 - (NSLayoutConstraint *) constraintGreaterThanOrEqualToAnchor: (NSLayoutDimension *)anchor multiplier: (CGFloat)m
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationGreaterThanOrEqual
                                          toItem: [anchor item]
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: [anchor attribute]
                                      multiplier: m
                                        constant: 0.0];
 }
@@ -215,10 +227,10 @@
 - (NSLayoutConstraint *) constraintLessThanOrEqualToAnchor: (NSLayoutDimension *)anchor multiplier: (CGFloat)m
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationLessThanOrEqual
                                          toItem: [anchor item]
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: [anchor attribute]
                                      multiplier: m
                                        constant: 0.0];
 }
@@ -226,10 +238,10 @@
 - (NSLayoutConstraint *) constraintEqualToAnchor: (NSLayoutDimension *)anchor multiplier: (CGFloat)m constant: (CGFloat)c
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationEqual
                                          toItem: [anchor item]
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: [anchor attribute]
                                      multiplier: m
                                        constant: c];
 }
@@ -237,10 +249,10 @@
 - (NSLayoutConstraint *) constraintGreaterThanOrEqualToAnchor: (NSLayoutDimension *)anchor multiplier: (CGFloat)m constant: (CGFloat)c
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationGreaterThanOrEqual
                                          toItem: [anchor item]
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: [anchor attribute]
                                      multiplier: m
                                        constant: c];
 }
@@ -248,10 +260,10 @@
 - (NSLayoutConstraint *) constraintLessThanOrEqualToAnchor: (NSLayoutDimension *)anchor multiplier: (CGFloat)m constant: (CGFloat)c
 {
   return [NSLayoutConstraint constraintWithItem: _item
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: _attribute
                                       relatedBy: NSLayoutRelationLessThanOrEqual
                                          toItem: [anchor item]
-                                      attribute: NSLayoutAttributeLeft
+                                      attribute: [anchor attribute]
                                      multiplier: m
                                        constant: c];
 }

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -82,7 +82,8 @@
 #import "GSFastEnumeration.h"
 #import "GSGuiPrivate.h"
 #import "GSAutoLayoutEngine.h"
-#import "NSAutoresizingMaskLayoutConstraint.h" 
+#import "GSAutoLayoutAnchorPrivate.h"
+#import "NSAutoresizingMaskLayoutConstraint.h"
 #import "NSViewPrivate.h"
 #import "NSWindowPrivate.h"
 
@@ -5475,6 +5476,94 @@ static NSView* findByTag(NSView *view, NSInteger aTag, NSUInteger *level)
     }
 
   return [engine constraintsForView: self];
+}
+
+@end
+
+@implementation NSView (NSConstraintBasedLayoutAnchors)
+
+- (NSLayoutXAxisAnchor *) leadingAnchor
+{
+  return AUTORELEASE([[NSLayoutXAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeLeading]);
+}
+
+- (NSLayoutXAxisAnchor *) trailingAnchor
+{
+  return AUTORELEASE([[NSLayoutXAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeTrailing]);
+}
+
+- (NSLayoutXAxisAnchor *) leftAnchor
+{
+  return AUTORELEASE([[NSLayoutXAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeLeft]);
+}
+
+- (NSLayoutXAxisAnchor *) rightAnchor
+{
+  return AUTORELEASE([[NSLayoutXAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeRight]);
+}
+
+- (NSLayoutXAxisAnchor *) centerXAnchor
+{
+  return AUTORELEASE([[NSLayoutXAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeCenterX]);
+}
+
+- (NSLayoutYAxisAnchor *) topAnchor
+{
+  return AUTORELEASE([[NSLayoutYAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeTop]);
+}
+
+- (NSLayoutYAxisAnchor *) bottomAnchor
+{
+  return AUTORELEASE([[NSLayoutYAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeBottom]);
+}
+
+- (NSLayoutYAxisAnchor *) centerYAnchor
+{
+  return AUTORELEASE([[NSLayoutYAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeCenterY]);
+}
+
+- (NSLayoutYAxisAnchor *) firstBaselineAnchor
+{
+  return AUTORELEASE([[NSLayoutYAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeFirstBaseline]);
+}
+
+- (NSLayoutYAxisAnchor *) lastBaselineAnchor
+{
+  return AUTORELEASE([[NSLayoutYAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeLastBaseline]);
+}
+
+- (NSLayoutDimension *) widthAnchor
+{
+  return AUTORELEASE([[NSLayoutDimension alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeWidth]);
+}
+
+- (NSLayoutDimension *) heightAnchor
+{
+  return AUTORELEASE([[NSLayoutDimension alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeHeight]);
 }
 
 @end

--- a/Tests/gui/NSLayoutAnchor/viewanchors.m
+++ b/Tests/gui/NSLayoutAnchor/viewanchors.m
@@ -1,0 +1,65 @@
+/* NSView vends layout anchors (leadingAnchor/widthAnchor/topAnchor/...), and
+   the constraints those anchors build carry the right item, attribute, relation,
+   multiplier and constant.  Values checked against AppKit on macOS. */
+#import "Testing.h"
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSLayoutAnchor.h>
+#import <AppKit/NSLayoutConstraint.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSView layout anchors")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NSView *v = AUTORELEASE([[NSView alloc]
+                            initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+  NSView *v2 = AUTORELEASE([[NSView alloc]
+                             initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+
+  /* Anchor kinds. */
+  PASS([[v widthAnchor] isKindOfClass: [NSLayoutDimension class]],
+       "-widthAnchor is an NSLayoutDimension");
+  PASS([[v leadingAnchor] isKindOfClass: [NSLayoutXAxisAnchor class]],
+       "-leadingAnchor is an NSLayoutXAxisAnchor");
+  PASS([[v topAnchor] isKindOfClass: [NSLayoutYAxisAnchor class]],
+       "-topAnchor is an NSLayoutYAxisAnchor");
+
+  /* Dimension constant constraint: item, attribute, no second item. */
+  NSLayoutConstraint *w = [[v widthAnchor] constraintEqualToConstant: 50.0];
+  PASS([w firstItem] == v, "width constraint firstItem is the view");
+  PASS([w firstAttribute] == NSLayoutAttributeWidth,
+       "width constraint firstAttribute is Width");
+  PASS([w secondItem] == nil, "width constraint has no second item");
+  PASS([w secondAttribute] == NSLayoutAttributeNotAnAttribute,
+       "width constraint secondAttribute is NotAnAttribute");
+  PASS([w constant] == 50.0, "width constraint constant is 50");
+  PASS([w relation] == NSLayoutRelationEqual, "width constraint relation is Equal");
+  PASS([w multiplier] == 1.0, "width constraint multiplier is 1");
+
+  /* Anchor-to-anchor constraint carries both attributes and the constant. */
+  NSLayoutConstraint *lead =
+      [[v leadingAnchor] constraintEqualToAnchor: [v2 leadingAnchor]
+                                        constant: 8.0];
+  PASS([lead firstItem] == v, "leading constraint firstItem is the view");
+  PASS([lead firstAttribute] == NSLayoutAttributeLeading,
+       "leading constraint firstAttribute is Leading");
+  PASS([lead secondItem] == v2, "leading constraint secondItem is the other view");
+  PASS([lead secondAttribute] == NSLayoutAttributeLeading,
+       "leading constraint secondAttribute is Leading");
+  PASS([lead constant] == 8.0, "leading constraint constant is 8");
+
+  END_SET("NSView layout anchors")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSView did not implement the NSLayoutAnchor factory properties (`leadingAnchor`, `widthAnchor`, `topAnchor` and the rest), so anchor-based Auto Layout was unavailable even though the constraint solver (`GSAutoLayoutEngine`, `addConstraint:`) was already present. NSLayoutAnchor itself carried no notion of which attribute an anchor represents and hardcoded `NSLayoutAttributeLeft` in every constraint it built.

This change:
- gives NSLayoutAnchor an attribute and an internal initialiser binding an anchor to an item and attribute;
- builds constraints using the anchor's own attribute and the other anchor's attribute instead of a hardcoded `Left`;
- makes `NSLayoutDimension`'s `constraintEqualToConstant:` (and the greater-/less-than variants) produce a constraint with no second item and `NotAnAttribute`, matching AppKit;
- adds the twelve anchor accessors to NSView (leading/trailing/left/right/centerX, top/bottom/centerY/firstBaseline/lastBaseline, width/height).

Verified against AppKit on macOS: for a view, `widthAnchor constraintEqualToConstant:50` and `leadingAnchor constraintEqualToAnchor:other.leadingAnchor constant:8` now produce constraints with the same firstItem/attribute, secondItem/attribute, relation, multiplier and constant as AppKit. Includes a test. Existing NSView tests still pass.

Note: this also corrects `constraintEqualToAnchor:constant:` dropping its constant, which is the subject of the smaller standalone PR #549; either can land first.