### PR TITLE
Fix: appearanceNamed: does not leak the appearance

### DIFF
--- a/Source/NSAppearance.m
+++ b/Source/NSAppearance.m
@@ -32,7 +32,8 @@ NSAppearance *__currentAppearance = nil;
 // Creating an appearance...
 + (instancetype) appearanceNamed: (NSString *)name
 {
-  return [[NSAppearance alloc] initWithAppearanceNamed: name bundle: nil];
+  return AUTORELEASE([[NSAppearance alloc] initWithAppearanceNamed: name
+                                                            bundle: nil]);
 }
 
 - (instancetype) initWithAppearanceNamed: (NSString *)name bundle: (NSBundle *)bundle

--- a/Tests/gui/NSAppearance/appearanceNamedOwnership.m
+++ b/Tests/gui/NSAppearance/appearanceNamedOwnership.m
@@ -1,0 +1,43 @@
+/* appearanceNamed: does not start with "alloc", "new", "copy" or
+ * "mutableCopy", so the caller does not own what it returns: the appearance has
+ * to be autoreleased, or every call leaks one.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSAppearance.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("appearanceNamed: ownership")
+    NSAutoreleasePool	*pool;
+    NSAppearance	*appearance;
+
+    pool = [NSAutoreleasePool new];
+    appearance = [NSAppearance appearanceNamed: NSAppearanceNameAqua];
+    RETAIN(appearance);
+    [pool release];
+
+    /* The pool held the only claim the method left behind, so draining it
+     * leaves just the retain taken above. */
+    PASS([appearance retainCount] == 1,
+      "appearanceNamed: returns an appearance the caller does not own");
+    PASS([[appearance name] isEqualToString: NSAppearanceNameAqua],
+      "the appearance is still usable after the pool it was made in");
+    RELEASE(appearance);
+  END_SET("appearanceNamed: ownership")
+
+  START_SET("appearanceNamed: still works")
+    NSAppearance	*appearance;
+
+    appearance = [NSAppearance appearanceNamed: NSAppearanceNameDarkAqua];
+    PASS(appearance != nil, "appearanceNamed: returns an appearance");
+    PASS([[appearance name] isEqualToString: NSAppearanceNameDarkAqua],
+      "the appearance keeps its name");
+  END_SET("appearanceNamed: still works")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
+appearanceNamed: returned the appearance the alloc left at +1. The method name
does not begin with alloc, new, copy or mutableCopy, so the caller does not own
the result and has no reason to release it: every call leaked an appearance.

Nothing in the library calls +appearanceNamed: today, so no caller is releasing
the result and none has to change.

The test retains the appearance, drains the pool it was made in, and checks the
retain count is back to its own claim, which only holds once the method
autoreleases. It also checks the appearance still carries its name afterwards.

Without the change 1 of the test's assertions fails; with it the NSAppearance
tests pass 4/4.
