### PR TITLE
Fix: NSAppearance keyed coding

### DIFF
--- a/Source/NSAppearance.m
+++ b/Source/NSAppearance.m
@@ -50,8 +50,15 @@ NSAppearance *__currentAppearance = nil;
 {
   if ([coder allowsKeyedCoding])
     {
+      /* The name carries the vibrancy with it, so the designated initialiser
+         works the rest out. */
+      return [self initWithAppearanceNamed:
+        [coder decodeObjectForKey: @"NSAppearanceName"]
+                                    bundle: nil];
     }
-  else
+
+  self = [super init];
+  if (self != nil)
     {
       ASSIGN(_name, [coder decodeObject]);
       [coder decodeValueOfObjCType: @encode(BOOL) at: &_allowsVibrancy];
@@ -61,8 +68,9 @@ NSAppearance *__currentAppearance = nil;
 
 - (void) encodeWithCoder: (NSCoder *)coder
 {
-    if ([coder allowsKeyedCoding])
+  if ([coder allowsKeyedCoding])
     {
+      [coder encodeObject: _name forKey: @"NSAppearanceName"];
     }
   else
     {

--- a/Tests/gui/NSAppearance/coding.m
+++ b/Tests/gui/NSAppearance/coding.m
@@ -1,0 +1,43 @@
+/* An appearance survives being archived, through a keyed archive as well as an
+ * old style one.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSAppearance.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("keyed coding")
+    NSAppearance	*appearance;
+    NSAppearance	*decoded;
+    NSData		*data;
+
+    appearance = [NSAppearance appearanceNamed: NSAppearanceNameDarkAqua];
+    data = [NSKeyedArchiver archivedDataWithRootObject: appearance];
+    PASS(data != nil && [data length] > 0, "the appearance archives");
+
+    decoded = [NSKeyedUnarchiver unarchiveObjectWithData: data];
+    PASS(decoded != nil, "the appearance comes back");
+    PASS([[decoded name] isEqualToString: NSAppearanceNameDarkAqua],
+      "the archived appearance keeps its name");
+  END_SET("keyed coding")
+
+  START_SET("old style coding")
+    NSAppearance	*appearance;
+    NSAppearance	*decoded;
+    NSData		*data;
+
+    appearance = [NSAppearance appearanceNamed: NSAppearanceNameAqua];
+    data = [NSArchiver archivedDataWithRootObject: appearance];
+    decoded = [NSUnarchiver unarchiveObjectWithData: data];
+    PASS(decoded != nil, "the appearance comes back from an old style archive");
+    PASS([[decoded name] isEqualToString: NSAppearanceNameAqua],
+      "the old style archived appearance keeps its name");
+  END_SET("old style coding")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The keyed branches of -initWithCoder: and -encodeWithCoder: were empty, so an
appearance archived by a keyed archiver wrote nothing and came back with no
name. Keyed coding is the path a nib takes.

Archiving an appearance on a macOS runner shows AppKit writes the name under
NSAppearanceName, so that key is used here. AppKit also writes an
NSAppearanceTintColor, which this class does not have and so does not encode.

AppKit stores no vibrancy flag: it works vibrancy out from the name when
decoding. The decoder here does the same by handing the name to the designated
initialiser, so the flag follows whatever that method decides. The old style
branch keeps encoding the flag, as it always has.

-initWithCoder: also never called [super init]; the old style branch now does.

Without the change 2 of the test's assertions fail; with it the NSAppearance
tests pass 5/5.
