### PR TITLE
tests: fix over-release in NSFormCell and NSTextFieldCell tests

### DIFF
--- a/Tests/gui/NSFormCell/title.m
+++ b/Tests/gui/NSFormCell/title.m
@@ -97,7 +97,6 @@ int main()
          "placeholderAttributedString returns the attributed placeholder");
     pass([cell placeholderString] == nil,
          "placeholderString is nil for an attributed placeholder");
-    RELEASE(attr);
   }
 
   END_SET("NSFormCell title")

--- a/Tests/gui/NSTextFieldCell/attributes.m
+++ b/Tests/gui/NSTextFieldCell/attributes.m
@@ -66,7 +66,6 @@ main(int argc, char **argv)
          "placeholderAttributedString returns the attributed placeholder");
     pass([cell placeholderString] == nil,
          "placeholderString is nil for an attributed placeholder");
-    RELEASE(attr);
   }
 
   /* The real string value is stored. */


### PR DESCRIPTION
Both tests created an autoreleased NSAttributedString and then sent it an extra
release. The cell keeps its own copy, so the extra release over-freed the
string and the test aborted when run against a backend. Removing the extra
release fixes the abort.
