### PR TITLE
Fix: NSView convertRect:toView: ignores the view hierarchy without a window

### DIFF
--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -1811,7 +1811,7 @@ convert_rect_using_matrices(NSRect aRect, NSAffineTransform *matrix1,
 {
   NSAffineTransform *matrix1, *matrix2;
 
-  if (aView == self || _window == nil || (aView != nil && [aView window] == nil))
+  if (aView == self)
     {
       return aRect;
     }
@@ -1843,7 +1843,7 @@ convert_rect_using_matrices(NSRect aRect, NSAffineTransform *matrix1,
 {
   NSAffineTransform *matrix1, *matrix2;
 
-  if (aView == self || _window == nil || (aView != nil && [aView window] == nil))
+  if (aView == self)
     {
       return aRect;
     }

--- a/Tests/gui/NSView/convertRectNoWindow.m
+++ b/Tests/gui/NSView/convertRectNoWindow.m
@@ -1,0 +1,69 @@
+#include "Testing.h"
+
+#include <math.h>
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSView.h>
+
+/* checked against AppKit: a windowless convertRect:toView:/fromView:
+   must apply the view hierarchy transform, the same as convertPoint:
+   does, instead of returning the rect unchanged. */
+
+int main(int argc, char **argv)
+{
+	CREATE_AUTORELEASE_POOL(arp);
+
+	NSView *outer;
+	NSView *inner;
+	NSRect r;
+	int passed;
+
+	START_SET("NSView GNUstep convertRectNoWindow")
+
+	NS_DURING
+	{
+		[NSApplication sharedApplication];
+	}
+	NS_HANDLER
+	{
+	if ([[localException name] isEqualToString: NSInternalInconsistencyException ])
+		SKIP("It looks like GNUstep backend is not yet installed")
+	}
+	NS_ENDHANDLER
+
+	outer = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0,0,200,200)]);
+	inner = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(50,30,100,100)]);
+	[outer addSubview: inner];
+
+	passed = 1;
+
+	r = [inner convertRect: NSMakeRect(10,10,20,20) toView: outer];
+	if (fabs(r.origin.x - 60.0) > 0.001
+	 || fabs(r.origin.y - 40.0) > 0.001
+	 || fabs(r.size.width - 20.0) > 0.001
+	 || fabs(r.size.height - 20.0) > 0.001)
+	{
+		passed = 0;
+		printf("expected (60 40)+(20 20), got (%g %g)+(%g %g)\n",
+			r.origin.x, r.origin.y, r.size.width, r.size.height);
+	}
+
+	r = [outer convertRect: NSMakeRect(10,10,20,20) fromView: inner];
+	if (fabs(r.origin.x - 60.0) > 0.001
+	 || fabs(r.origin.y - 40.0) > 0.001
+	 || fabs(r.size.width - 20.0) > 0.001
+	 || fabs(r.size.height - 20.0) > 0.001)
+	{
+		passed = 0;
+		printf("expected (60 40)+(20 20), got (%g %g)+(%g %g)\n",
+			r.origin.x, r.origin.y, r.size.width, r.size.height);
+	}
+
+	pass(passed, "NSView -convertRect:toView:/-convertRect:fromView: apply the hierarchy transform without a window");
+
+	END_SET("NSView GNUstep convertRectNoWindow")
+
+	DESTROY(arp);
+	return 0;
+}


### PR DESCRIPTION
-[NSView convertRect:toView:] and convertRect:fromView: returned the rect
unchanged when the view had no window, while convertPoint: applies the hierarchy
transform in the same case. AppKit transforms the rect. This removes the
no-window short-circuit so convertRect matches convertPoint and AppKit.
gui/NSView/convertRectNoWindow.m fails before and passes after.
