### PR TITLE
Fix: give NSPDFInfo AppKit init defaults

### DIFF
--- a/Source/NSPDFInfo.m
+++ b/Source/NSPDFInfo.m
@@ -29,6 +29,19 @@
 
 @implementation NSPDFInfo
 
+- (instancetype) init
+{
+  self = [super init];
+  if (self != nil)
+    {
+      _attributes = [[NSMutableDictionary alloc] init];
+      _tagNames = [[NSArray alloc] init];
+      _fileExtensionHidden = YES;
+      _paperSize = [[NSPrintInfo sharedPrintInfo] paperSize];
+    }
+  return self;
+}
+
 - (instancetype) initWithCoder: (NSCoder *)coder
 {
   return nil;

--- a/Tests/gui/NSPDFInfo/initdefaults.m
+++ b/Tests/gui/NSPDFInfo/initdefaults.m
@@ -1,0 +1,38 @@
+/* -[NSPDFInfo init] gives AppKit's defaults: a non-nil (empty) attributes
+   dictionary and tagNames array, fileExtensionHidden YES, and a paper size
+   taken from the shared print info (the system default), rather than leaving
+   everything zero/nil. */
+#import "Testing.h"
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSPrintInfo.h>
+#import <AppKit/NSPDFInfo.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  NSPDFInfo *info = [[NSPDFInfo alloc] init];
+
+  PASS([info attributes] != nil, "default attributes is non-nil");
+  PASS([[info attributes] isKindOfClass: [NSMutableDictionary class]],
+       "attributes is a mutable dictionary");
+  PASS([[info attributes] count] == 0, "default attributes is empty");
+
+  PASS([info tagNames] != nil, "default tagNames is non-nil");
+  PASS([[info tagNames] count] == 0, "default tagNames is empty");
+
+  PASS([info isFileExtensionHidden] == YES,
+       "default fileExtensionHidden is YES");
+
+  NSSize dflt = [[NSPrintInfo sharedPrintInfo] paperSize];
+  PASS(NSEqualSizes([info paperSize], dflt),
+       "default paperSize is the shared print info's paper size");
+  PASS([info paperSize].width > 0 && [info paperSize].height > 0,
+       "default paperSize is non-zero");
+
+  RELEASE(info);
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSPDFInfo had no `-init`, so a fresh instance left `-attributes` and `-tagNames` nil, `-isFileExtensionHidden` NO and `-paperSize` zero. AppKit returns a non-nil (empty) attributes dictionary and tag-name array, a hidden file extension by default, and a non-zero paper size.

This adds `-init` setting those. The paper size is taken from `[NSPrintInfo sharedPrintInfo] paperSize` so it follows the system default (Letter, A4, ...) rather than a hardcoded value; AppKit's default is likewise the system paper size.

Verified against AppKit on macOS. Includes a test that fails before the change and passes after.