### PR TITLE
Fix: the application owns its dock tile

### DIFF
--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -2485,6 +2485,7 @@ image.</p><p>See Also: -applicationIconImage</p>
   if (!_dock_tile)
     {
       _dock_tile = [[NSDockTile alloc] init];
+      [_dock_tile setOwner: self];
       [_dock_tile setContentView: [_app_icon_window contentView]];
     }
   return _dock_tile;

--- a/Tests/gui/NSDockTile/owner.m
+++ b/Tests/gui/NSDockTile/owner.m
@@ -1,0 +1,43 @@
+/* The application's dock tile is owned by the application, so that whatever is
+ * handed the tile can find its way back.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSDockTile.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("the dock tile owner")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    NSDockTile	*tile;
+
+    tile = [NSApp dockTile];
+    PASS([tile owner] == NSApp,
+      "the application dock tile is owned by the application");
+
+    /* and the owner is still whatever it is set to */
+    [tile setOwner: nil];
+    PASS([tile owner] == nil, "the owner round-trips");
+    [tile setOwner: NSApp];
+    PASS([tile owner] == NSApp, "the owner reads back");
+  }
+
+  END_SET("the dock tile owner")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-[NSApplication dockTile] built its tile without telling it who owns it, so
-owner was nil. AppKit has the application's tile owned by the application,
checked on a macOS runner, and the header here already describes owner as
"typically the application instance".

setOwner: does not retain, so this does not make a cycle between the two.

Without the change 1 of the test's assertions fails; with it the NSDockTile
tests pass 3/3.
