### PR TITLE
Fix: implement the NSToolbarItemGroup selection API

### DIFF
--- a/Headers/AppKit/NSToolbarItemGroup.h
+++ b/Headers/AppKit/NSToolbarItemGroup.h
@@ -36,15 +36,51 @@
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
 
 @class NSArray;
+@class NSMutableIndexSet;
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_15, GS_API_LATEST)
+enum {
+  NSToolbarItemGroupSelectionModeSelectOne = 0,
+  NSToolbarItemGroupSelectionModeSelectAny = 1,
+  NSToolbarItemGroupSelectionModeMomentary = 2
+};
+typedef NSInteger NSToolbarItemGroupSelectionMode;
+
+enum {
+  NSToolbarItemGroupControlRepresentationAutomatic = 0,
+  NSToolbarItemGroupControlRepresentationExpanded = 1,
+  NSToolbarItemGroupControlRepresentationCollapsed = 2
+};
+typedef NSInteger NSToolbarItemGroupControlRepresentation;
+#endif
 
 APPKIT_EXPORT_CLASS
 @interface NSToolbarItemGroup : NSToolbarItem
 {
 	NSArray *_subitems;
+	NSMutableIndexSet *_selectedIndexes;
+	NSInteger _selectionMode;
+	NSInteger _controlRepresentation;
+	NSInteger _selectedIndex;
 }
 
 - (void) setSubitems: (NSArray *)items;
 - (NSArray *) subitems;
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_15, GS_API_LATEST)
+- (NSToolbarItemGroupSelectionMode) selectionMode;
+- (void) setSelectionMode: (NSToolbarItemGroupSelectionMode)selectionMode;
+
+- (NSToolbarItemGroupControlRepresentation) controlRepresentation;
+- (void) setControlRepresentation:
+  (NSToolbarItemGroupControlRepresentation)controlRepresentation;
+
+- (NSInteger) selectedIndex;
+- (void) setSelectedIndex: (NSInteger)selectedIndex;
+
+- (BOOL) isSelectedAtIndex: (NSInteger)index;
+- (void) setSelected: (BOOL)selected atIndex: (NSInteger)index;
+#endif
 
 @end
 

--- a/Source/NSToolbarItemGroup.m
+++ b/Source/NSToolbarItemGroup.m
@@ -28,14 +28,34 @@
 */ 
 
 #import <Foundation/NSArray.h>
+#import <Foundation/NSException.h>
+#import <Foundation/NSIndexSet.h>
 #import "AppKit/NSToolbarItemGroup.h"
 
+@interface NSToolbarItemGroup (Private)
+- (void) _checkIndex: (NSInteger)index;
+@end
+
 @implementation NSToolbarItemGroup
-// FIXME: Most of the implementation is missing.
+// FIXME: The subitems are not laid out by the toolbar yet.
+
+- (id) initWithItemIdentifier: (NSString *)itemIdentifier
+{
+  self = [super initWithItemIdentifier: itemIdentifier];
+  if (self != nil)
+    {
+      _selectedIndexes = [[NSMutableIndexSet alloc] init];
+      _selectedIndex = -1;
+    }
+
+  return self;
+}
 
 - (void) setSubitems: (NSArray *)items
 {
   ASSIGN(_subitems, items);
+  [_selectedIndexes removeAllIndexes];
+  _selectedIndex = -1;
 }
 
 - (NSArray *) subitems
@@ -43,10 +63,103 @@
   return _subitems;
 }
 
+- (NSToolbarItemGroupSelectionMode) selectionMode
+{
+  return _selectionMode;
+}
+
+/* The mode decides what later selection changes do; it leaves any selection
+   already made alone. */
+- (void) setSelectionMode: (NSToolbarItemGroupSelectionMode)selectionMode
+{
+  _selectionMode = selectionMode;
+}
+
+- (NSToolbarItemGroupControlRepresentation) controlRepresentation
+{
+  return _controlRepresentation;
+}
+
+- (void) setControlRepresentation:
+  (NSToolbarItemGroupControlRepresentation)controlRepresentation
+{
+  _controlRepresentation = controlRepresentation;
+}
+
+/* The index selected last, or -1 when nothing has been selected.  Deselecting
+   leaves it alone. */
+- (NSInteger) selectedIndex
+{
+  return _selectedIndex;
+}
+
+- (void) setSelectedIndex: (NSInteger)selectedIndex
+{
+  if (selectedIndex == -1)
+    {
+      return;
+    }
+
+  [self _checkIndex: selectedIndex];
+  if (_selectionMode == NSToolbarItemGroupSelectionModeMomentary)
+    {
+      _selectedIndex = selectedIndex;
+      return;
+    }
+
+  if (_selectionMode == NSToolbarItemGroupSelectionModeSelectOne)
+    {
+      [_selectedIndexes removeAllIndexes];
+    }
+  [_selectedIndexes addIndex: selectedIndex];
+  _selectedIndex = selectedIndex;
+}
+
+- (BOOL) isSelectedAtIndex: (NSInteger)index
+{
+  [self _checkIndex: index];
+  return [_selectedIndexes containsIndex: index];
+}
+
+- (void) setSelected: (BOOL)selected atIndex: (NSInteger)index
+{
+  [self _checkIndex: index];
+  if (_selectionMode == NSToolbarItemGroupSelectionModeMomentary)
+    {
+      return;
+    }
+
+  if (selected)
+    {
+      if (_selectionMode == NSToolbarItemGroupSelectionModeSelectOne)
+        {
+          [_selectedIndexes removeAllIndexes];
+        }
+      [_selectedIndexes addIndex: index];
+      _selectedIndex = index;
+    }
+  else if (_selectionMode == NSToolbarItemGroupSelectionModeSelectAny)
+    {
+      /* A group that selects one is never left with nothing selected. */
+      [_selectedIndexes removeIndex: index];
+    }
+}
+
+- (void) _checkIndex: (NSInteger)index
+{
+  if (index < 0 || (NSUInteger)index >= [_subitems count])
+    {
+      [NSException raise: NSRangeException
+                  format: @"subitem index %ld out of range 0 to %lu",
+        (long)index, (unsigned long)[_subitems count]];
+    }
+}
+
 - (void) dealloc
 {
   RELEASE(_subitems);
-  
+  RELEASE(_selectedIndexes);
+
   [super dealloc];
 }
 

--- a/Tests/gui/NSToolbarItemGroup/selection.m
+++ b/Tests/gui/NSToolbarItemGroup/selection.m
@@ -1,0 +1,201 @@
+/* The selection a group keeps for its subitems: which indexes are selected,
+ * which was selected last, and how each selection mode treats a change.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSArray.h>
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSException.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSToolbarItem.h>
+#include <AppKit/NSToolbarItemGroup.h>
+
+static NSToolbarItemGroup *
+groupWithMode(NSToolbarItemGroupSelectionMode mode)
+{
+  NSToolbarItemGroup	*group;
+  NSMutableArray	*subitems;
+  NSUInteger		i;
+
+  group = AUTORELEASE([[NSToolbarItemGroup alloc]
+    initWithItemIdentifier: @"group"]);
+  subitems = [NSMutableArray array];
+  for (i = 0; i < 3; i++)
+    {
+      NSString		*identifier;
+      NSToolbarItem	*subitem;
+
+      identifier = [NSString stringWithFormat: @"i%lu", (unsigned long)i];
+      subitem = AUTORELEASE([[NSToolbarItem alloc]
+        initWithItemIdentifier: identifier]);
+      [subitems addObject: subitem];
+    }
+  [group setSubitems: subitems];
+  [group setSelectionMode: mode];
+  return group;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("selection")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    NSToolbarItemGroup	*group;
+    BOOL		raised;
+
+    /* the enumerations */
+    PASS(NSToolbarItemGroupSelectionModeSelectOne == 0
+      && NSToolbarItemGroupSelectionModeSelectAny == 1
+      && NSToolbarItemGroupSelectionModeMomentary == 2,
+      "the selection modes have their AppKit values");
+    PASS(NSToolbarItemGroupControlRepresentationAutomatic == 0
+      && NSToolbarItemGroupControlRepresentationExpanded == 1
+      && NSToolbarItemGroupControlRepresentationCollapsed == 2,
+      "the control representations have their AppKit values");
+
+    /* defaults */
+    group = AUTORELEASE([[NSToolbarItemGroup alloc]
+      initWithItemIdentifier: @"group"]);
+    PASS([group selectionMode] == NSToolbarItemGroupSelectionModeSelectOne,
+      "a new group selects one subitem");
+    PASS([group controlRepresentation]
+      == NSToolbarItemGroupControlRepresentationAutomatic,
+      "a new group has the automatic control representation");
+    PASS([group selectedIndex] == -1, "a new group has nothing selected");
+
+    /* round-trips */
+    [group setSelectionMode: NSToolbarItemGroupSelectionModeSelectAny];
+    PASS([group selectionMode] == NSToolbarItemGroupSelectionModeSelectAny,
+      "the selection mode round-trips");
+    [group setControlRepresentation:
+      NSToolbarItemGroupControlRepresentationCollapsed];
+    PASS([group controlRepresentation]
+      == NSToolbarItemGroupControlRepresentationCollapsed,
+      "the control representation round-trips");
+
+    /* selecting one */
+    group = groupWithMode(NSToolbarItemGroupSelectionModeSelectOne);
+    PASS([group selectedIndex] == -1,
+      "a group with subitems starts with nothing selected");
+    PASS([group isSelectedAtIndex: 0] == NO,
+      "no subitem starts out selected");
+
+    [group setSelected: YES atIndex: 0];
+    PASS([group selectedIndex] == 0 && [group isSelectedAtIndex: 0] == YES,
+      "selecting a subitem selects it");
+
+    [group setSelected: YES atIndex: 2];
+    PASS([group selectedIndex] == 2 && [group isSelectedAtIndex: 2] == YES
+      && [group isSelectedAtIndex: 0] == NO,
+      "selecting another subitem deselects the first when selecting one");
+
+    [group setSelected: NO atIndex: 2];
+    PASS([group isSelectedAtIndex: 2] == YES && [group selectedIndex] == 2,
+      "a group that selects one keeps its subitem selected");
+
+    /* selecting any */
+    group = groupWithMode(NSToolbarItemGroupSelectionModeSelectAny);
+    [group setSelected: YES atIndex: 2];
+    [group setSelected: YES atIndex: 0];
+    PASS([group isSelectedAtIndex: 0] == YES
+      && [group isSelectedAtIndex: 2] == YES,
+      "a group that selects any keeps both subitems selected");
+    PASS([group selectedIndex] == 0,
+      "the selected index is the subitem selected last");
+
+    [group setSelected: NO atIndex: 2];
+    PASS([group isSelectedAtIndex: 2] == NO
+      && [group isSelectedAtIndex: 0] == YES,
+      "a group that selects any deselects a subitem");
+    PASS([group selectedIndex] == 0,
+      "deselecting a subitem leaves the selected index alone");
+
+    /* momentary */
+    group = groupWithMode(NSToolbarItemGroupSelectionModeMomentary);
+    [group setSelected: YES atIndex: 1];
+    PASS([group isSelectedAtIndex: 1] == NO && [group selectedIndex] == -1,
+      "a momentary group does not hold a selection");
+    [group setSelectedIndex: 1];
+    PASS([group selectedIndex] == 1 && [group isSelectedAtIndex: 1] == NO,
+      "a momentary group records the selected index without selecting");
+
+    /* setSelectedIndex: */
+    group = groupWithMode(NSToolbarItemGroupSelectionModeSelectOne);
+    [group setSelectedIndex: 1];
+    PASS([group selectedIndex] == 1 && [group isSelectedAtIndex: 1] == YES,
+      "setting the selected index selects that subitem");
+
+    group = groupWithMode(NSToolbarItemGroupSelectionModeSelectAny);
+    [group setSelected: YES atIndex: 0];
+    [group setSelectedIndex: 1];
+    PASS([group isSelectedAtIndex: 0] == YES
+      && [group isSelectedAtIndex: 1] == YES && [group selectedIndex] == 1,
+      "setting the selected index adds to the selection when selecting any");
+
+    group = groupWithMode(NSToolbarItemGroupSelectionModeSelectOne);
+    [group setSelected: YES atIndex: 1];
+    [group setSelectedIndex: -1];
+    PASS([group selectedIndex] == 1 && [group isSelectedAtIndex: 1] == YES,
+      "setting the selected index to -1 leaves the selection alone");
+
+    /* the mode leaves an existing selection alone */
+    group = groupWithMode(NSToolbarItemGroupSelectionModeSelectAny);
+    [group setSelected: YES atIndex: 0];
+    [group setSelected: YES atIndex: 2];
+    [group setSelectionMode: NSToolbarItemGroupSelectionModeSelectOne];
+    PASS([group isSelectedAtIndex: 0] == YES
+      && [group isSelectedAtIndex: 2] == YES && [group selectedIndex] == 2,
+      "changing the selection mode leaves the selection alone");
+
+    /* replacing the subitems */
+    group = groupWithMode(NSToolbarItemGroupSelectionModeSelectOne);
+    [group setSelected: YES atIndex: 2];
+    [group setSubitems: [NSArray arrayWithObject:
+      AUTORELEASE([[NSToolbarItem alloc] initWithItemIdentifier: @"x"])]];
+    PASS([group selectedIndex] == -1 && [group isSelectedAtIndex: 0] == NO,
+      "replacing the subitems clears the selection");
+
+    /* out of range */
+    group = groupWithMode(NSToolbarItemGroupSelectionModeSelectOne);
+    raised = NO;
+    NS_DURING
+      [group isSelectedAtIndex: 99];
+    NS_HANDLER
+      raised = [[localException name] isEqualToString: NSRangeException];
+    NS_ENDHANDLER
+    PASS(raised == YES, "asking about an index out of range raises");
+
+    raised = NO;
+    NS_DURING
+      [group setSelected: YES atIndex: 99];
+    NS_HANDLER
+      raised = [[localException name] isEqualToString: NSRangeException];
+    NS_ENDHANDLER
+    PASS(raised == YES, "selecting an index out of range raises");
+
+    raised = NO;
+    NS_DURING
+      [group setSelectedIndex: 99];
+    NS_HANDLER
+      raised = [[localException name] isEqualToString: NSRangeException];
+    NS_ENDHANDLER
+    PASS(raised == YES, "setting the selected index out of range raises");
+  }
+
+  END_SET("selection")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSToolbarItemGroup carried a subitems array and nothing else, so an application
could group items but not track which of them is chosen. This adds the selection
API: the two enumerations, the selection mode, the control representation, the
selected index and the per-index selection.

The behaviour follows AppKit, checked on a macOS runner:

- the enumeration values: SelectOne 0, SelectAny 1, Momentary 2, and Automatic
  0, Expanded 1, Collapsed 2
- a new group selects one subitem, has the automatic control representation and
  a selected index of -1
- selecting one: selecting a subitem deselects the previous one, and
  deselecting is ignored, so the group is never left with nothing selected
- selecting any: subitems select and deselect independently, and selectedIndex
  is the one selected last
- momentary: -setSelected:atIndex: holds no selection, while -setSelectedIndex:
  records the index without selecting anything
- -setSelectedIndex: -1 leaves the selection alone; an index out of range raises
  NSRangeException
- changing the selection mode leaves an existing selection alone
- replacing the subitems clears the selection

Two things worth flagging.

AppKit only tracks selection on groups built by its convenience constructors;
on a group built with -initWithItemIdentifier: and -setSubitems: the same calls
do nothing at all. Those constructors exist to build the segmented control that
represents the group, which is also where the titles they take end up. That
representation does not exist here, so the constructors are not part of this
change and the selection is tracked for any group with subitems rather than
reproducing AppKit's silence.

The toolbar does not lay out group subitems yet, so this is state that the
group keeps rather than something the user can see. It is the model half of the
class, and a renderer needs it either way.

26 tests, all passing.
