### PR TITLE
Fix: the vibrant appearances allow vibrancy

### DIFF
--- a/Source/NSAppearance.m
+++ b/Source/NSAppearance.m
@@ -41,7 +41,13 @@ NSAppearance *__currentAppearance = nil;
   if (self)
     {
       ASSIGNCOPY(_name, name);
-      _allowsVibrancy = NO;
+      _allowsVibrancy
+        = [name isEqualToString: NSAppearanceNameVibrantLight]
+        || [name isEqualToString: NSAppearanceNameVibrantDark]
+        || [name isEqualToString:
+             NSAppearanceNameAccessibilityHighContrastVibrantLight]
+        || [name isEqualToString:
+             NSAppearanceNameAccessibilityHighContrastVibrantDark];
     }
   return self;
 }

--- a/Tests/gui/NSAppearance/vibrancy.m
+++ b/Tests/gui/NSAppearance/vibrancy.m
@@ -1,0 +1,29 @@
+/* The vibrant appearances allow vibrancy; the plain ones and a name that is not
+ * an appearance at all do not.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSAppearance.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("vibrancy")
+    PASS([[NSAppearance appearanceNamed: NSAppearanceNameVibrantLight]
+      allowsVibrancy] == YES, "the vibrant light appearance is vibrant");
+    PASS([[NSAppearance appearanceNamed: NSAppearanceNameVibrantDark]
+      allowsVibrancy] == YES, "the vibrant dark appearance is vibrant");
+
+    PASS([[NSAppearance appearanceNamed: NSAppearanceNameAqua]
+      allowsVibrancy] == NO, "the aqua appearance is not vibrant");
+    PASS([[NSAppearance appearanceNamed: NSAppearanceNameDarkAqua]
+      allowsVibrancy] == NO, "the dark aqua appearance is not vibrant");
+    PASS([[NSAppearance appearanceNamed: @"NotAnAppearance"]
+      allowsVibrancy] == NO, "an unknown appearance is not vibrant");
+  END_SET("vibrancy")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-allowsVibrancy was hardwired to NO, so the vibrant appearances reported that
they do not allow vibrancy.

AppKit, checked on a macOS runner: the vibrant light and vibrant dark
appearances allow vibrancy, aqua and dark aqua do not, and a name AppKit does
not know does not either.

The initialiser now sets the flag from the name. The accessibility vibrant
names are included: AppKit resolves those to the vibrant appearance underneath,
which allows vibrancy. They are not asserted in the test, because that
resolution depends on the machine's accessibility settings.

Without the change 2 of the test's assertions fail; with it the NSAppearance
tests pass 5/5.
