### PR TITLE
Fix: NSSearchFieldCell -recentSearches returns an empty array

### DIFF
--- a/Source/NSSearchFieldCell.m
+++ b/Source/NSSearchFieldCell.m
@@ -181,6 +181,10 @@
 
 - (NSArray *) recentSearches
 {
+  if (_recent_searches == nil)
+    {
+      return [NSArray array];
+    }
   return _recent_searches;
 }
 

--- a/Tests/gui/NSSearchFieldCell/recentSearchesEmpty.m
+++ b/Tests/gui/NSSearchFieldCell/recentSearchesEmpty.m
@@ -1,0 +1,49 @@
+/* -recentSearches returns an empty array rather than nil for a cell that has
+ * none, so that callers can enumerate the result without a nil check.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSArray.h>
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSearchFieldCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("empty recent searches")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    NSSearchFieldCell	*cell;
+
+    cell = AUTORELEASE([[NSSearchFieldCell alloc] initTextCell: @"find"]);
+    PASS([cell recentSearches] != nil,
+      "a new cell has an empty recent searches array");
+    PASS([[cell recentSearches] count] == 0, "a new cell has no recent searches");
+
+    [cell setRecentSearches: [NSArray arrayWithObject: @"one"]];
+    PASS([[cell recentSearches] count] == 1, "the recent searches are set");
+
+    [cell setRecentSearches: nil];
+    PASS([cell recentSearches] != nil,
+      "clearing the recent searches leaves an empty array");
+    PASS([[cell recentSearches] count] == 0,
+      "clearing the recent searches removes them");
+  }
+
+  END_SET("empty recent searches")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-recentSearches returned nil for a cell that has no recent searches. AppKit
returns an empty array, checked on a macOS runner, both for a new cell and
after the searches are set back to nil.

The initialiser has the line that would have built the array commented out; the
getter answers for it instead, the same shape as the -pathItems and -subitems
getters.

Without the change 3 of the test's assertions fail; with it the
NSSearchFieldCell tests pass 5/5.
