### PR TITLE
Fix: NSAffineTransform rotationAngle keeps the sign of a negative rotation

### DIFF
--- a/Source/NSAffineTransform.m
+++ b/Source/NSAffineTransform.m
@@ -165,8 +165,6 @@ static const CGFloat pi = 3.1415926535897932384626434;
   CGFloat rotationAngle = atan2(-C, A);
 
   rotationAngle *= 180.0 / pi;
-  if (rotationAngle < 0.0)
-    rotationAngle += 360.0;
 
   return rotationAngle;
 }

--- a/Tests/gui/NSView/frameRotationSign.m
+++ b/Tests/gui/NSView/frameRotationSign.m
@@ -1,0 +1,57 @@
+#include "Testing.h"
+
+#include <math.h>
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSView.h>
+
+/* checked against AppKit: frameRotation keeps the sign of a negative
+   rotation and reads back a full turn as ~0, instead of normalizing
+   into [0, 360). */
+
+int main(int argc, char **argv)
+{
+	CREATE_AUTORELEASE_POOL(arp);
+
+	NSView *view;
+	int passed;
+
+	START_SET("NSView GNUstep frameRotationSign")
+
+	NS_DURING
+	{
+		[NSApplication sharedApplication];
+	}
+	NS_HANDLER
+	{
+	if ([[localException name] isEqualToString: NSInternalInconsistencyException ])
+		SKIP("It looks like GNUstep backend is not yet installed")
+	}
+	NS_ENDHANDLER
+
+	view = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0,0,100,100)]);
+
+	passed = 1;
+
+	[view setFrameRotation: -45.0];
+	if (fabs([view frameRotation] - (-45.0)) > 0.0001)
+	{
+		passed = 0;
+		printf("expected frameRotation -45, got %g\n", [view frameRotation]);
+	}
+
+	[view setFrameRotation: 360.0];
+	if (fabs([view frameRotation]) > 0.0001)
+	{
+		passed = 0;
+		printf("expected frameRotation ~0, got %g\n", [view frameRotation]);
+	}
+
+	pass(passed, "NSView -frameRotation keeps the sign of a negative rotation");
+
+	END_SET("NSView GNUstep frameRotationSign")
+
+	DESTROY(arp);
+	return 0;
+}


### PR DESCRIPTION
-[NSAffineTransform rotationAngle] added 360 to a negative angle, so a view set
to frameRotation -45 read back 315. AppKit keeps the equivalent angle in
(-180,180]. This drops the normalization. gui/NSView/frameRotationSign.m fails
before and passes after; the NSAffineTransform and NSView_frame_rotation tests
still pass.
