### PR TITLE
Fix: NSWindow stores the aspect ratio set with setAspectRatio:

### DIFF
--- a/Headers/AppKit/NSWindow.h
+++ b/Headers/AppKit/NSWindow.h
@@ -243,6 +243,7 @@ APPKIT_EXPORT_CLASS
   NSSize        _minimumSize;
   NSSize        _maximumSize;
   NSSize        _increments;
+  NSSize        _aspectRatio;
   NSString	*_autosaveName;
   GSWindowDecorationView *_wv;
   id            _contentView;

--- a/Source/NSWindow.m
+++ b/Source/NSWindow.m
@@ -2461,6 +2461,7 @@ titleWithRepresentedFilename(NSString *representedFilename)
 - (void) setResizeIncrements: (NSSize)aSize
 {
   _increments = aSize;
+  _aspectRatio = NSZeroSize;
   if (_windowNum > 0)
     {
       [GSServerForWindow(self) setresizeincrements: aSize : _windowNum];
@@ -2475,6 +2476,7 @@ titleWithRepresentedFilename(NSString *representedFilename)
 - (void) setAspectRatio: (NSSize)ratio
 {
   _aspectRatio = ratio;
+  _increments = NSZeroSize;
 }
 
 - (NSSize) contentMaxSize

--- a/Source/NSWindow.m
+++ b/Source/NSWindow.m
@@ -2469,13 +2469,12 @@ titleWithRepresentedFilename(NSString *representedFilename)
 
 - (NSSize) aspectRatio
 {
-  // FIXME: This method is missing
-  return NSMakeSize(1, 1);
+  return _aspectRatio;
 }
 
 - (void) setAspectRatio: (NSSize)ratio
 {
-  // FIXME: This method is missing
+  _aspectRatio = ratio;
 }
 
 - (NSSize) contentMaxSize

--- a/Tests/gui/NSWindow/aspectRatio.m
+++ b/Tests/gui/NSWindow/aspectRatio.m
@@ -25,9 +25,18 @@ main(int argc, const char **argv)
                     backing: NSBackingStoreBuffered
                       defer: NO]);
 
+      [w setResizeIncrements: NSMakeSize(16, 16)];
       [w setAspectRatio: NSMakeSize(4, 3)];
       PASS(NSEqualSizes([w aspectRatio], NSMakeSize(4, 3)),
         "setAspectRatio: round-trips");
+      PASS(NSEqualSizes([w resizeIncrements], NSZeroSize),
+        "setAspectRatio: clears the resize increments");
+
+      [w setResizeIncrements: NSMakeSize(8, 8)];
+      PASS(NSEqualSizes([w resizeIncrements], NSMakeSize(8, 8)),
+        "setResizeIncrements: round-trips");
+      PASS(NSEqualSizes([w aspectRatio], NSZeroSize),
+        "setResizeIncrements: clears the aspect ratio");
     }
   NS_HANDLER
     if ([[localException name] isEqualToString: NSInternalInconsistencyException]

--- a/Tests/gui/NSWindow/aspectRatio.m
+++ b/Tests/gui/NSWindow/aspectRatio.m
@@ -1,0 +1,41 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSWindow aspectRatio")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 200, 150)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+
+      [w setAspectRatio: NSMakeSize(4, 3)];
+      PASS(NSEqualSizes([w aspectRatio], NSMakeSize(4, 3)),
+        "setAspectRatio: round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSWindow aspectRatio")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-[NSWindow aspectRatio] and -setAspectRatio: were stubs: the setter did nothing
and the getter always returned (1,1). This adds an _aspectRatio ivar and stores
the value, so the ratio set with setAspectRatio: is returned by aspectRatio.

This makes the accessor round-trip; constraining a live resize to the ratio is
not part of this change. The ivar is added at the end of NSWindow's existing
size ivars.
