### PR TITLE
Fix: NSPasteboardItem registers the type when data is set

### DIFF
--- a/Source/NSPasteboardItem.m
+++ b/Source/NSPasteboardItem.m
@@ -85,8 +85,12 @@
     {
       return NO;
     }
-  
+
   [_dataMap setObject: data forKey: type];
+  if (![_types containsObject: type])
+    {
+      [_types addObject: type];
+    }
   return YES;
 }
 
@@ -94,8 +98,12 @@
 {
   if (![string isKindOfClass: [NSString class]])
     return NO;
-  
+
   [_dataMap setObject: string forKey: type];
+  if (![_types containsObject: type])
+    {
+      [_types addObject: type];
+    }
   return YES;
 }
 
@@ -106,6 +114,10 @@
     return NO;
 
   [_dataMap setObject: propertyList forKey: type];
+  if (![_types containsObject: type])
+    {
+      [_types addObject: type];
+    }
   return YES;
 }
 

--- a/Tests/gui/NSPasteboardItem/registertype.m
+++ b/Tests/gui/NSPasteboardItem/registertype.m
@@ -1,0 +1,35 @@
+/* Setting data/string/property-list for a type registers that type in -types,
+   matching AppKit, and does not duplicate a type set more than once. */
+#import "Testing.h"
+#import <Foundation/NSArray.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSString.h>
+#import <AppKit/NSPasteboard.h>
+#import <AppKit/NSPasteboardItem.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  NSString *t1 = @"public.utf8-plain-text";
+  NSString *t2 = @"public.data";
+
+  NSPasteboardItem *item = [[NSPasteboardItem alloc] init];
+
+  [item setString: @"hi" forType: t1];
+  PASS([[item types] containsObject: t1], "setString:forType: registers the type");
+  PASS([[item types] count] == 1, "one type is registered");
+
+  NSData *d = [@"x" dataUsingEncoding: NSUTF8StringEncoding];
+  [item setData: d forType: t2];
+  PASS([[item types] containsObject: t2], "setData:forType: registers the type");
+  PASS([[item types] count] == 2, "a second type is registered");
+
+  [item setData: d forType: t2];
+  PASS([[item types] count] == 2,
+       "setting the same type twice does not duplicate it");
+
+  RELEASE(item);
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
setData:forType:, setString:forType: and setPropertyList:forType: stored the value in the item but never added the type to `-types`, so a freshly written item reported no types (and `-writableTypesForPasteboard:` was empty). AppKit registers the type. This adds the type on each of the three setters, without duplicating a type that is already present.

Verified against AppKit on macOS (after setData:/setString: the type appears in `-types`). Includes a test that fails before the change and passes after.