### PR TITLE
Fix: NSTextTableBlock takes the row and column as NSIntegers

### DIFF
--- a/Headers/AppKit/NSTextTable.h
+++ b/Headers/AppKit/NSTextTable.h
@@ -167,21 +167,21 @@ APPKIT_EXPORT_CLASS
 @interface NSTextTableBlock : NSTextBlock
 {
   NSTextTable *_table;
-  int _row;
-  int _rowSpan;
-  int _col;
-  int _colSpan;
+  NSInteger _row;
+  NSInteger _rowSpan;
+  NSInteger _col;
+  NSInteger _colSpan;
 }
 
 - (id) initWithTable: (NSTextTable *)table
-         startingRow: (int)row
-             rowSpan: (int)rspan
-      startingColumn: (int)col
-          columnSpan: (int)cspan;
-- (int) columnSpan;
-- (int) rowSpan;
-- (int) startingColumn;
-- (int) startingRow;
+         startingRow: (NSInteger)row
+             rowSpan: (NSInteger)rspan
+      startingColumn: (NSInteger)col
+          columnSpan: (NSInteger)cspan;
+- (NSInteger) columnSpan;
+- (NSInteger) rowSpan;
+- (NSInteger) startingColumn;
+- (NSInteger) startingRow;
 - (NSTextTable *) table;
 
 @end

--- a/Source/NSTextTableBlock.m
+++ b/Source/NSTextTableBlock.m
@@ -34,10 +34,10 @@
 @implementation NSTextTableBlock
 
 - (id) initWithTable: (NSTextTable *)table
-         startingRow: (int)row
-             rowSpan: (int)rspan
-      startingColumn: (int)col
-          columnSpan: (int)cspan;
+         startingRow: (NSInteger)row
+             rowSpan: (NSInteger)rspan
+      startingColumn: (NSInteger)col
+          columnSpan: (NSInteger)cspan;
 {
   self = [super init];
   if (self == nil)
@@ -58,22 +58,22 @@
   [super dealloc];
 }
 
-- (int) columnSpan
+- (NSInteger) columnSpan
 {
   return _colSpan;
 }
 
-- (int) rowSpan
+- (NSInteger) rowSpan
 {
   return _rowSpan;
 }
 
-- (int) startingColumn
+- (NSInteger) startingColumn
 {
   return _col;
 }
 
-- (int) startingRow
+- (NSInteger) startingRow
 {
   return _row;
 }

--- a/Tests/gui/NSTextTableBlock/integerTypes.m
+++ b/Tests/gui/NSTextTableBlock/integerTypes.m
@@ -1,0 +1,109 @@
+/* The row and column a block covers are NSIntegers, as they are in AppKit, so
+ * that code written against AppKit's declarations calls these methods with the
+ * arguments they expect.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTextTable.h>
+
+#include <objc/runtime.h>
+
+static BOOL
+returnsNSInteger(const char *name)
+{
+  SEL		sel;
+  Method	method;
+  char		*type;
+  BOOL		result;
+
+  sel = NSSelectorFromString([NSString stringWithUTF8String: name]);
+  method = class_getInstanceMethod([NSTextTableBlock class], sel);
+  if (method == NULL)
+    {
+      return NO;
+    }
+  type = method_copyReturnType(method);
+  result = (strcmp(type, @encode(NSInteger)) == 0);
+  free(type);
+  return result;
+}
+
+static BOOL
+takesNSIntegerAt(const char *name, unsigned index)
+{
+  SEL		sel;
+  Method	method;
+  char		*type;
+  BOOL		result;
+
+  sel = NSSelectorFromString([NSString stringWithUTF8String: name]);
+  method = class_getInstanceMethod([NSTextTableBlock class], sel);
+  if (method == NULL)
+    {
+      return NO;
+    }
+  type = method_copyArgumentType(method, index);
+  result = (strcmp(type, @encode(NSInteger)) == 0);
+  free(type);
+  return result;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("the row and column types")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  {
+    const char	*initName;
+    NSTextTable		*table;
+    NSTextTableBlock	*block;
+
+    PASS(returnsNSInteger("startingRow") == YES,
+      "startingRow answers an NSInteger");
+    PASS(returnsNSInteger("rowSpan") == YES, "rowSpan answers an NSInteger");
+    PASS(returnsNSInteger("startingColumn") == YES,
+      "startingColumn answers an NSInteger");
+    PASS(returnsNSInteger("columnSpan") == YES,
+      "columnSpan answers an NSInteger");
+
+    /* arguments 0 and 1 are self and _cmd, so the table is 2 and the row is 3 */
+    initName = "initWithTable:startingRow:rowSpan:startingColumn:columnSpan:";
+    PASS(takesNSIntegerAt(initName, 3) == YES,
+      "the initialiser takes the starting row as an NSInteger");
+    PASS(takesNSIntegerAt(initName, 4) == YES,
+      "the initialiser takes the row span as an NSInteger");
+    PASS(takesNSIntegerAt(initName, 5) == YES,
+      "the initialiser takes the starting column as an NSInteger");
+    PASS(takesNSIntegerAt(initName, 6) == YES,
+      "the initialiser takes the column span as an NSInteger");
+
+    /* and the values still read back */
+    table = AUTORELEASE([[NSTextTable alloc] init]);
+    block = AUTORELEASE([[NSTextTableBlock alloc] initWithTable: table
+                                                   startingRow: 1
+                                                       rowSpan: 2
+                                                startingColumn: 3
+                                                    columnSpan: 4]);
+    PASS([block startingRow] == 1 && [block rowSpan] == 2
+      && [block startingColumn] == 3 && [block columnSpan] == 4,
+      "the row and column a block covers still read back");
+  }
+
+  END_SET("the row and column types")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSTextTableBlock declares the row and column a block covers as int, where
AppKit declares them NSInteger. Read off the runtime on a macOS runner against
the same read here:

    startingRow      AppKit q16@0:8      here i16@0:8
    rowSpan          AppKit q16@0:8      here i16@0:8
    startingColumn   AppKit q16@0:8      here i16@0:8
    columnSpan       AppKit q16@0:8      here i16@0:8
    initWithTable:   AppKit @56@0:8@16q24q32q40q48
                     here   @40@0:8@16i24i28i32i36

q is NSInteger, i is int. The values and everything else about the class
already agree with AppKit (covered in #597); only the types they are declared
with differ. It matters for anything that reads the signatures rather than
calling through the header: an NSInvocation built for AppKit's initialiser
lays its arguments out at the offsets on the right.

The ivars are widened to match, so the class stays consistent with itself. That
does change the instance layout. Nothing in the library calls the initialiser or
the four getters, so nothing here has to change with it.

The test reads the types back off the runtime rather than trusting the header,
and checks the values still read back. Without the change 8 of its assertions
fail; with it the NSTextTableBlock tests pass 9/9. The coverage tests in #597
pass either way.
