### PR TITLE
Fix: NSTextAlternatives copies the strings it is given

### DIFF
--- a/Source/NSTextAlternatives.m
+++ b/Source/NSTextAlternatives.m
@@ -39,8 +39,8 @@ NSString *NSTextAlternativesSelectedAlternativeStringNotification =
 {
   if ((self = [super init]))
     {
-      _primaryString = RETAIN(primaryString);
-      _alternativeStrings = RETAIN(alternativeStrings);
+      _primaryString = [primaryString copy];
+      _alternativeStrings = [alternativeStrings copy];
     }
 
   return self;
@@ -48,12 +48,12 @@ NSString *NSTextAlternativesSelectedAlternativeStringNotification =
 
 - (NSString *)primaryString
 {
-  return [_primaryString copy];
+  return _primaryString;
 }
 
 - (NSArray *)alternativeStrings
 {
-  return [_alternativeStrings copy];
+  return _alternativeStrings;
 }
 
 - (void)noteSelectedAlternativeString:(NSString *)alternativeString

--- a/Tests/gui/NSTextAlternatives/copiesStrings.m
+++ b/Tests/gui/NSTextAlternatives/copiesStrings.m
@@ -1,0 +1,74 @@
+/* The initialiser copies the strings it is given, as its properties declare, so
+ * that mutating the caller's objects afterwards does not show through.  The
+ * getters hand back that storage rather than a fresh copy, so each call returns
+ * the same object.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSTextAlternatives.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("mutable strings are copied")
+    NSMutableString	*primary;
+    NSMutableArray	*alternatives;
+    NSTextAlternatives	*alt;
+
+    primary = [NSMutableString stringWithString: @"abc"];
+    alternatives = [NSMutableArray arrayWithObject: @"x"];
+    alt = AUTORELEASE([[NSTextAlternatives alloc]
+      initWithPrimaryString: primary
+         alternativeStrings: alternatives]);
+
+    PASS([alt primaryString] != (NSString *)primary,
+      "the primary string is not the mutable string passed in");
+    PASS([alt alternativeStrings] != (NSArray *)alternatives,
+      "the alternative strings are not the mutable array passed in");
+
+    [primary appendString: @"DEF"];
+    [alternatives addObject: @"y"];
+
+    PASS([[alt primaryString] isEqualToString: @"abc"],
+      "mutating the primary string afterwards does not change the copy");
+    PASS([[alt alternativeStrings] count] == 1,
+      "mutating the alternative strings afterwards does not change the copy");
+  END_SET("mutable strings are copied")
+
+  START_SET("the getters return their storage")
+    NSMutableString	*primary;
+    NSMutableArray	*alternatives;
+    NSTextAlternatives	*alt;
+
+    primary = [NSMutableString stringWithString: @"abc"];
+    alternatives = [NSMutableArray arrayWithObject: @"x"];
+    alt = AUTORELEASE([[NSTextAlternatives alloc]
+      initWithPrimaryString: primary
+         alternativeStrings: alternatives]);
+
+    PASS([alt primaryString] == [alt primaryString],
+      "primaryString returns the same object each time");
+    PASS([alt alternativeStrings] == [alt alternativeStrings],
+      "alternativeStrings returns the same object each time");
+  END_SET("the getters return their storage")
+
+  START_SET("immutable strings are kept")
+    NSArray		*alternatives;
+    NSTextAlternatives	*alt;
+
+    alternatives = [NSArray arrayWithObject: @"color"];
+    alt = AUTORELEASE([[NSTextAlternatives alloc]
+      initWithPrimaryString: @"colour"
+         alternativeStrings: alternatives]);
+
+    PASS([[alt primaryString] isEqualToString: @"colour"],
+      "an immutable primary string reads back");
+    PASS([alt alternativeStrings] == alternatives,
+      "copying an immutable array keeps the array passed in");
+  END_SET("immutable strings are kept")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The primaryString and alternativeStrings properties are declared copy, but the
initialiser retained its arguments, so mutating the caller's objects afterwards
changed what the object reported:

    NSMutableString *s = [NSMutableString stringWithString: @"abc"];
    NSTextAlternatives *alt;

    alt = [[NSTextAlternatives alloc] initWithPrimaryString: s
                                        alternativeStrings: a];
    [s appendString: @"DEF"];
    [alt primaryString];   // abcDEF, AppKit reports abc

The getters returned [ivar copy]. Neither name implies ownership, so the +1
object they handed back leaked on every call. With the initialiser taking the
copy the getters can return their storage, which also matches AppKit returning
the same object on every call.

Both were checked on a macOS runner: AppKit snapshots the strings at init, its
getters are stable across calls, and for an immutable argument the stored object
is the argument itself, since copying it returns self.

Without the change 4 of the test's assertions fail; with it the
NSTextAlternatives tests pass 8/8. The separate coverage tests stay green either
way.
