### PR TITLE
Fix: a new NSTokenFieldCell has the default tokenizing character set

### DIFF
--- a/Source/NSTokenFieldCell.m
+++ b/Source/NSTokenFieldCell.m
@@ -43,6 +43,18 @@
     }
 }
 
+- (id) initTextCell: (NSString*)aString
+{
+  self = [super initTextCell: aString];
+  if (self != nil)
+    {
+      ASSIGN(tokenizingCharacterSet,
+        [[self class] defaultTokenizingCharacterSet]);
+      completionDelay = [[self class] defaultCompletionDelay];
+    }
+  return self;
+}
+
 - (void) dealloc
 {
   RELEASE(tokenizingCharacterSet);

--- a/Tests/gui/NSTokenFieldCell/defaultTokenizingCharacterSet.m
+++ b/Tests/gui/NSTokenFieldCell/defaultTokenizingCharacterSet.m
@@ -1,0 +1,55 @@
+/* A new token field cell starts with the class's default tokenizing character
+ * set, so that it tokenizes without being told what to tokenize on.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSCharacterSet.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTokenFieldCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("the default tokenizing character set")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    NSTokenFieldCell	*cell;
+    NSCharacterSet	*set;
+    NSCharacterSet	*semicolons;
+
+    cell = AUTORELEASE([[NSTokenFieldCell alloc] initTextCell: @"token"]);
+    set = [cell tokenizingCharacterSet];
+    PASS(set != nil, "a new cell has a tokenizing character set");
+    PASS([set characterIsMember: ','] == YES,
+      "a new cell tokenizes on a comma");
+    PASS([cell completionDelay] == [NSTokenFieldCell defaultCompletionDelay],
+      "a new cell has the default completion delay");
+
+    cell = AUTORELEASE([[NSTokenFieldCell alloc] init]);
+    PASS([cell tokenizingCharacterSet] != nil,
+      "a cell made with init has a tokenizing character set");
+
+    /* and it is still whatever it is set to */
+    semicolons = [NSCharacterSet characterSetWithCharactersInString: @";"];
+    [cell setTokenizingCharacterSet: semicolons];
+    PASS([cell tokenizingCharacterSet] == semicolons,
+      "the tokenizing character set round-trips");
+  }
+
+  END_SET("the default tokenizing character set")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A new token field cell had no tokenizing character set at all, so it had
nothing to tokenize on until one was set. AppKit starts a cell on the comma set,
checked on a macOS runner, which is exactly what this class's own
+defaultTokenizingCharacterSet already vends.

The cell had no initialiser of its own. This adds one on -initTextCell:, the
funnel NSCell -init goes through, so a cell made either way starts with the
class defaults.

The completion delay is taken from +defaultCompletionDelay in the same place.
That is 0 here, so it changes nothing today, but it keeps both defaults coming
from the class methods that name them rather than from a zeroed ivar.

Without the change 3 of the test's assertions fail; with it the
NSTokenFieldCell tests pass 5/5.
