### PR TITLE
Fix: NSTextAlternatives rejects a nil primary string

### DIFF
--- a/Source/NSTextAlternatives.m
+++ b/Source/NSTextAlternatives.m
@@ -37,6 +37,14 @@ NSString *NSTextAlternativesSelectedAlternativeStringNotification =
 - (id)initWithPrimaryString:(NSString *)primaryString
          alternativeStrings:(NSArray *)alternativeStrings
 {
+  if (primaryString == nil)
+    {
+      DESTROY(self);
+      [NSException raise: NSInvalidArgumentException
+                  format: @"Attempt to create text alternatives without a"
+        @" primary string"];
+    }
+
   if ((self = [super init]))
     {
       _primaryString = RETAIN(primaryString);

--- a/Tests/gui/NSTextAlternatives/nilPrimaryString.m
+++ b/Tests/gui/NSTextAlternatives/nilPrimaryString.m
@@ -1,0 +1,50 @@
+/* A text alternatives object has no meaning without the text the alternatives
+ * are for, so a nil primary string raises rather than building an object whose
+ * primaryString is nil.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSTextAlternatives.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("a nil primary string")
+    NSArray		*alternatives;
+    NSTextAlternatives	*alt;
+    BOOL		raised;
+
+    alternatives = [NSArray arrayWithObject: @"color"];
+
+    raised = NO;
+    NS_DURING
+      alt = AUTORELEASE([[NSTextAlternatives alloc]
+        initWithPrimaryString: nil
+           alternativeStrings: alternatives]);
+    NS_HANDLER
+      raised = [[localException name]
+        isEqualToString: NSInvalidArgumentException];
+    NS_ENDHANDLER
+    PASS(raised == YES,
+      "a nil primary string raises NSInvalidArgumentException");
+
+    /* A primary string with no alternatives is still a usable object. */
+    raised = NO;
+    alt = nil;
+    NS_DURING
+      alt = AUTORELEASE([[NSTextAlternatives alloc]
+        initWithPrimaryString: @"colour"
+           alternativeStrings: nil]);
+    NS_HANDLER
+      raised = YES;
+    NS_ENDHANDLER
+    PASS(raised == NO, "a nil alternative strings array does not raise");
+    PASS([[alt primaryString] isEqualToString: @"colour"],
+      "the primary string reads back when there are no alternatives");
+  END_SET("a nil primary string")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The initialiser accepted a nil primary string and returned an object whose
primaryString is nil. The alternatives are alternatives for that string, so
there is nothing such an object can be used for.

AppKit raises NSInvalidArgumentException here, checked on a macOS runner:

    -[NSTextAlternatives initWithPrimaryString:alternativeStrings:]:
    must have original text

A nil alternativeStrings array is left alone: AppKit was only seen to object to
the missing primary string, and an object with no alternatives is still usable.
The test covers that as a guard.

Without the change 1 of the test's assertions fails; with it the
NSTextAlternatives tests pass 3/3.

This touches the same initialiser as #570, so the two conflict textually. I am
happy to rebase whichever lands second.
