### PR TITLE
Fix: NSLayoutGuide copies its identifier

### DIFF
--- a/Source/NSLayoutGuide.m
+++ b/Source/NSLayoutGuide.m
@@ -48,7 +48,7 @@
 
 - (void) setIdentifier: (NSUserInterfaceItemIdentifier)identifier
 {
-  _identifier = identifier;
+  ASSIGNCOPY(_identifier, identifier);
 }
 
 - (NSLayoutXAxisAnchor *) leadingAnchor
@@ -119,6 +119,12 @@
       _frame = NSZeroRect;
     }
   return self;
+}
+
+- (void) dealloc
+{
+  RELEASE(_identifier);
+  [super dealloc];
 }
 
 - (instancetype) initWithCoder: (NSCoder *)coder

--- a/Tests/gui/NSLayoutGuide/identifier.m
+++ b/Tests/gui/NSLayoutGuide/identifier.m
@@ -1,0 +1,24 @@
+/* -[NSLayoutGuide setIdentifier:] copies its argument, matching AppKit (the
+   NSUserInterfaceItemIdentification identifier property is copy): mutating the
+   string passed in must not change the guide's identifier. */
+#import "Testing.h"
+#import <Foundation/NSString.h>
+#import <AppKit/NSLayoutGuide.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  NSLayoutGuide *g = AUTORELEASE([[NSLayoutGuide alloc] init]);
+
+  NSMutableString *ms = [NSMutableString stringWithString: @"id1"];
+  [g setIdentifier: ms];
+  PASS([[g identifier] isEqualToString: @"id1"], "setIdentifier: round-trips");
+
+  [ms appendString: @"X"];
+  PASS([[g identifier] isEqualToString: @"id1"],
+       "identifier is copied, not shared with the argument");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The `NSUserInterfaceItemIdentification` `identifier` property is declared `copy`, but `-[NSLayoutGuide setIdentifier:]` assigned the argument directly. As a result the guide's identifier changed whenever the caller mutated the string it had passed in. This copies the identifier (and releases it in `-dealloc`).

Verified against AppKit on macOS (mutating the passed-in string does not change the guide's identifier). Includes a test that fails before the change and passes after.