### PR TITLE
Fix: an autosave name with nothing saved keeps the searches it found

### DIFF
--- a/Source/NSSearchFieldCell.m
+++ b/Source/NSSearchFieldCell.m
@@ -711,7 +711,12 @@
     {
       list = [[NSUserDefaults standardUserDefaults]
 	         stringArrayForKey: name];
-      [self setRecentSearches: list];
+      /* Nothing saved under that name says nothing about the searches the
+         cell already has. */
+      if (list != nil)
+	{
+	  [self setRecentSearches: list];
+	}
     }
 }
 

--- a/Tests/gui/NSSearchFieldCell/autosaveName.m
+++ b/Tests/gui/NSSearchFieldCell/autosaveName.m
@@ -1,0 +1,67 @@
+/* Giving a cell a recents autosave name loads the searches saved under it, but
+ * a name with nothing saved under it says nothing about the searches the cell
+ * already has.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSArray.h>
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSUserDefaults.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSearchFieldCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("the recents autosave name")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    NSSearchFieldCell	*cell;
+    NSArray		*searches;
+    NSString		*unusedName = @"GSTestSearchesNothingSavedHere";
+    NSString		*savedName = @"GSTestSearchesSomethingSavedHere";
+
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey: unusedName];
+
+    /* a name with nothing saved under it leaves the searches alone */
+    cell = AUTORELEASE([[NSSearchFieldCell alloc] initTextCell: @"find"]);
+    searches = [NSArray arrayWithObjects: @"one", @"two", nil];
+    [cell setRecentSearches: searches];
+    [cell setRecentsAutosaveName: unusedName];
+
+    PASS([[cell recentsAutosaveName] isEqualToString: unusedName],
+      "the autosave name is set");
+    PASS([[cell recentSearches] count] == 2,
+      "an autosave name with nothing saved leaves the searches alone");
+
+    /* and a name with searches saved under it loads them */
+    [[NSUserDefaults standardUserDefaults]
+      setObject: [NSArray arrayWithObject: @"saved"]
+         forKey: savedName];
+
+    cell = AUTORELEASE([[NSSearchFieldCell alloc] initTextCell: @"find"]);
+    [cell setRecentSearches: [NSArray arrayWithObjects: @"one", @"two", nil]];
+    [cell setRecentsAutosaveName: savedName];
+    PASS([[cell recentSearches] count] == 1
+      && [[[cell recentSearches] objectAtIndex: 0] isEqualToString: @"saved"],
+      "an autosave name with searches saved under it loads them");
+
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey: savedName];
+  }
+
+  END_SET("the recents autosave name")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-setRecentsAutosaveName: loads the searches saved under the name it is given.
When nothing is saved under it, -stringArrayForKey: answers nil, and that nil
went on to -setRecentSearches:, which threw away the searches the cell already
had:

    [cell setRecentSearches: [NSArray arrayWithObjects: @"one", @"two", nil]];
    [cell setRecentsAutosaveName: @"aNameNothingIsSavedUnder"];
    [[cell recentSearches] count];   // 0, AppKit says 2

Checked on a macOS runner: setting the name after the searches leaves them at
2, and setting a name that does have searches saved under it still loads them.

Nothing saved under a name says nothing about the searches the cell has, so
the load only happens when there is something to load. The test covers both
ways round.

Without the change 1 of the test's assertions fails; with it the
NSSearchFieldCell tests pass 3/3.
