### PR TITLE
Fix: vend layout anchors from NSLayoutGuide

### DIFF
--- a/Headers/AppKit/NSLayoutGuide.h
+++ b/Headers/AppKit/NSLayoutGuide.h
@@ -44,16 +44,6 @@ APPKIT_EXPORT_CLASS
   NSRect _frame;
   NSView *_owningView;
   NSUserInterfaceItemIdentifier _identifier;
-  NSLayoutXAxisAnchor *_leadingAnchor;
-  NSLayoutXAxisAnchor *_trailingAnchor;
-  NSLayoutXAxisAnchor *_leftAnchor;
-  NSLayoutXAxisAnchor *_rightAnchor;
-  NSLayoutYAxisAnchor *_topAnchor;
-  NSLayoutYAxisAnchor *_bottomAnchor;
-  NSLayoutDimension *_widthAnchor;
-  NSLayoutDimension *_heightAnchor;
-  NSLayoutXAxisAnchor *_centerXAnchor;
-  NSLayoutYAxisAnchor *_centerYAnchor;
 
   BOOL _hasAmbiguousLayout;
 }

--- a/Source/NSLayoutGuide.m
+++ b/Source/NSLayoutGuide.m
@@ -23,6 +23,8 @@
 */
 
 #import "AppKit/NSLayoutGuide.h"
+#import "AppKit/NSLayoutAnchor.h"
+#import "GSAutoLayoutAnchorPrivate.h"
 
 @implementation NSLayoutGuide
 
@@ -53,52 +55,72 @@
 
 - (NSLayoutXAxisAnchor *) leadingAnchor
 {
-  return _leadingAnchor;
+  return AUTORELEASE([[NSLayoutXAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeLeading]);
 }
 
 - (NSLayoutXAxisAnchor *) trailingAnchor
 {
-  return _trailingAnchor;
+  return AUTORELEASE([[NSLayoutXAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeTrailing]);
 }
 
 - (NSLayoutXAxisAnchor *) leftAnchor
 {
-  return _leftAnchor;
+  return AUTORELEASE([[NSLayoutXAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeLeft]);
 }
 
 - (NSLayoutXAxisAnchor *) rightAnchor
 {
-  return _rightAnchor;
+  return AUTORELEASE([[NSLayoutXAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeRight]);
 }
 
 - (NSLayoutYAxisAnchor *) topAnchor
 {
-  return _topAnchor;
+  return AUTORELEASE([[NSLayoutYAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeTop]);
 }
 
 - (NSLayoutYAxisAnchor *) bottomAnchor
 {
-  return _bottomAnchor;
+  return AUTORELEASE([[NSLayoutYAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeBottom]);
 }
 
 - (NSLayoutDimension *) widthAnchor
 {
-  return _widthAnchor;
+  return AUTORELEASE([[NSLayoutDimension alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeWidth]);
 }
 
 - (NSLayoutDimension *) heightAnchor
 {
-  return _heightAnchor;
+  return AUTORELEASE([[NSLayoutDimension alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeHeight]);
 }
 
 - (NSLayoutXAxisAnchor *) centerXAnchor
 {
-  return _centerXAnchor;
+  return AUTORELEASE([[NSLayoutXAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeCenterX]);
 }
 
 - (NSLayoutYAxisAnchor *) centerYAnchor
 {
-  return _centerYAnchor;
+  return AUTORELEASE([[NSLayoutYAxisAnchor alloc]
+                       initWithItem: self
+                          attribute: NSLayoutAttributeCenterY]);
 }
 
 - (BOOL) hasAmbiguousLayout

--- a/Tests/gui/NSLayoutGuide/anchors.m
+++ b/Tests/gui/NSLayoutGuide/anchors.m
@@ -1,0 +1,45 @@
+/* NSLayoutGuide vends layout anchors bound to the guide, and the constraints
+   those anchors build carry the guide as their item with the right attribute
+   and constant.  Values checked against AppKit on macOS. */
+#import "Testing.h"
+#import <AppKit/NSLayoutGuide.h>
+#import <AppKit/NSLayoutAnchor.h>
+#import <AppKit/NSLayoutConstraint.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  NSLayoutGuide *g = AUTORELEASE([[NSLayoutGuide alloc] init]);
+  NSLayoutGuide *g2 = AUTORELEASE([[NSLayoutGuide alloc] init]);
+
+  /* Anchor kinds. */
+  PASS([[g widthAnchor] isKindOfClass: [NSLayoutDimension class]],
+       "-widthAnchor is an NSLayoutDimension");
+  PASS([[g leadingAnchor] isKindOfClass: [NSLayoutXAxisAnchor class]],
+       "-leadingAnchor is an NSLayoutXAxisAnchor");
+  PASS([[g topAnchor] isKindOfClass: [NSLayoutYAxisAnchor class]],
+       "-topAnchor is an NSLayoutYAxisAnchor");
+
+  /* A dimension constant constraint is bound to the guide. */
+  NSLayoutConstraint *w = [[g widthAnchor] constraintEqualToConstant: 10.0];
+  PASS([w firstItem] == g, "width constraint firstItem is the guide");
+  PASS([w firstAttribute] == NSLayoutAttributeWidth,
+       "width constraint firstAttribute is Width");
+  PASS([w secondItem] == nil, "width constraint has no second item");
+  PASS([w constant] == 10.0, "width constraint constant is 10");
+
+  /* An anchor-to-anchor constraint carries both guides and attributes. */
+  NSLayoutConstraint *lead =
+      [[g leadingAnchor] constraintEqualToAnchor: [g2 leadingAnchor]];
+  PASS([lead firstItem] == g, "leading constraint firstItem is the guide");
+  PASS([lead firstAttribute] == NSLayoutAttributeLeading,
+       "leading constraint firstAttribute is Leading");
+  PASS([lead secondItem] == g2,
+       "leading constraint secondItem is the other guide");
+  PASS([lead secondAttribute] == NSLayoutAttributeLeading,
+       "leading constraint secondAttribute is Leading");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Prerequisite: #550 

NSLayoutGuide's anchor accessors (`leadingAnchor`, `widthAnchor`, `topAnchor` and the rest) returned nil because the anchors were never created. This vends an anchor bound to the guide and the matching attribute for each accessor, so `guide.widthAnchor constraintEqualToConstant:` and anchor-to-anchor constraints build against the guide.

Verified against AppKit on macOS: `guide.widthAnchor constraintEqualToConstant:10` yields a constraint with the guide as firstItem, firstAttribute Width and no second item; `guide.leadingAnchor constraintEqualToAnchor:other.leadingAnchor` carries both guides and the Leading attribute. Includes a test.

**Depends on #550** — it uses the `initWithItem:attribute:` anchor infrastructure added there, so this branch is stacked on it and the diff currently shows #550's commits too. Merge #550 first; this then reduces to just the NSLayoutGuide change.