### PR TITLE
Fix: there is always a current appearance

### DIFF
--- a/Source/NSAppearance.m
+++ b/Source/NSAppearance.m
@@ -97,6 +97,12 @@ NSAppearance *__currentAppearance = nil;
 
 + (NSAppearance *) currentAppearance
 {
+  if (__currentAppearance == nil)
+    {
+      __currentAppearance = [[NSAppearance alloc]
+        initWithAppearanceNamed: NSAppearanceNameAqua
+                         bundle: nil];
+    }
   return __currentAppearance;
 }
 

--- a/Tests/gui/NSAppearance/currentAppearance.m
+++ b/Tests/gui/NSAppearance/currentAppearance.m
@@ -1,0 +1,38 @@
+/* There is always a current appearance, so that the views and the application
+ * asked for their effective appearance before anyone has set one have an
+ * appearance to answer with.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSAppearance.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  /* This has to come before anything sets the current appearance. */
+  START_SET("before anything sets one")
+    NSAppearance	*current;
+
+    current = [NSAppearance currentAppearance];
+    PASS(current != nil, "there is a current appearance from the start");
+    PASS([[current name] isEqualToString: NSAppearanceNameAqua],
+      "the current appearance starts out as aqua");
+  END_SET("before anything sets one")
+
+  START_SET("setting one")
+    NSAppearance	*dark;
+
+    dark = [NSAppearance appearanceNamed: NSAppearanceNameDarkAqua];
+    [NSAppearance setCurrentAppearance: dark];
+    PASS([NSAppearance currentAppearance] == dark,
+      "the current appearance reads back");
+    PASS([[[NSAppearance currentAppearance] name]
+      isEqualToString: NSAppearanceNameDarkAqua],
+      "the current appearance keeps its name");
+  END_SET("setting one")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
+currentAppearance returned nil until something set an appearance. AppKit
always has one, and reports aqua on a machine that has not been told otherwise,
checked on a macOS runner.

This is visible past NSAppearance: -[NSView effectiveAppearance] and
-[NSApplication effectiveAppearance] both fall back to +currentAppearance, so a
view with no appearance of its own, in a window with none, answered nil where
AppKit answers an appearance. Those two are the only callers, and neither
checks for nil.

The appearance is made on the first ask and kept, so it stays the same object
across calls. It is built directly rather than through +appearanceNamed:, so
this does not depend on #578.

Without the change 2 of the test's assertions fail; with it the NSAppearance
tests pass 4/4.
