### PR TITLE
tests: add NSWindow tests

### DIFF
--- a/Tests/gui/NSWindow/behaviour.m
+++ b/Tests/gui/NSWindow/behaviour.m
@@ -1,0 +1,54 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSText.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSWindow behaviour")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 120, 120)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+
+      /* First responder, field editor and content view. Checked against
+         AppKit. */
+      PASS([w firstResponder] == w,
+        "a new window is its own first responder");
+
+      NSText *fe = [w fieldEditor: YES forObject: nil];
+      PASS(fe != nil && [fe isKindOfClass: [NSText class]],
+        "fieldEditor:forObject: returns an NSText");
+
+      NSView *cv = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 80, 80)]);
+      [w setContentView: cv];
+      PASS([w contentView] == cv, "setContentView: sets the content view");
+      PASS([cv window] == w, "a content view reports its window");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSWindow behaviour")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSWindow/frameContent.m
+++ b/Tests/gui/NSWindow/frameContent.m
@@ -1,0 +1,58 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSWindow frame and content")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSRect fr = NSMakeRect(10, 20, 200, 150);
+
+      /* A borderless window has no decoration, so content and frame rects are
+         equal. Checked against AppKit. */
+      PASS(NSEqualRects([NSWindow contentRectForFrameRect: fr
+                                              styleMask: NSWindowStyleMaskBorderless], fr),
+        "+contentRectForFrameRect:styleMask: is identity for a borderless window");
+      PASS(NSEqualRects([NSWindow frameRectForContentRect: fr
+                                              styleMask: NSWindowStyleMaskBorderless], fr),
+        "+frameRectForContentRect:styleMask: is identity for a borderless window");
+
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 200, 150)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      PASS(NSEqualRects([w frame], NSMakeRect(0, 0, 200, 150)),
+        "a borderless window frame equals its content rect");
+      PASS(NSEqualRects([w contentRectForFrameRect: fr], fr),
+        "-contentRectForFrameRect: is identity for a borderless window");
+      PASS(NSEqualRects([w frameRectForContentRect: fr], fr),
+        "-frameRectForContentRect: is identity for a borderless window");
+
+      [w setContentSize: NSMakeSize(300, 250)];
+      PASS(NSEqualSizes([w frame].size, NSMakeSize(300, 250)),
+        "setContentSize: sets the frame size of a borderless window");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSWindow frame and content")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSWindow/screen.m
+++ b/Tests/gui/NSWindow/screen.m
@@ -1,0 +1,45 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSWindow screen conversion")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 200, 150)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+
+      /* Converting a rect to screen coordinates and back is the identity,
+         independent of where the window sits on screen. Checked against
+         AppKit. */
+      NSRect r = NSMakeRect(5, 5, 20, 20);
+      NSRect onScreen = [w convertRectToScreen: r];
+      PASS(NSEqualRects([w convertRectFromScreen: onScreen], r),
+        "convertRectToScreen: then convertRectFromScreen: round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSWindow screen conversion")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSWindow/sizing.m
+++ b/Tests/gui/NSWindow/sizing.m
@@ -1,0 +1,62 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSWindow sizing")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 200, 150)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+
+      /* Sizing constraints round-trip. Checked against AppKit. */
+      [w setMinSize: NSMakeSize(120, 90)];
+      PASS(NSEqualSizes([w minSize], NSMakeSize(120, 90)), "setMinSize: round-trips");
+
+      [w setMaxSize: NSMakeSize(800, 600)];
+      PASS(NSEqualSizes([w maxSize], NSMakeSize(800, 600)), "setMaxSize: round-trips");
+
+      [w setResizeIncrements: NSMakeSize(10, 5)];
+      PASS(NSEqualSizes([w resizeIncrements], NSMakeSize(10, 5)),
+        "setResizeIncrements: round-trips");
+
+      [w setContentMinSize: NSMakeSize(100, 80)];
+      PASS(NSEqualSizes([w contentMinSize], NSMakeSize(100, 80)),
+        "setContentMinSize: round-trips");
+
+      [w setContentMaxSize: NSMakeSize(700, 500)];
+      PASS(NSEqualSizes([w contentMaxSize], NSMakeSize(700, 500)),
+        "setContentMaxSize: round-trips");
+
+      [w setLevel: 5];
+      PASS([w level] == 5, "setLevel: round-trips");
+
+      PASS([w styleMask] == NSWindowStyleMaskBorderless,
+        "a borderless window reports the borderless style mask");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSWindow sizing")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSWindow/windowRender.m
+++ b/Tests/gui/NSWindow/windowRender.m
@@ -1,0 +1,68 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSColor.h>
+#import <AppKit/NSGraphics.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+@interface RedContent : NSView
+@end
+@implementation RedContent
+- (void) drawRect: (NSRect)r
+{
+  [[NSColor redColor] set];
+  NSRectFill([self bounds]);
+}
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSWindow content rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 16, 16)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      RedContent *v = AUTORELEASE([[RedContent alloc]
+        initWithFrame: NSMakeRect(0, 0, 16, 16)]);
+      [w setContentView: v];
+
+      /* The window's content view renders through the offscreen path (a
+         regression lock, not a pixel comparison against AppKit). */
+      [v lockFocus];
+      [v drawRect: [v bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 16, 16)]);
+      [v unlockFocus];
+
+      NSColor *c = [[rep colorAtX: 8 y: 8]
+        colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+      PASS(c != nil && [c redComponent] > 0.9
+        && [c greenComponent] < 0.1 && [c blueComponent] < 0.1,
+        "the window content view renders red at its centre");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSWindow content rendering")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for NSWindow geometry.

frameContent.m checks a borderless window's content and frame rects: the class
and instance contentRectForFrameRect:/frameRectForContentRect: are the identity
for a borderless window (no decoration), a borderless window's frame equals its
content rect, and setContentSize: sets the frame size.

sizing.m checks that the sizing constraints round-trip: minSize, maxSize,
contentMinSize, contentMaxSize, resizeIncrements, level, and the borderless
style mask.

screen.m checks that converting a rect to screen coordinates and back is the
identity.

The tests create a window, so they carry the backend skip guard and skip
cleanly where no display is available.
