### PR TITLE
tests: add NSDockTile tests

### DIFF
--- a/Tests/gui/NSDockTile/basic.m
+++ b/Tests/gui/NSDockTile/basic.m
@@ -1,0 +1,62 @@
+/* Coverage for NSDockTile: the tile the application vends, and the badge label,
+ * application badge and content view round-trips.  Every assertion here matches
+ * AppKit (verified on a macOS runner) and passes on unmodified GNUstep.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSDockTile.h>
+#include <AppKit/NSView.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("the application dock tile")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    NSDockTile	*tile;
+    NSView	*view;
+
+    tile = [NSApp dockTile];
+    PASS(tile != nil, "the application has a dock tile");
+    PASS([tile badgeLabel] == nil, "the dock tile starts with no badge label");
+    PASS([tile size].width > 0 && [tile size].height > 0,
+      "the dock tile has a size");
+
+    [tile setBadgeLabel: @"7"];
+    PASS([[tile badgeLabel] isEqualToString: @"7"],
+      "the badge label round-trips");
+    [tile setBadgeLabel: nil];
+    PASS([tile badgeLabel] == nil, "the badge label can be cleared");
+
+    [tile setShowsApplicationBadge: NO];
+    PASS([tile showsApplicationBadge] == NO,
+      "the application badge flag round-trips when unset");
+    [tile setShowsApplicationBadge: YES];
+    PASS([tile showsApplicationBadge] == YES,
+      "the application badge flag round-trips when set");
+
+    view = AUTORELEASE([[NSView alloc]
+      initWithFrame: NSMakeRect(0, 0, 10, 10)]);
+    [tile setContentView: view];
+    PASS([tile contentView] == view, "the content view reads back");
+  }
+
+  END_SET("the application dock tile")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSDockTile has no tests. This adds coverage for the tile the application vends
and the badge label, application badge and content view round-trips.

Every assertion was checked against AppKit on a macOS runner and passes on
unmodified GNUstep:

- the application has a dock tile, it starts with no badge label, and it has a
  size
- the badge label round-trips and can be set back to nil
- the application badge flag round-trips both ways
- the content view reads back as the same view

Left out: the tile's size (AppKit reports 128x128, here it is whatever the
display server says an icon is, which is the right answer for the platform),
and the content view, owner and application badge defaults, which diverge.
