### PR TITLE
Fix: NSWindow cascadeTopLeftFromPoint: offsets down and to the right

### DIFF
--- a/Source/NSWindow.m
+++ b/Source/NSWindow.m
@@ -2075,7 +2075,7 @@ titleWithRepresentedFilename(NSString *representedFilename)
 
 - (NSPoint) cascadeTopLeftFromPoint: (NSPoint)topLeftPoint
 {
-  NSRect cRect;
+  CGFloat delta;
 
   if (NSEqualPoints(topLeftPoint, NSZeroPoint) == YES)
     {
@@ -2084,9 +2084,13 @@ titleWithRepresentedFilename(NSString *representedFilename)
     }
 
   [self setFrameTopLeftPoint: topLeftPoint];
-  cRect = [self contentRectForFrameRect: _frame];
-  topLeftPoint.x = NSMinX(cRect);
-  topLeftPoint.y = NSMaxY(cRect);
+
+  /* The next window in a cascade is offset down and to the right by the
+     height of a standard title bar. */
+  delta = [NSWindow frameRectForContentRect: NSMakeRect(0, 0, 100, 100)
+                                  styleMask: NSTitledWindowMask].size.height - 100.0;
+  topLeftPoint.x += delta;
+  topLeftPoint.y -= delta;
 
   /* make sure the new point is inside the screen */
   if ([self screen])

--- a/Tests/gui/NSWindow/cascade.m
+++ b/Tests/gui/NSWindow/cascade.m
@@ -1,0 +1,47 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSWindow cascade")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 100, 100)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+
+      /* A cascade offsets the next window down and to the right; the offset
+         magnitude is a system metric and is not asserted. */
+      NSPoint p1 = [w cascadeTopLeftFromPoint: NSMakePoint(50, 300)];
+      PASS(p1.x > 50 && p1.y < 300,
+        "cascadeTopLeftFromPoint: cascades down and to the right");
+
+      NSPoint p2 = [w cascadeTopLeftFromPoint: p1];
+      PASS(p2.x > p1.x && p2.y < p1.y,
+        "cascadeTopLeftFromPoint: advances the cascade on each call");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSWindow cascade")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-[NSWindow cascadeTopLeftFromPoint:] returned the positioned window's content
top-left with no cascade offset, so successive windows did not advance (and a
borderless window, having no title bar, did not move at all). This offsets the
returned point down and to the right by the height of a standard title bar, so
the cascade advances on each call as AppKit's does. The magnitude is a system
metric, not a fixed value.
