### PR TITLE
Fix: NSDockTile lets go of its ivars in dealloc

### DIFF
--- a/Source/NSDockTile.m
+++ b/Source/NSDockTile.m
@@ -69,13 +69,13 @@
   return self;
 }
 
-- (oneway void) release
+- (void) dealloc
 {
   RELEASE(_contentView);
   RELEASE(_badgeLabel);
   RELEASE(_appIconImage);
   RELEASE(_dockTileImage);
-  [super release];
+  [super dealloc];
 }
 
 - (NSView *) contentView

--- a/Tests/gui/NSDockTile/ownership.m
+++ b/Tests/gui/NSDockTile/ownership.m
@@ -1,0 +1,57 @@
+/* A dock tile lets go of what it holds when it is deallocated, not on every
+ * release: a tile that is retained and released again is still whole.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSDockTile.h>
+#include <AppKit/NSView.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("a balancing release keeps the tile whole")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    NSDockTile	*tile;
+    NSView	*view;
+
+    tile = [[NSDockTile alloc] init];
+    view = [tile contentView];
+    RETAIN(view);
+
+    /* One retain and one release, leaving the tile alive throughout. */
+    RETAIN(tile);
+    RELEASE(tile);
+
+    PASS([tile contentView] == view, "the tile still has its content view");
+    PASS([view retainCount] == 2,
+      "a balancing release does not let go of the content view");
+
+    [tile setBadgeLabel: @"7"];
+    RETAIN(tile);
+    RELEASE(tile);
+    PASS([[tile badgeLabel] isEqualToString: @"7"],
+      "a balancing release does not let go of the badge label");
+
+    RELEASE(view);
+    RELEASE(tile);
+  }
+
+  END_SET("a balancing release keeps the tile whole")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSDockTile lets go of its content view, badge label and images in -release
rather than in -dealloc, so it does so on every release, not when it is
deallocated. A tile that is retained and released again, which is all it takes,
is left holding four dangling pointers while still alive.

The second such cycle then over-releases them. With the test below on an
unmodified library:

    Failed test: a balancing release does not let go of the content view
    *** -[NSImage release]: message sent to deallocated instance 0x...
    timeout: the monitored command dumped core

-dealloc is where this belongs: the ivars are let go of once, when the tile
goes.

The test retains and releases a tile and checks it still holds its content view
and badge label. Without the change the first assertion fails and the program
dumps core partway through; with it the NSDockTile tests pass 3/3, and the
coverage tests in #585 pass either way.
