### PR TITLE
Fix: NSPathControl default allowedTypes is nil

### DIFF
--- a/Source/NSPathControl.m
+++ b/Source/NSPathControl.m
@@ -87,7 +87,6 @@ static Class pathCellClass;
       [self setPathStyle: NSPathStyleStandard];
       [self setURL: nil];
       [self setDelegate: nil];
-      [self setAllowedTypes: [NSArray arrayWithObject: NSFilenamesPboardType]];
       _editable = YES;
     }
   return self;


### PR DESCRIPTION
-[NSPathControl initWithFrame:] set a non-nil default for allowedTypes. AppKit
and NSPathCell leave it nil. This removes the seed, so a newly created
NSPathControl reports nil allowedTypes. gui/NSPathControl/basic.m checks the
default.
