### PR TITLE
Fix: implement bestMatchFromAppearancesWithNames:

### DIFF
--- a/Source/NSAppearance.m
+++ b/Source/NSAppearance.m
@@ -83,9 +83,41 @@ NSAppearance *__currentAppearance = nil;
   return _name;
 }
 
+/* The appearance a vibrant appearance is a variant of.  Anything else stands
+   for itself, so it only ever matches its own name. */
+- (NSAppearanceName) _baseAppearanceName
+{
+  if ([_name isEqualToString: NSAppearanceNameVibrantLight]
+    || [_name isEqualToString:
+         NSAppearanceNameAccessibilityHighContrastVibrantLight])
+    {
+      return NSAppearanceNameAqua;
+    }
+  if ([_name isEqualToString: NSAppearanceNameVibrantDark]
+    || [_name isEqualToString:
+         NSAppearanceNameAccessibilityHighContrastVibrantDark])
+    {
+      return NSAppearanceNameDarkAqua;
+    }
+  return _name;
+}
+
 // Determining the most appropriate appearance
 - (NSAppearanceName) bestMatchFromAppearancesWithNames: (NSArray *)appearances
 {
+  NSAppearanceName base;
+
+  if ([appearances containsObject: _name])
+    {
+      return _name;
+    }
+
+  base = [self _baseAppearanceName];
+  if (base != nil && [appearances containsObject: base])
+    {
+      return base;
+    }
+
   return nil;
 }
 

--- a/Tests/gui/NSAppearance/bestMatch.m
+++ b/Tests/gui/NSAppearance/bestMatch.m
@@ -1,0 +1,92 @@
+/* bestMatchFromAppearancesWithNames: picks the appearance's own name when the
+ * list offers it, otherwise the appearance it is a variant of, otherwise
+ * nothing.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSAppearance.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("an exact name wins")
+    NSAppearance	*aqua;
+    NSAppearance	*dark;
+    NSArray		*aquaFirst;
+    NSArray		*darkFirst;
+
+    aqua = [NSAppearance appearanceNamed: NSAppearanceNameAqua];
+    dark = [NSAppearance appearanceNamed: NSAppearanceNameDarkAqua];
+    aquaFirst = [NSArray arrayWithObjects: NSAppearanceNameAqua,
+      NSAppearanceNameDarkAqua, nil];
+    darkFirst = [NSArray arrayWithObjects: NSAppearanceNameDarkAqua,
+      NSAppearanceNameAqua, nil];
+
+    PASS([[aqua bestMatchFromAppearancesWithNames: aquaFirst]
+      isEqualToString: NSAppearanceNameAqua],
+      "the aqua appearance matches aqua");
+    PASS([[aqua bestMatchFromAppearancesWithNames: darkFirst]
+      isEqualToString: NSAppearanceNameAqua],
+      "the order of the names does not decide the match");
+    PASS([[dark bestMatchFromAppearancesWithNames: aquaFirst]
+      isEqualToString: NSAppearanceNameDarkAqua],
+      "the dark aqua appearance matches dark aqua");
+  END_SET("an exact name wins")
+
+  START_SET("a vibrant appearance falls back to the one it varies")
+    NSAppearance	*light;
+    NSAppearance	*dark;
+    NSArray		*both;
+    NSArray		*onlyAqua;
+    NSArray		*onlyDark;
+
+    light = [NSAppearance appearanceNamed: NSAppearanceNameVibrantLight];
+    dark = [NSAppearance appearanceNamed: NSAppearanceNameVibrantDark];
+    both = [NSArray arrayWithObjects: NSAppearanceNameAqua,
+      NSAppearanceNameDarkAqua, nil];
+    onlyAqua = [NSArray arrayWithObject: NSAppearanceNameAqua];
+    onlyDark = [NSArray arrayWithObject: NSAppearanceNameDarkAqua];
+
+    PASS([[light bestMatchFromAppearancesWithNames: both]
+      isEqualToString: NSAppearanceNameAqua],
+      "the vibrant light appearance falls back to aqua");
+    PASS([[dark bestMatchFromAppearancesWithNames: both]
+      isEqualToString: NSAppearanceNameDarkAqua],
+      "the vibrant dark appearance falls back to dark aqua");
+    PASS([[light bestMatchFromAppearancesWithNames: onlyAqua]
+      isEqualToString: NSAppearanceNameAqua],
+      "the vibrant light appearance matches a list of just aqua");
+    PASS([dark bestMatchFromAppearancesWithNames: onlyAqua] == nil,
+      "the vibrant dark appearance does not match aqua");
+    PASS([light bestMatchFromAppearancesWithNames: onlyDark] == nil,
+      "the vibrant light appearance does not match dark aqua");
+  END_SET("a vibrant appearance falls back to the one it varies")
+
+  START_SET("no match")
+    NSAppearance	*aqua;
+    NSAppearance	*light;
+
+    aqua = [NSAppearance appearanceNamed: NSAppearanceNameAqua];
+    light = [NSAppearance appearanceNamed: NSAppearanceNameVibrantLight];
+
+    PASS([aqua bestMatchFromAppearancesWithNames:
+      [NSArray arrayWithObject: NSAppearanceNameDarkAqua]] == nil,
+      "the aqua appearance does not match dark aqua");
+    PASS([aqua bestMatchFromAppearancesWithNames:
+      [NSArray arrayWithObject: NSAppearanceNameVibrantLight]] == nil,
+      "a plain appearance does not match a vibrant one");
+    PASS([aqua bestMatchFromAppearancesWithNames: [NSArray array]] == nil,
+      "an empty list matches nothing");
+    PASS([aqua bestMatchFromAppearancesWithNames:
+      [NSArray arrayWithObject: @"Bogus"]] == nil,
+      "a list of names that are not appearances matches nothing");
+    PASS([light bestMatchFromAppearancesWithNames:
+      [NSArray arrayWithObject: NSAppearanceNameVibrantDark]] == nil,
+      "one vibrant appearance does not match the other");
+  END_SET("no match")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-bestMatchFromAppearancesWithNames: always returned nil, so an application
asking which of the appearances it can draw suits the current one got no answer.

AppKit's choice, checked on a macOS runner:

- if the list holds the appearance's own name, that name wins, whatever order
  the list is in
- otherwise a vibrant appearance falls back to the appearance it is a variant
  of: vibrant light to aqua, vibrant dark to dark aqua
- otherwise nil. Aqua does not match dark aqua, a plain appearance does not
  match a vibrant one, and one vibrant appearance does not match the other

The fallback is one way round: vibrant light matches a list offering aqua, but
aqua does not match a list offering vibrant light.

The accessibility vibrant names fall back the same way as the vibrant names
they stand for. They are not asserted in the test, because AppKit resolves
those to the appearance underneath depending on the machine's accessibility
settings.

Without the change 11 of the test's assertions fail; with it the NSAppearance
tests pass 13/13.
