### PR TITLE
Fix: a new NSMenuToolbarItem shows its indicator

### DIFF
--- a/Source/NSMenuToolbarItem.m
+++ b/Source/NSMenuToolbarItem.m
@@ -35,7 +35,7 @@
   self = [super initWithItemIdentifier: identifier];
   if (self != nil)
     {
-      [self setImage: [NSImage imageNamed: @"NSMenuToolbarItem"]];
+      [self setShowsIndicator: YES];
       [self setTarget: self];
       [self setAction: @selector(_showMenu:)];
     }

--- a/Tests/gui/NSMenuToolbarItem/showsIndicator.m
+++ b/Tests/gui/NSMenuToolbarItem/showsIndicator.m
@@ -1,0 +1,45 @@
+/* A new menu toolbar item shows its indicator, and the initialiser gives it the
+ * indicator image to match.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSImage.h>
+#include <AppKit/NSMenuToolbarItem.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("showsIndicator default")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    NSMenuToolbarItem	*item;
+
+    item = AUTORELEASE([[NSMenuToolbarItem alloc]
+      initWithItemIdentifier: @"myItem"]);
+    PASS([item showsIndicator] == YES, "a new item shows its indicator");
+    PASS([item image] != nil, "a new item has the indicator image");
+
+    [item setShowsIndicator: NO];
+    PASS([item showsIndicator] == NO, "showsIndicator round-trips when unset");
+    [item setShowsIndicator: YES];
+    PASS([item showsIndicator] == YES, "showsIndicator round-trips when set");
+  }
+
+  END_SET("showsIndicator default")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
showsIndicator was NO for a new menu toolbar item. AppKit has it YES, checked
on a macOS runner.

The initialiser already installed the NSMenuToolbarItem indicator image, so the
flag disagreed with the image it is meant to track: -showsIndicator answered NO
while the indicator was on screen, and -setShowsIndicator: NO then had nothing
to remove.

-setShowsIndicator: YES installs that same image, so the initialiser can set the
flag through it and keep the two in step.

Without the change 1 of the test's assertions fails; with it the
NSMenuToolbarItem tests pass 4/4.
