### PR TITLE
Fix: NSTableRowView answers to the AppKit selector names

### DIFF
--- a/Headers/AppKit/NSTableRowView.h
+++ b/Headers/AppKit/NSTableRowView.h
@@ -76,15 +76,15 @@ extern "C" {
 - (void) setSelectionHighlightStyle: (NSTableViewSelectionHighlightStyle) selectionHighlightStyle;
 
 - (NSTableViewDraggingDestinationFeedbackStyle) draggingDestinationFeedbackStyle;
-- (void) setTableViewDraggingDestinationFeedbackStyle: (NSTableViewDraggingDestinationFeedbackStyle) draggingDestinationFeedbackStyle;
+- (void) setDraggingDestinationFeedbackStyle: (NSTableViewDraggingDestinationFeedbackStyle) draggingDestinationFeedbackStyle;
 
 - (CGFloat) indentationForDropOperation;
 - (void) setIndentationForDropOperation: (CGFloat)indentationForDropOperation;
 
-- (BOOL) targetForDropOperation;
+- (BOOL) isTargetForDropOperation;
 - (void) setTargetForDropOperation: (BOOL)flag;
 
-- (BOOL) groupRowStyle;
+- (BOOL) isGroupRowStyle;
 - (void) setGroupRowStyle: (BOOL)flag;
 
 - (NSInteger) numberOfColumns;

--- a/Source/NSTableRowView.m
+++ b/Source/NSTableRowView.m
@@ -76,7 +76,7 @@
   return _draggingDestinationFeedbackStyle;
 }
 
-- (void) setTableViewDraggingDestinationFeedbackStyle: (NSTableViewDraggingDestinationFeedbackStyle) draggingDestinationFeedbackStyle
+- (void) setDraggingDestinationFeedbackStyle: (NSTableViewDraggingDestinationFeedbackStyle) draggingDestinationFeedbackStyle
 {
   _draggingDestinationFeedbackStyle = draggingDestinationFeedbackStyle;
 }
@@ -91,7 +91,7 @@
   _indentationForDropOperation = indentationForDropOperation;
 }
 
-- (BOOL) targetForDropOperation
+- (BOOL) isTargetForDropOperation
 {
   return _targetForDropOperation;
 }
@@ -101,7 +101,7 @@
   _targetForDropOperation = flag;
 }
 
-- (BOOL) groupRowStyle
+- (BOOL) isGroupRowStyle
 {
   return _groupRowStyle;
 }

--- a/Tests/gui/NSTableRowView/selectorNames.m
+++ b/Tests/gui/NSTableRowView/selectorNames.m
@@ -1,0 +1,90 @@
+/* The drop target, the group row style and the dragging destination feedback
+ * style answer to the names AppKit gives them, so that code written against
+ * AppKit reaches them.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTableRowView.h>
+#include <AppKit/NSTableView.h>
+
+/* Declared so this file builds against a header that does not have them yet;
+ * what the test asks is whether the class answers to them. */
+@interface NSTableRowView (AppKitNames)
+- (void) setDraggingDestinationFeedbackStyle:
+  (NSTableViewDraggingDestinationFeedbackStyle)style;
+- (BOOL) isTargetForDropOperation;
+- (BOOL) isGroupRowStyle;
+@end
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("the AppKit selector names")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    NSTableRowView	*view;
+    BOOL		hasSetter;
+    BOOL		hasTarget;
+    BOOL		hasGroup;
+
+    view = AUTORELEASE([[NSTableRowView alloc]
+      initWithFrame: NSMakeRect(0, 0, 100, 20)]);
+
+    hasSetter = [view respondsToSelector:
+      @selector(setDraggingDestinationFeedbackStyle:)];
+    hasTarget = [view respondsToSelector: @selector(isTargetForDropOperation)];
+    hasGroup = [view respondsToSelector: @selector(isGroupRowStyle)];
+
+    PASS(hasSetter == YES,
+      "the dragging destination feedback style has a setter");
+    PASS(hasTarget == YES,
+      "the drop target flag is asked for with isTargetForDropOperation");
+    PASS(hasGroup == YES,
+      "the group row style flag is asked for with isGroupRowStyle");
+
+    if (hasSetter)
+      {
+        [view setDraggingDestinationFeedbackStyle:
+          NSTableViewDraggingDestinationFeedbackStyleGap];
+        PASS([view draggingDestinationFeedbackStyle]
+          == NSTableViewDraggingDestinationFeedbackStyleGap,
+          "the dragging destination feedback style round-trips");
+      }
+
+    if (hasTarget)
+      {
+        PASS([view isTargetForDropOperation] == NO,
+          "a new row view is not a drop target");
+        [view setTargetForDropOperation: YES];
+        PASS([view isTargetForDropOperation] == YES,
+          "the drop target flag round-trips");
+      }
+
+    if (hasGroup)
+      {
+        PASS([view isGroupRowStyle] == NO,
+          "a new row view does not have the group row style");
+        [view setGroupRowStyle: YES];
+        PASS([view isGroupRowStyle] == YES,
+          "the group row style round-trips");
+      }
+  }
+
+  END_SET("the AppKit selector names")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Three of NSTableRowView's selectors are not the ones AppKit uses, so code
written against AppKit does not reach them and raises instead:

    setTableViewDraggingDestinationFeedbackStyle:
                              -> setDraggingDestinationFeedbackStyle:
    targetForDropOperation    -> isTargetForDropOperation
    groupRowStyle             -> isGroupRowStyle

Checked on a macOS runner: AppKit answers to the names on the right, and does
not answer to the ones on the left at all, so nothing portable can be calling
them. Inside the library only NSTableRowView itself used them.

The rest of the class already agrees with AppKit: every other selector is
present under the same name, the init defaults match, and so do the setter
round-trips (covered in #583).

Without the change 3 of the test's assertions fail and the calls behind them do
not run; with it the NSTableRowView tests pass 8/8.
