### PR TITLE
Fix: correct the accessibility appearance names

### DIFF
--- a/Source/externs.m
+++ b/Source/externs.m
@@ -753,10 +753,10 @@ const NSAppearanceName NSAppearanceNameAqua = @"NSAppearanceNameAqua";
 const NSAppearanceName NSAppearanceNameDarkAqua = @"NSAppearanceNameDarkAqua";
 const NSAppearanceName NSAppearanceNameVibrantLight = @"NSAppearanceNameVibrantLight";
 const NSAppearanceName NSAppearanceNameVibrantDark = @"NSAppearanceNameVibrantDark";
-const NSAppearanceName NSAppearanceNameAccessibilityHighContrastAqua = @"NSAppearanceNameAccessibilityHighContrastAqua";
-const NSAppearanceName NSAppearanceNameAccessibilityHighContrastDarkAqua = @"NSAppearanceNameAccessibilityHighContrastDarkAqua";
-const NSAppearanceName NSAppearanceNameAccessibilityHighContrastVibrantLight = @"NSAppearanceNameAccessibilityHighContrastVibrantLight";
-const NSAppearanceName NSAppearanceNameAccessibilityHighContrastVibrantDark = @"NSAppearanceNameAccessibilityHighContrastVibrantDark";
+const NSAppearanceName NSAppearanceNameAccessibilityHighContrastAqua = @"NSAppearanceNameAccessibilityAqua";
+const NSAppearanceName NSAppearanceNameAccessibilityHighContrastDarkAqua = @"NSAppearanceNameAccessibilityDarkAqua";
+const NSAppearanceName NSAppearanceNameAccessibilityHighContrastVibrantLight = @"NSAppearanceNameAccessibilityVibrantLight";
+const NSAppearanceName NSAppearanceNameAccessibilityHighContrastVibrantDark = @"NSAppearanceNameAccessibilityVibrantDark";
 const NSAppearanceName NSAppearanceNameLightContent = @"NSAppearanceNameLightContent";
 
 // Values for NSFontCollectionAction

--- a/Tests/gui/NSAppearance/accessibilityNames.m
+++ b/Tests/gui/NSAppearance/accessibilityNames.m
@@ -1,0 +1,38 @@
+/* The accessibility appearance names are the strings AppKit uses, which do not
+ * spell out "HighContrast" the way the constants naming them do.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSAppearance.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("the accessibility appearance names")
+    PASS([NSAppearanceNameAccessibilityHighContrastAqua
+      isEqualToString: @"NSAppearanceNameAccessibilityAqua"],
+      "the high contrast aqua name is the one AppKit uses");
+    PASS([NSAppearanceNameAccessibilityHighContrastDarkAqua
+      isEqualToString: @"NSAppearanceNameAccessibilityDarkAqua"],
+      "the high contrast dark aqua name is the one AppKit uses");
+    PASS([NSAppearanceNameAccessibilityHighContrastVibrantLight
+      isEqualToString: @"NSAppearanceNameAccessibilityVibrantLight"],
+      "the high contrast vibrant light name is the one AppKit uses");
+    PASS([NSAppearanceNameAccessibilityHighContrastVibrantDark
+      isEqualToString: @"NSAppearanceNameAccessibilityVibrantDark"],
+      "the high contrast vibrant dark name is the one AppKit uses");
+  END_SET("the accessibility appearance names")
+
+  START_SET("the other appearance names are unchanged")
+    PASS([NSAppearanceNameAqua isEqualToString: @"NSAppearanceNameAqua"],
+      "the aqua name is unchanged");
+    PASS([NSAppearanceNameVibrantLight
+      isEqualToString: @"NSAppearanceNameVibrantLight"],
+      "the vibrant light name is unchanged");
+  END_SET("the other appearance names are unchanged")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The four accessibility appearance name constants held strings that spell out
"HighContrast", following the constant names rather than the strings AppKit
uses. Checked on a macOS runner:

    NSAppearanceNameAccessibilityHighContrastAqua
      -> NSAppearanceNameAccessibilityAqua
    NSAppearanceNameAccessibilityHighContrastDarkAqua
      -> NSAppearanceNameAccessibilityDarkAqua
    NSAppearanceNameAccessibilityHighContrastVibrantLight
      -> NSAppearanceNameAccessibilityVibrantLight
    NSAppearanceNameAccessibilityHighContrastVibrantDark
      -> NSAppearanceNameAccessibilityVibrantDark

The constant names keep their spelling, since that is what AppKit calls them;
only the strings behind them change. These strings are what ends up in an
archive and what -appearanceNamed: is matched against, so the value is the part
that has to agree.

The four names that were already right (aqua, dark aqua, vibrant light, vibrant
dark) are untouched, and the test guards two of them.

Without the change 4 of the test's assertions fail; with it the NSAppearance
tests pass 6/6.
