### PR TITLE
Fix: NSBrowserCell -copyWithZone: retains the copy's alternate image

### DIFF
--- a/Source/NSBrowserCell.m
+++ b/Source/NSBrowserCell.m
@@ -146,9 +146,7 @@ static NSFont *_leafFont;
 {
   NSBrowserCell	*c = [super copyWithZone: zone];
 
-  _alternateImage = TEST_RETAIN (_alternateImage);
-  //c->_browsercell_is_leaf = _browsercell_is_leaf;
-  //c->_browsercell_is_loaded = _browsercell_is_loaded;
+  c->_alternateImage = TEST_RETAIN (_alternateImage);
 
   return c;
 }

--- a/Tests/gui/NSBrowserCell/copy.m
+++ b/Tests/gui/NSBrowserCell/copy.m
@@ -1,0 +1,44 @@
+/* -[NSBrowserCell copyWithZone:] gives the copy its own retained reference to
+   the alternate image (rather than mistakenly retaining the receiver's), so a
+   copy keeps the leaf/loaded flags and the alternate image. */
+#import "Testing.h"
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSImage.h>
+#import <AppKit/NSBrowserCell.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSBrowserCell copy")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NSBrowserCell *cell = [[NSBrowserCell alloc] initTextCell: @"Item"];
+  NSImage *img = [[NSImage alloc] initWithSize: NSMakeSize(8, 8)];
+  [cell setLeaf: YES];
+  [cell setLoaded: YES];
+  [cell setAlternateImage: img];
+
+  NSBrowserCell *copy = [cell copy];
+  PASS(copy != nil, "-copy is non-nil");
+  PASS(copy != cell, "-copy is a distinct object");
+  PASS([copy isLeaf] == YES, "copy keeps the leaf flag");
+  PASS([copy isLoaded] == YES, "copy keeps the loaded flag");
+  PASS([copy alternateImage] == img, "copy keeps the alternate image");
+
+  RELEASE(copy);
+  RELEASE(cell);
+  RELEASE(img);
+
+  END_SET("NSBrowserCell copy")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSBrowserCell copyWithZone:]` retained the **receiver's** `_alternateImage` (`_alternateImage = TEST_RETAIN(_alternateImage)`) rather than the copy's, so the new cell never took its own reference to the alternate image and the receiver ended up retained one extra time. This retains `c->_alternateImage` instead.

Transparency note: because the superclass copy uses `NSCopyObject` (which already copies the `_alternateImage` pointer into the copy), the two extra/missing retains happen to cancel out for the common create-copy-release sequence, so this is not observable as a crash or leak today. The change corrects the assignment so the copy owns its reference regardless of how the superclass copy is implemented. The added test guards that a copy keeps its leaf/loaded flags and alternate image.