### PR TITLE
Fix: NSPDFInfo -copyWithZone: returns a real copy

### DIFF
--- a/Source/NSPDFInfo.m
+++ b/Source/NSPDFInfo.m
@@ -48,7 +48,22 @@
 
 - (instancetype) copyWithZone: (NSZone *)zone
 {
-  return nil;
+  NSPDFInfo *copy = [[[self class] allocWithZone: zone] init];
+
+  if (copy != nil)
+    {
+      RELEASE(copy->_url);
+      copy->_url = [_url copyWithZone: zone];
+      copy->_fileExtensionHidden = _fileExtensionHidden;
+      RELEASE(copy->_tagNames);
+      copy->_tagNames = [_tagNames copyWithZone: zone];
+      copy->_paperSize = _paperSize;
+      RELEASE(copy->_attributes);
+      copy->_attributes = [_attributes mutableCopyWithZone: zone];
+      copy->_orientation = _orientation;
+    }
+
+  return copy;
 }
 
 - (NSURL *) URL

--- a/Tests/gui/NSPDFInfo/copy.m
+++ b/Tests/gui/NSPDFInfo/copy.m
@@ -1,0 +1,32 @@
+/* -[NSPDFInfo copyWithZone:] returns a distinct copy that preserves the
+   receiver's settable properties, rather than returning nil (which broke
+   NSCopying). */
+#import "Testing.h"
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSPrintInfo.h>
+#import <AppKit/NSPDFInfo.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  NSPDFInfo *info = [[NSPDFInfo alloc] init];
+  [info setFileExtensionHidden: YES];
+  [info setOrientation: NSPaperOrientationLandscape];
+  [info setPaperSize: NSMakeSize(100, 200)];
+
+  NSPDFInfo *copy = [info copy];
+  PASS(copy != nil, "-copy is non-nil");
+  PASS(copy != info, "-copy is a distinct object");
+  PASS([copy isFileExtensionHidden] == YES,
+       "copy preserves fileExtensionHidden");
+  PASS([copy orientation] == NSPaperOrientationLandscape,
+       "copy preserves orientation");
+  PASS(NSEqualSizes([copy paperSize], NSMakeSize(100, 200)),
+       "copy preserves paperSize");
+
+  RELEASE(info);
+  RELEASE(copy);
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSPDFInfo copyWithZone:]` returned nil, so copying an NSPDFInfo (which declares NSCopying) yielded nil. This returns a distinct instance with the URL, tag names, attributes (mutable copy), paper size, orientation and file-extension flag copied from the receiver.

Verified against AppKit on macOS (`-copy` is non-nil and preserves the properties). Includes a test that fails before the change and passes after.