### PR TITLE
Fix: NSDataLink -writeToPasteboard: declares its pasteboard type

### DIFF
--- a/Source/NSDataLink.m
+++ b/Source/NSDataLink.m
@@ -182,6 +182,7 @@
 - (void)writeToPasteboard:(NSPasteboard *)pasteboard
 {
   NSData *data = [NSArchiver archivedDataWithRootObject: self];
+  [pasteboard declareTypes: [NSArray arrayWithObject: NSDataLinkPboardType] owner: nil];
   [pasteboard setData: data forType: NSDataLinkPboardType];
 }
 


### PR DESCRIPTION
-[NSDataLink writeToPasteboard:] called setData:forType: without first declaring
the type with declareTypes:owner:, so the pasteboard dropped the data and a
later -initWithPasteboard: read back nil. It now declares the type before
writing the data. gui/NSDataLink/basic.m exercises the pasteboard round trip.
