### PR TITLE
Fix: implement NSView layout-guide support

### DIFF
--- a/Headers/AppKit/NSView.h
+++ b/Headers/AppKit/NSView.h
@@ -200,6 +200,7 @@ PACKAGE_SCOPE
   NSShadow *_shadow;
   NSAppearance* _appearance;
   NSUserInterfaceItemIdentifier _identifier;
+  NSMutableArray *_layoutGuides;
 
 }
 

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -64,6 +64,7 @@
 #import "AppKit/NSGraphics.h"
 #import "AppKit/NSKeyValueBinding.h"
 #import "AppKit/NSLayoutConstraint.h"
+#import "AppKit/NSLayoutGuide.h"
 #import "AppKit/NSMenu.h"
 #import "AppKit/NSPasteboard.h"
 #import "AppKit/NSPrintInfo.h"
@@ -794,7 +795,8 @@ GSSetDragTypes(NSView* obj, NSArray *types)
   TEST_RELEASE(_cursor_rects);
   TEST_RELEASE(_tracking_rects);
   TEST_RELEASE(_shadow);
-  
+  TEST_RELEASE(_layoutGuides);
+
   [self unregisterDraggedTypes];
   [self releaseGState];
 
@@ -5649,6 +5651,49 @@ static NSView* findByTag(NSView *view, NSInteger aTag, NSUInteger *level)
   return AUTORELEASE([[NSLayoutDimension alloc]
                        initWithItem: self
                           attribute: NSLayoutAttributeHeight]);
+}
+
+@end
+
+@implementation NSView (NSLayoutGuideSupport)
+
+- (void) addLayoutGuide: (NSLayoutGuide *)guide
+{
+  if (guide == nil)
+    {
+      return;
+    }
+
+  if (_layoutGuides == nil)
+    {
+      _layoutGuides = [[NSMutableArray alloc] init];
+    }
+
+  if (![_layoutGuides containsObject: guide])
+    {
+      [_layoutGuides addObject: guide];
+      [guide setOwningView: self];
+    }
+}
+
+- (void) removeLayoutGuide: (NSLayoutGuide *)guide
+{
+  if (guide == nil || ![_layoutGuides containsObject: guide])
+    {
+      return;
+    }
+
+  [guide setOwningView: nil];
+  [_layoutGuides removeObject: guide];
+}
+
+- (NSArray *) layoutGuides
+{
+  if (_layoutGuides == nil)
+    {
+      return [NSArray array];
+    }
+  return [NSArray arrayWithArray: _layoutGuides];
 }
 
 @end

--- a/Tests/gui/NSLayoutGuide/support.m
+++ b/Tests/gui/NSLayoutGuide/support.m
@@ -1,0 +1,52 @@
+/* NSView layout-guide support: -addLayoutGuide: adds the guide and sets its
+   owning view, -layoutGuides reports it, and -removeLayoutGuide: reverses both.
+   Behaviour checked against AppKit on macOS. */
+#import "Testing.h"
+#import <Foundation/NSArray.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSLayoutGuide.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSView layout guides")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NSView *v = AUTORELEASE([[NSView alloc]
+                            initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+  NSLayoutGuide *g = AUTORELEASE([[NSLayoutGuide alloc] init]);
+
+  /* A view with no guides reports an empty (non-nil) array. */
+  PASS([v layoutGuides] != nil, "-layoutGuides is not nil");
+  PASS([[v layoutGuides] count] == 0, "-layoutGuides is empty by default");
+
+  /* Adding a guide registers it and sets its owning view. */
+  [v addLayoutGuide: g];
+  PASS([g owningView] == v, "-addLayoutGuide: sets the guide's owningView");
+  PASS([[v layoutGuides] containsObject: g],
+       "-layoutGuides contains the added guide");
+  PASS([[v layoutGuides] count] == 1, "one guide is registered");
+
+  /* Adding the same guide again does not duplicate it. */
+  [v addLayoutGuide: g];
+  PASS([[v layoutGuides] count] == 1, "adding the same guide twice is a no-op");
+
+  /* Removing the guide reverses both effects. */
+  [v removeLayoutGuide: g];
+  PASS([g owningView] == nil, "-removeLayoutGuide: clears the owningView");
+  PASS([[v layoutGuides] count] == 0, "the guide is unregistered");
+
+  END_SET("NSView layout guides")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSLayoutGuide/support.m
+++ b/Tests/gui/NSLayoutGuide/support.m
@@ -10,8 +10,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSView layout guides")
 
   NS_DURING
@@ -47,6 +45,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSView layout guides")
 
-  DESTROY(arp);
   return 0;
 }


### PR DESCRIPTION
The `NSView (NSLayoutGuideSupport)` category (`addLayoutGuide:`, `removeLayoutGuide:`, `layoutGuides`) was declared in NSLayoutGuide.h but never implemented, so a view could not host layout guides.

This tracks the guides on the view, sets each guide's owning view on add and clears it on remove, ignores duplicate adds, and returns an empty array (not nil) when there are none.

Verified against AppKit on macOS: after `addLayoutGuide:` the guide's `owningView` is the view and `layoutGuides` contains it; after `removeLayoutGuide:` both are reversed. Includes a test. Existing NSView tests still pass.