### PR TITLE
tests: add NSView geometry and rendering tests

### DIFF
--- a/Tests/gui/NSView/geometry.m
+++ b/Tests/gui/NSView/geometry.m
@@ -1,0 +1,40 @@
+#import "Testing.h"
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSView.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSView geometry")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NSView *outer = AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+  NSView *inner = AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(50, 30, 100, 100)]);
+  [outer addSubview: inner];
+
+  /* A point in inner's coordinates, expressed in outer's coordinates, is
+     offset by inner's origin (both views unflipped). Values verified on
+     AppKit. */
+  NSPoint p = [inner convertPoint: NSMakePoint(10, 10) toView: outer];
+  PASS(NSEqualPoints(p, NSMakePoint(60, 40)),
+    "convertPoint:toView: offsets by the subview origin");
+
+  NSPoint back = [outer convertPoint: p toView: inner];
+  PASS(NSEqualPoints(back, NSMakePoint(10, 10)),
+    "convertPoint:toView: round-trips");
+
+  PASS([inner isFlipped] == NO, "a plain NSView is not flipped");
+
+  END_SET("NSView geometry")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSView/rendering.m
+++ b/Tests/gui/NSView/rendering.m
@@ -1,0 +1,58 @@
+#import "Testing.h"
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSBitmapImageRep.h>
+#import <AppKit/NSColor.h>
+#import <AppKit/NSGraphics.h>
+
+@interface Swatch : NSView
+@end
+@implementation Swatch
+- (void) drawRect: (NSRect)r
+{
+  [[NSColor redColor] set];
+  NSRectFill([self bounds]);
+}
+@end
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSView rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NSWindow *w = AUTORELEASE([[NSWindow alloc]
+    initWithContentRect: NSMakeRect(0, 0, 16, 16)
+              styleMask: NSWindowStyleMaskBorderless
+                backing: NSBackingStoreBuffered
+                  defer: NO]);
+  Swatch *v = AUTORELEASE([[Swatch alloc] initWithFrame: NSMakeRect(0, 0, 16, 16)]);
+  [w setContentView: v];
+
+  [v lockFocus];
+  [v drawRect: [v bounds]];
+  NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+    initWithFocusedViewRect: NSMakeRect(0, 0, 16, 16)]);
+  [v unlockFocus];
+
+  PASS(rep != nil && [rep pixelsWide] == 16 && [rep pixelsHigh] == 16,
+    "offscreen render produced a 16x16 bitmap");
+
+  NSColor *c = [[rep colorAtX: 8 y: 8]
+    colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+  PASS(c != nil && [c redComponent] > 0.9
+    && [c greenComponent] < 0.1 && [c blueComponent] < 0.1,
+    "centre pixel of a red-fill view is red");
+
+  END_SET("NSView rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSView/rendering.m
+++ b/Tests/gui/NSView/rendering.m
@@ -29,23 +29,36 @@ int main(int argc, const char **argv)
       SKIP("It looks like GNUstep backend is not yet installed")
   NS_ENDHANDLER
 
-  NSWindow *w = AUTORELEASE([[NSWindow alloc]
-    initWithContentRect: NSMakeRect(0, 0, 16, 16)
-              styleMask: NSWindowStyleMaskBorderless
-                backing: NSBackingStoreBuffered
-                  defer: NO]);
-  Swatch *v = AUTORELEASE([[Swatch alloc] initWithFrame: NSMakeRect(0, 0, 16, 16)]);
-  [w setContentView: v];
+  NSBitmapImageRep *rep = nil;
 
-  [v lockFocus];
-  [v drawRect: [v bounds]];
-  NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
-    initWithFocusedViewRect: NSMakeRect(0, 0, 16, 16)]);
-  [v unlockFocus];
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 16, 16)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      Swatch *v = AUTORELEASE([[Swatch alloc] initWithFrame: NSMakeRect(0, 0, 16, 16)]);
+      [w setContentView: v];
+
+      [v lockFocus];
+      [v drawRect: [v bounds]];
+      rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 16, 16)]);
+      [v unlockFocus];
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available to render into")
+  NS_ENDHANDLER
 
   PASS(rep != nil && [rep pixelsWide] == 16 && [rep pixelsHigh] == 16,
     "offscreen render produced a 16x16 bitmap");
 
+  /* NSBitmapImageRep pixel coordinates originate at the top-left, unlike
+     the view's bottom-left, so a replicator reading a non-uniform render
+     must flip y to land on the same point as the view-space rect above. */
   NSColor *c = [[rep colorAtX: 8 y: 8]
     colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
   PASS(c != nil && [c redComponent] > 0.9


### PR DESCRIPTION
Adds tests for NSView.

geometry.m checks -convertPoint:toView: between a view and a subview: a point in
the subview's coordinates is offset by the subview's origin, and the conversion
round-trips. It also checks that a plain NSView is not flipped. The views are
built without a window, so the test needs no display.

rendering.m checks that -drawRect: reaches the drawing surface: it fills a view
with red, captures the focused view rect into an NSBitmapImageRep, and reads the
centre pixel back as red. It skips when no display is available.

Both use the existing backend skip guard, so they skip when no backend is
installed and run otherwise.
