### PR TITLE
tests: add NSControl tests

### DIFF
--- a/Tests/gui/NSControl/rendering.m
+++ b/Tests/gui/NSControl/rendering.m
@@ -1,0 +1,56 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSControl.h>
+#import <AppKit/NSActionCell.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSControl rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 60, 24)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSControl *c = AUTORELEASE([[NSControl alloc]
+        initWithFrame: NSMakeRect(0, 0, 60, 24)]);
+      [c setCell: AUTORELEASE([[NSActionCell alloc] initTextCell: @"x"])];
+      [w setContentView: c];
+
+      /* The control draws through its cell without error and produces a
+         bitmap of its own size (a render regression lock, not a pixel
+         comparison against AppKit). */
+      [c lockFocus];
+      [c drawRect: [c bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 60, 24)]);
+      [c unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 60 && [rep pixelsHigh] == 24,
+        "a control renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSControl rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSControl/sendAction.m
+++ b/Tests/gui/NSControl/sendAction.m
@@ -1,0 +1,59 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <Foundation/NSObject.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSControl.h>
+#import <AppKit/NSActionCell.h>
+
+@interface Recorder : NSObject
+{
+@public
+  BOOL got;
+}
+@end
+@implementation Recorder
+- (void) recorded: (id)sender { got = YES; }
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSControl sendAction")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSControl *c = AUTORELEASE([[NSControl alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 20)]);
+      [c setCell: AUTORELEASE([[NSActionCell alloc] initTextCell: @""])];
+
+      Recorder *r = AUTORELEASE([Recorder new]);
+      [c setTarget: r];
+      [c setAction: @selector(recorded:)];
+
+      /* sendAction:to: dispatches the action to the target. Checked against
+         AppKit. */
+      BOOL sent = [c sendAction: [c action] to: [c target]];
+      PASS(sent == YES,
+        "sendAction:to: reports success when the target handles the action");
+      PASS(r->got == YES,
+        "sendAction:to: invokes the action method on the target");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSControl sendAction")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSControl/state.m
+++ b/Tests/gui/NSControl/state.m
@@ -1,0 +1,66 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <Foundation/NSObject.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSControl.h>
+#import <AppKit/NSActionCell.h>
+#import <AppKit/NSText.h>
+
+@interface CtlTarget : NSObject
+@end
+@implementation CtlTarget
+- (void) act: (id)sender {}
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSControl state")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSControl *c = AUTORELEASE([[NSControl alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 20)]);
+      [c setCell: AUTORELEASE([[NSActionCell alloc] initTextCell: @""])];
+
+      /* Target, action and state round-trip. Checked against AppKit. */
+      CtlTarget *t = AUTORELEASE([CtlTarget new]);
+      [c setTarget: t];
+      PASS([c target] == t, "setTarget: round-trips");
+
+      [c setAction: @selector(act:)];
+      PASS([c action] == @selector(act:), "setAction: round-trips");
+
+      [c setEnabled: NO];
+      PASS([c isEnabled] == NO, "setEnabled:NO round-trips");
+      [c setEnabled: YES];
+      PASS([c isEnabled] == YES, "setEnabled:YES round-trips");
+
+      [c setTag: 7];
+      PASS([c tag] == 7, "setTag: round-trips");
+
+      [c setAlignment: NSTextAlignmentRight];
+      PASS([c alignment] == NSTextAlignmentRight, "setAlignment: round-trips");
+
+      [c setContinuous: YES];
+      PASS([c isContinuous] == YES, "setContinuous: round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSControl state")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSControl/value.m
+++ b/Tests/gui/NSControl/value.m
@@ -1,0 +1,69 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <Foundation/NSString.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSControl.h>
+#import <AppKit/NSActionCell.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSControl value")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSControl *c = AUTORELEASE([[NSControl alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 20)]);
+      [c setCell: AUTORELEASE([[NSActionCell alloc] initTextCell: @""])];
+
+      /* Value round-trips and cross-type conversions. Checked against AppKit. */
+      [c setStringValue: @"hello"];
+      PASS([[c stringValue] isEqualToString: @"hello"], "stringValue round-trips");
+
+      [c setIntValue: 42];
+      PASS([c intValue] == 42, "intValue round-trips");
+      PASS([[c stringValue] isEqualToString: @"42"], "an int value reads back as its decimal string");
+      PASS([c doubleValue] == 42.0, "an int value reads back as a double");
+
+      [c setDoubleValue: 3.5];
+      PASS([c doubleValue] == 3.5, "doubleValue round-trips");
+      PASS([c intValue] == 3, "intValue truncates 3.5 toward zero");
+      PASS([[c stringValue] isEqualToString: @"3.5"], "a double value reads back as its string");
+
+      [c setStringValue: @"3.5"];
+      PASS([c doubleValue] == 3.5, "a numeric string reads back as a double");
+      PASS([c intValue] == 3, "a numeric string reads back as a truncated int");
+
+      [c setStringValue: @"abc"];
+      PASS([c intValue] == 0, "a non-numeric string reads back as int 0");
+      PASS([c doubleValue] == 0.0, "a non-numeric string reads back as double 0");
+
+      [c setIntegerValue: 99];
+      PASS([c integerValue] == 99, "integerValue round-trips");
+
+      [c setFloatValue: 2.5f];
+      PASS([c floatValue] == 2.5f, "floatValue round-trips");
+
+      [c setObjectValue: @"obj"];
+      PASS([[c objectValue] isEqual: @"obj"], "objectValue round-trips");
+      PASS([[c stringValue] isEqualToString: @"obj"], "an object value reads back as its string");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSControl value")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for NSControl across three tiers.

value.m checks value round-trips and cross-type conversions: setting an int,
double, string, integer, float or object value and reading it back in another
type. A numeric string reads back as a number, intValue truncates toward zero,
and a non-numeric string reads back as zero.

state.m checks that target, action, enabled, tag, alignment and continuous
round-trip.

sendAction.m checks that sendAction:to: dispatches the action to the target.

rendering.m checks that a control renders into a bitmap of its bounds.

The control is backed by an NSActionCell and the tests carry the backend skip
guard, so they skip cleanly where no backend is installed.
