### PR TITLE
Fix: NSPageController asks its delegate which view controller shows a page

### DIFF
--- a/Source/NSPageController.m
+++ b/Source/NSPageController.m
@@ -48,6 +48,7 @@
 - (void) dealloc
 {
   RELEASE(_arrangedObjects);
+  RELEASE(_selectedViewController);
   [super dealloc];
 }
 
@@ -123,15 +124,60 @@
   return _selectedIndex;
 }
 
+/* The arranged objects are the application's own, whatever they are; it is the
+   delegate that says which view controller shows one. */
+- (NSViewController *) _viewControllerForObject: (id)object
+{
+  NSPageControllerObjectIdentifier identifier;
+  NSViewController *controller;
+
+  if (![_delegate respondsToSelector:
+    @selector(pageController:identifierForObject:)]
+    || ![_delegate respondsToSelector:
+    @selector(pageController:viewControllerForIdentifier:)])
+    {
+      return nil;
+    }
+
+  identifier = [_delegate pageController: self identifierForObject: object];
+  controller = [_delegate pageController: self
+             viewControllerForIdentifier: identifier];
+  if (controller != nil
+    && [_delegate respondsToSelector:
+    @selector(pageController:prepareViewController:withObject:)])
+    {
+      [_delegate pageController: self
+          prepareViewController: controller
+                     withObject: object];
+    }
+
+  return controller;
+}
+
 - (void) setSelectedIndex: (NSInteger)index
 {
+  id object;
+
+  if (index == _selectedIndex)
+    {
+      return;
+    }
+  if (index < 0 || (NSUInteger)index >= [_arrangedObjects count])
+    {
+      [NSException raise: NSInternalInconsistencyException
+                  format: @"selected index %ld out of range 0 to %lu",
+        (long)index, (unsigned long)[_arrangedObjects count]];
+    }
+
   if ([_delegate respondsToSelector: @selector(pageControllerWillStartLiveTransition:)])
     {
       [_delegate pageControllerWillStartLiveTransition: self];
     }
+
+  object = [_arrangedObjects objectAtIndex: index];
   [self willChangeValueForKey: @"selectedIndex"];
   _selectedIndex = index;
-  _selectedViewController = [_arrangedObjects objectAtIndex: _selectedIndex];
+  ASSIGN(_selectedViewController, [self _viewControllerForObject: object]);
   [self didChangeValueForKey: @"selectedIndex"];
 
   // Complete...
@@ -146,13 +192,13 @@
   // Notify delegate that transition is finished.
   if ([_delegate respondsToSelector: @selector(pageController:didTransitionToObject:)])
     {
-      [_delegate pageController: self didTransitionToObject: _selectedViewController];
+      [_delegate pageController: self didTransitionToObject: object];
     }
 
   // Resize based on frame...
   if ([_delegate respondsToSelector: @selector(pageController:frameForObject:)])
     {
-      NSRect rect = [_delegate pageController: self frameForObject: _selectedViewController];
+      NSRect rect = [_delegate pageController: self frameForObject: object];
       [[_selectedViewController view] setFrame: rect];
     }
 }
@@ -171,7 +217,10 @@
 
 - (void) completeTransition
 {
-  [self setView: [_selectedViewController view]];
+  if (_selectedViewController != nil)
+    {
+      [self setView: [_selectedViewController view]];
+    }
 }
 
 - (IBAction) navigateBack: (id)sender

--- a/Tests/gui/NSPageController/selection.m
+++ b/Tests/gui/NSPageController/selection.m
@@ -1,0 +1,212 @@
+/* Selecting a page: the arranged objects are the application's own, and the
+ * delegate says which view controller shows one.  The controller reports the
+ * object it moved to, and refuses an index it has no object for.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSArray.h>
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSException.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSPageController.h>
+#include <AppKit/NSView.h>
+#include <AppKit/NSViewController.h>
+
+@interface Delegate : NSObject
+{
+@public
+  NSMutableArray	*calls;
+  NSViewController	*vended;
+  id			transitionedTo;
+  id			framedFor;
+}
+@end
+
+@implementation Delegate
+
+- (id) init
+{
+  self = [super init];
+  if (self != nil)
+    {
+      calls = [[NSMutableArray alloc] init];
+    }
+  return self;
+}
+
+- (void) dealloc
+{
+  RELEASE(calls);
+  RELEASE(vended);
+  [super dealloc];
+}
+
+- (NSString *) pageController: (NSPageController *)controller
+          identifierForObject: (id)object
+{
+  [calls addObject: @"identifierForObject:"];
+  return [NSString stringWithFormat: @"id-%@", object];
+}
+
+- (NSViewController *) pageController: (NSPageController *)controller
+          viewControllerForIdentifier: (NSString *)identifier
+{
+  NSViewController	*controllerForPage;
+  NSView		*view;
+
+  [calls addObject: @"viewControllerForIdentifier:"];
+  controllerForPage = AUTORELEASE([[NSViewController alloc] init]);
+  view = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 10, 10)]);
+  [controllerForPage setView: view];
+  ASSIGN(vended, controllerForPage);
+  return controllerForPage;
+}
+
+- (void) pageController: (NSPageController *)controller
+  prepareViewController: (NSViewController *)viewController
+             withObject: (id)object
+{
+  [calls addObject: @"prepareViewController:withObject:"];
+}
+
+- (void) pageController: (NSPageController *)controller
+  didTransitionToObject: (id)object
+{
+  [calls addObject: @"didTransitionToObject:"];
+  transitionedTo = object;
+}
+
+- (NSRect) pageController: (NSPageController *)controller
+           frameForObject: (id)object
+{
+  [calls addObject: @"frameForObject:"];
+  framedFor = object;
+  return NSMakeRect(0, 0, 50, 50);
+}
+@end
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("selection")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    NSPageController	*controller;
+    Delegate		*delegate;
+    NSArray		*objects;
+    BOOL		raised;
+
+    /* selecting through the delegate */
+    controller = AUTORELEASE([[NSPageController alloc] init]);
+    delegate = AUTORELEASE([[Delegate alloc] init]);
+    objects = [NSArray arrayWithObjects: @"a", @"b", @"c", nil];
+
+    [controller setDelegate: delegate];
+    [controller setArrangedObjects: objects];
+    [controller setSelectedIndex: 2];
+
+    PASS([controller selectedIndex] == 2, "the selected index is set");
+    PASS([controller selectedViewController] == delegate->vended,
+      "the selected view controller is the one the delegate vends");
+    PASS([delegate->calls containsObject: @"identifierForObject:"],
+      "the delegate is asked for the object's identifier");
+    PASS([delegate->calls containsObject: @"viewControllerForIdentifier:"],
+      "the delegate is asked for the view controller of that identifier");
+    PASS([delegate->calls containsObject: @"prepareViewController:withObject:"],
+      "the delegate is asked to prepare the view controller");
+    PASS([(NSString *)delegate->transitionedTo isEqualToString: @"c"],
+      "the delegate is told which object was moved to, not its view controller");
+    PASS([(NSString *)delegate->framedFor isEqualToString: @"c"],
+      "the delegate is asked for the frame of the object, not its view controller");
+
+    /* selecting without a delegate */
+    controller = AUTORELEASE([[NSPageController alloc] init]);
+    [controller setArrangedObjects:
+      [NSArray arrayWithObjects: @"a", @"b", nil]];
+
+    raised = NO;
+    NS_DURING
+      [controller setSelectedIndex: 1];
+    NS_HANDLER
+      raised = YES;
+    NS_ENDHANDLER
+
+    PASS(raised == NO, "selecting a page with no delegate does not raise");
+    PASS([controller selectedIndex] == 1, "the selected index is still set");
+    PASS([controller selectedViewController] == nil,
+      "there is no selected view controller without a delegate");
+
+    /* an index with no object.  Selecting the index already selected asks for
+     * nothing and so cannot be out of range, which is why an empty controller
+     * tolerates zero. */
+    controller = AUTORELEASE([[NSPageController alloc] init]);
+    raised = NO;
+    NS_DURING
+      [controller setSelectedIndex: 0];
+    NS_HANDLER
+      raised = YES;
+    NS_ENDHANDLER
+    PASS(raised == NO, "selecting zero on an empty controller does not raise");
+    PASS([controller selectedIndex] == 0, "the selected index stays at zero");
+
+    raised = NO;
+    NS_DURING
+      [controller setSelectedIndex: 5];
+    NS_HANDLER
+      raised = [[localException name]
+        isEqualToString: NSInternalInconsistencyException];
+    NS_ENDHANDLER
+    PASS(raised == YES, "an index an empty controller has no object for raises");
+
+    controller = AUTORELEASE([[NSPageController alloc] init]);
+    [controller setArrangedObjects:
+      [NSArray arrayWithObjects: @"a", @"b", @"c", nil]];
+
+    raised = NO;
+    NS_DURING
+      [controller setSelectedIndex: 3];
+    NS_HANDLER
+      raised = [[localException name]
+        isEqualToString: NSInternalInconsistencyException];
+    NS_ENDHANDLER
+    PASS(raised == YES, "an index past the last object raises");
+
+    raised = NO;
+    NS_DURING
+      [controller setSelectedIndex: -1];
+    NS_HANDLER
+      raised = [[localException name]
+        isEqualToString: NSInternalInconsistencyException];
+    NS_ENDHANDLER
+    PASS(raised == YES, "a negative index raises");
+
+    /* navigating an empty controller */
+    controller = AUTORELEASE([[NSPageController alloc] init]);
+    raised = NO;
+    NS_DURING
+      [controller navigateBack: nil];
+    NS_HANDLER
+      raised = YES;
+    NS_ENDHANDLER
+    PASS(raised == NO, "navigating back on an empty controller does not raise");
+    PASS([controller selectedIndex] == 0,
+      "the selected index stays at zero when navigating back");
+  }
+
+  END_SET("selection")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-setSelectedIndex: took each arranged object to be the view controller that
shows it:

    _selectedViewController = [_arrangedObjects objectAtIndex: _selectedIndex];

The arranged objects are the application's own, whatever they are; the delegate
protocol here says as much, with -pageController:identifierForObject: and
-pageController:viewControllerForIdentifier: to map one to a view controller.
Neither was called anywhere. So selecting a page raised for anything that is
not itself a view controller, which is the ordinary case:

    [controller setArrangedObjects:
      [NSArray arrayWithObjects: @"a", @"b", @"c", nil]];
    [controller setSelectedIndex: 2];
    // NSInvalidArgumentException: GSTinyString(instance) does not
    // recognize view

Selection now goes through the delegate: identifierForObject:, then
viewControllerForIdentifier:, then prepareViewController:withObject: if it
takes it. That is the order AppKit calls them in, recorded from a delegate on a
macOS runner. With no delegate there is no view controller, and the selected
index is still set, as on AppKit.

Two more things the recording showed. -pageController:didTransitionToObject:
and -pageController:frameForObject: are handed the object, not its view
controller; both were passed _selectedViewController here. And an index the
controller has no object for raises NSInternalInconsistencyException rather
than reaching objectAtIndex: and raising NSRangeException. Selecting the index
already selected asks for nothing and so cannot be out of range, which is why
an empty controller tolerates zero, and why -navigateBack: on one no longer
raises.

The view controller is retained now that it comes from the delegate rather than
from the arranged objects array, and released in -dealloc.
-completeTransition leaves the view alone when there is no view controller,
rather than setting it to nil.

Without the change the test's first set aborts on the exception above and 7
further assertions fail; with it the NSPageController tests pass 17/17. The
coverage tests in #591 pass either way.
