### PR TITLE
Fix warnings. 

### DIFF
--- a/Headers/Additions/GNUstepGUI/GSFontAssetDownloader.h
+++ b/Headers/Additions/GNUstepGUI/GSFontAssetDownloader.h
@@ -137,6 +137,17 @@ GS_EXPORT_CLASS
  */
 - (instancetype) initWithOptions: (NSUInteger)options;
 
+/*
+ */
+- (BOOL) validateFontFile: (NSString *)fontPath
+		    error: (NSError **)error;
+
+/*
+ */
+- (BOOL) installFontAtPath: (NSString *)fontPath
+                     error: (NSError **)error;
+
+
 /**
  * Downloads and installs a font from the specified descriptor.
  * This is the main entry point for font downloading. The method

--- a/Source/GSFontAssetDownloader.m
+++ b/Source/GSFontAssetDownloader.m
@@ -255,7 +255,7 @@ static Class _defaultDownloaderClass = nil;
   // Clean up temporary download file
   if (downloadedPath != nil)
     {
-      [[NSFileManager defaultManager] removeItemAtPath: downloadedPath error: nil];
+      [[NSFileManager defaultManager] removeItemAtPath: downloadedPath error: NULL];
     }
 
   // Hide progress panel


### PR DESCRIPTION
Use NULL for NSError**; declare methods so types are known, else we get a warning about default id type and it is a size mismatch with BOOL.