### PR TITLE
Fix: NSTokenFieldCell archives its token style, delay and character set

### DIFF
--- a/Source/NSTokenFieldCell.m
+++ b/Source/NSTokenFieldCell.m
@@ -39,7 +39,7 @@
 {
   if (self == [NSTokenFieldCell class])
     {
-      [self setVersion: 1];
+      [self setVersion: 2];
     }
 }
 
@@ -58,21 +58,50 @@
 
   if ([aCoder allowsKeyedCoding])
     {
+      [aCoder encodeInt: tokenStyle forKey: @"NSTokenStyle"];
+      [aCoder encodeDouble: completionDelay forKey: @"NSCompletionDelay"];
+      [aCoder encodeObject: tokenizingCharacterSet
+                    forKey: @"NSTokenizingCharacterSet"];
     }
   else
     {
+      [aCoder encodeValueOfObjCType: @encode(NSTokenStyle) at: &tokenStyle];
+      [aCoder encodeValueOfObjCType: @encode(NSTimeInterval)
+                                 at: &completionDelay];
+      [aCoder encodeObject: tokenizingCharacterSet];
     }
 }
 
 - (id) initWithCoder: (NSCoder*)aDecoder
 {
   self = [super initWithCoder: aDecoder];
- 
+  if (self == nil)
+    {
+      return nil;
+    }
+
   if ([aDecoder allowsKeyedCoding])
     {
+      if ([aDecoder containsValueForKey: @"NSTokenStyle"])
+        {
+          tokenStyle = [aDecoder decodeIntForKey: @"NSTokenStyle"];
+        }
+      if ([aDecoder containsValueForKey: @"NSCompletionDelay"])
+        {
+          completionDelay = [aDecoder decodeDoubleForKey: @"NSCompletionDelay"];
+        }
+      if ([aDecoder containsValueForKey: @"NSTokenizingCharacterSet"])
+        {
+          ASSIGN(tokenizingCharacterSet,
+            [aDecoder decodeObjectForKey: @"NSTokenizingCharacterSet"]);
+        }
     }
-  else
+  else if ([aDecoder versionForClassName: @"NSTokenFieldCell"] >= 2)
     {
+      [aDecoder decodeValueOfObjCType: @encode(NSTokenStyle) at: &tokenStyle];
+      [aDecoder decodeValueOfObjCType: @encode(NSTimeInterval)
+                                   at: &completionDelay];
+      ASSIGN(tokenizingCharacterSet, [aDecoder decodeObject]);
     }
 
   return self;

--- a/Tests/gui/NSTokenFieldCell/coding.m
+++ b/Tests/gui/NSTokenFieldCell/coding.m
@@ -1,0 +1,78 @@
+/* A token field cell carries its token style, completion delay and tokenizing
+ * character set through an archive, keyed or old style.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSArchiver.h>
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSCharacterSet.h>
+#include <Foundation/NSData.h>
+#include <Foundation/NSKeyedArchiver.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTokenFieldCell.h>
+
+static NSTokenFieldCell *
+cellToArchive(void)
+{
+  NSTokenFieldCell	*cell;
+
+  cell = AUTORELEASE([[NSTokenFieldCell alloc] initTextCell: @"token"]);
+  [cell setTokenStyle: NSRoundedTokenStyle];
+  [cell setCompletionDelay: 2.5];
+  [cell setTokenizingCharacterSet:
+    [NSCharacterSet characterSetWithCharactersInString: @";"]];
+  return cell;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("coding")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    NSTokenFieldCell	*decoded;
+    NSData		*data;
+
+    /* keyed */
+    data = [NSKeyedArchiver archivedDataWithRootObject: cellToArchive()];
+    decoded = [NSKeyedUnarchiver unarchiveObjectWithData: data];
+
+    PASS(decoded != nil, "the cell comes back from a keyed archive");
+    PASS([decoded tokenStyle] == NSRoundedTokenStyle,
+      "the archived cell keeps its token style");
+    PASS([decoded completionDelay] == 2.5,
+      "the archived cell keeps its completion delay");
+    PASS([decoded tokenizingCharacterSet] != nil
+      && [[decoded tokenizingCharacterSet] characterIsMember: ';'],
+      "the archived cell keeps its tokenizing character set");
+
+    /* old style */
+    data = [NSArchiver archivedDataWithRootObject: cellToArchive()];
+    decoded = [NSUnarchiver unarchiveObjectWithData: data];
+
+    PASS(decoded != nil, "the cell comes back from an old style archive");
+    PASS([decoded tokenStyle] == NSRoundedTokenStyle,
+      "the old style archived cell keeps its token style");
+    PASS([decoded completionDelay] == 2.5,
+      "the old style archived cell keeps its completion delay");
+    PASS([decoded tokenizingCharacterSet] != nil
+      && [[decoded tokenizingCharacterSet] characterIsMember: ';'],
+      "the old style archived cell keeps its tokenizing character set");
+  }
+
+  END_SET("coding")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Both branches of -encodeWithCoder: and -initWithCoder: were empty, so a token
field cell wrote none of its three ivars and came back from an archive with the
token style, the completion delay and the tokenizing character set all lost.

Archiving a cell on a macOS runner shows the keys AppKit uses, which are the
ones used here:

    NSTokenStyle = 2;
    NSCompletionDelay = "2.5";
    NSTokenizingCharacterSet = <the character set>;

The keyed branch guards each key with -containsValueForKey:, so an archive
written before this change decodes as it did.

The old style branch has no keys to guard with, and the class version was
already 1 when nothing was being written, so there is no telling an old empty
archive from a new one at that version. The version therefore goes to 2 and the
decoder only reads the three values at version 2 or later, the way
NSTextFieldCell and NSButtonCell handle their own format changes.

Without the change 6 of the test's assertions fail; with it the
NSTokenFieldCell tests pass 8/8.
