### PR TITLE
Fix: a new NSTableCellView has the custom row size style

### DIFF
--- a/Source/NSTableCellView.m
+++ b/Source/NSTableCellView.m
@@ -33,7 +33,7 @@
   self = [super initWithFrame: frame];
   if (self != nil)
     {
-      _rowSizeStyle = NSTableViewRowSizeStyleDefault;
+      _rowSizeStyle = NSTableViewRowSizeStyleCustom;
       _backgroundStyle = NSBackgroundStyleLight;
     }
   return self;

--- a/Tests/gui/NSTableCellView/rowSizeStyle.m
+++ b/Tests/gui/NSTableCellView/rowSizeStyle.m
@@ -1,0 +1,48 @@
+/* A new cell view sizes its row itself until a table view gives it one of the
+ * standard row size styles.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTableCellView.h>
+#include <AppKit/NSTableView.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("the default row size style")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    NSTableCellView	*view;
+
+    view = AUTORELEASE([[NSTableCellView alloc]
+      initWithFrame: NSMakeRect(0, 0, 100, 20)]);
+    PASS([view rowSizeStyle] == NSTableViewRowSizeStyleCustom,
+      "a new cell view has the custom row size style");
+
+    view = AUTORELEASE([[NSTableCellView alloc] init]);
+    PASS([view rowSizeStyle] == NSTableViewRowSizeStyleCustom,
+      "a cell view made with init has the custom row size style");
+
+    [view setRowSizeStyle: NSTableViewRowSizeStyleLarge];
+    PASS([view rowSizeStyle] == NSTableViewRowSizeStyleLarge,
+      "the row size style round-trips");
+  }
+
+  END_SET("the default row size style")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-initWithFrame: set the row size style to NSTableViewRowSizeStyleDefault. AppKit
leaves a new cell view on NSTableViewRowSizeStyleCustom, checked on a macOS
runner: a cell view sizes its row itself until a table view hands it one of the
standard styles.

The enumeration values themselves already match AppKit (Default -1, Custom 0,
Small 1, Medium 2, Large 3); only the value the initialiser picks differed.

Without the change 2 of the test's assertions fail; with it the NSTableCellView
tests pass 3/3.
