### PR TITLE
ci: run the gui tests headless against a cairo backend

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,9 +141,9 @@ jobs:
             ${{ env.SRC_PATH }}/config.log
             ${{ env.SRC_PATH }}/Tests/tests.log
 
-  ########### Linux (headless, cairo backend) ###########
+  ########### Linux (cairo backend, virtual display) ###########
   linux-headless:
-    name: Ubuntu x64 Clang gnustep-2.0 (headless, cairo backend)
+    name: Ubuntu x64 Clang gnustep-2.0 (cairo backend, Xvfb)
     runs-on: ubuntu-latest
     # don't run pull requests from local branches twice
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
@@ -170,9 +170,12 @@ jobs:
         run: |
           sudo apt-get -q -y update
           # libs-back builds an x11 server layer even for the cairo graphics
-          # backend, so the X development libraries are required to build it
+          # backend, so the X development libraries are required to build it.
+          # xvfb provides a virtual display so the gui tests that reach the
+          # window server can run on a runner with no physical display.
           sudo apt-get -q -y install $APT_PACKAGES $APT_PACKAGES_clang \
-            libxt-dev libxmu-dev libxft-dev libxrandr-dev libxfixes-dev libxcursor-dev
+            libxt-dev libxmu-dev libxft-dev libxrandr-dev libxfixes-dev libxcursor-dev \
+            xvfb
 
           # gnustep-2.0 runtime requires ld.gold or lld
           sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 10
@@ -203,7 +206,7 @@ jobs:
       - name: Run tests
         run: |
           . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
-          env -u DISPLAY -u WAYLAND_DISPLAY make check
+          xvfb-run -a make check
 
       - name: Upload logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,10 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get -q -y update
-          sudo apt-get -q -y install $APT_PACKAGES $APT_PACKAGES_clang
+          # libs-back builds an x11 server layer even for the cairo graphics
+          # backend, so the X development libraries are required to build it
+          sudo apt-get -q -y install $APT_PACKAGES $APT_PACKAGES_clang \
+            libxt-dev libxmu-dev libxft-dev libxrandr-dev libxfixes-dev libxcursor-dev
 
           # gnustep-2.0 runtime requires ld.gold or lld
           sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 10
@@ -194,13 +197,13 @@ jobs:
           . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
           git clone -q -b ${LIBS_BACK_BRANCH:-master} https://github.com/gnustep/libs-back.git
           cd libs-back
-          ./configure
+          ./configure --enable-graphics=cairo
           make && make install
 
       - name: Run tests
         run: |
           . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
-          make check
+          env -u DISPLAY -u WAYLAND_DISPLAY make check
 
       - name: Upload logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,3 +140,73 @@ jobs:
           path: |
             ${{ env.SRC_PATH }}/config.log
             ${{ env.SRC_PATH }}/Tests/tests.log
+
+  ########### Linux (headless, cairo backend) ###########
+  linux-headless:
+    name: Ubuntu x64 Clang gnustep-2.0 (headless, cairo backend)
+    runs-on: ubuntu-latest
+    # don't run pull requests from local branches twice
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+
+    env:
+      SRC_PATH: ${{ github.workspace }}/source
+      DEPS_PATH: ${{ github.workspace }}/dependencies
+      INSTALL_PATH: ${{ github.workspace }}/build
+      CC: clang
+      CXX: clang++
+      LIBRARY_COMBO: ng-gnu-gnu
+      RUNTIME_VERSION: gnustep-2.0
+
+    defaults:
+      run:
+        working-directory: ${{ env.SRC_PATH }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ env.SRC_PATH }}
+
+      - name: Install packages
+        run: |
+          sudo apt-get -q -y update
+          sudo apt-get -q -y install $APT_PACKAGES $APT_PACKAGES_clang
+
+          # gnustep-2.0 runtime requires ld.gold or lld
+          sudo update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 10
+
+      - name: Install dependencies
+        env:
+          TOOLS_MAKE_BRANCH: ${{github.event.inputs.tools_make_branch}}
+          LIBS_BASE_BRANCH: ${{github.event.inputs.libs_base_branch}}
+        run: ./.github/scripts/dependencies.sh
+
+      - name: Build source
+        run: |
+          . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
+          ./configure
+          make && make install
+
+      - name: Build libs-back # cairo backend, required to run the gui tests instead of skipping them
+        working-directory: ${{env.DEPS_PATH}}
+        env:
+          LIBS_BACK_BRANCH: ${{github.event.inputs.libs_back_branch}}
+        run: |
+          . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
+          git clone -q -b ${LIBS_BACK_BRANCH:-master} https://github.com/gnustep/libs-back.git
+          cd libs-back
+          ./configure
+          make && make install
+
+      - name: Run tests
+        run: |
+          . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
+          make check
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: Logs - Ubuntu x64 Clang gnustep-2.0 (headless)
+          path: |
+            ${{ env.SRC_PATH }}/config.log
+            ${{ env.SRC_PATH }}/Tests/tests.log


### PR DESCRIPTION
Closes #602 

This adds a Linux CI job that installs a cairo backend (gnustep/libs-back) and
runs the gui tests under xvfb, so the tests that need a backend run instead of
skipping. It addresses #602. On the runner it reports 2481 passed and 0 skipped
where the same tests skip today.

The job exposes four pre-existing failures, fixed in #604, #605 and #606. Once
those merge the job runs green; it needs a rebase onto master after they land.
