### PR TITLE
tests: add NSScrollView tests

### DIFF
--- a/Tests/gui/NSScrollView/geometry.m
+++ b/Tests/gui/NSScrollView/geometry.m
@@ -1,0 +1,54 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSScrollView.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSScrollView geometry")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSScrollView *sv = AUTORELEASE([[NSScrollView alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+      [sv setHasHorizontalScroller: NO];
+      [sv setHasVerticalScroller: NO];
+      [sv setBorderType: NSNoBorder];
+
+      /* With no scrollers and no border there is no decoration, so content
+         and frame sizes are equal. Checked against AppKit. */
+      PASS(NSEqualSizes([sv contentSize], NSMakeSize(100, 100)),
+        "contentSize with no scrollers or border equals the frame size");
+      PASS(NSEqualSizes([NSScrollView frameSizeForContentSize: NSMakeSize(80, 60)
+                                       hasHorizontalScroller: NO
+                                         hasVerticalScroller: NO
+                                                  borderType: NSNoBorder],
+                        NSMakeSize(80, 60)),
+        "frameSizeForContentSize: is identity without decoration");
+      PASS(NSEqualSizes([NSScrollView contentSizeForFrameSize: NSMakeSize(80, 60)
+                                       hasHorizontalScroller: NO
+                                         hasVerticalScroller: NO
+                                                  borderType: NSNoBorder],
+                        NSMakeSize(80, 60)),
+        "contentSizeForFrameSize: is identity without decoration");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSScrollView geometry")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSScrollView/rendering.m
+++ b/Tests/gui/NSScrollView/rendering.m
@@ -1,0 +1,65 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSScrollView.h>
+#import <AppKit/NSClipView.h>
+#import <AppKit/NSColor.h>
+#import <AppKit/NSGraphics.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSScrollView rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 16, 16)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSScrollView *sv = AUTORELEASE([[NSScrollView alloc]
+        initWithFrame: NSMakeRect(0, 0, 16, 16)]);
+      [sv setBorderType: NSNoBorder];
+      [w setContentView: sv];
+
+      /* The scroll view draws its background through its clip view (a
+         regression lock, not a pixel comparison against AppKit). */
+      NSClipView *clip = [sv contentView];
+      [clip setDrawsBackground: YES];
+      [clip setBackgroundColor: [NSColor redColor]];
+      NSRect b = [clip bounds];
+
+      [clip lockFocus];
+      [clip drawRect: b];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: b]);
+      [clip unlockFocus];
+
+      NSColor *c = [[rep colorAtX: [rep pixelsWide] / 2 y: [rep pixelsHigh] / 2]
+        colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+      PASS(c != nil && [c redComponent] > 0.9
+        && [c greenComponent] < 0.1 && [c blueComponent] < 0.1,
+        "a scroll view renders its background red");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSScrollView rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSScrollView/scroll.m
+++ b/Tests/gui/NSScrollView/scroll.m
@@ -1,0 +1,47 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSScrollView.h>
+#import <AppKit/NSView.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSScrollView scroll")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSScrollView *sv = AUTORELEASE([[NSScrollView alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+      [sv setHasHorizontalScroller: NO];
+      [sv setHasVerticalScroller: NO];
+      [sv setBorderType: NSNoBorder];
+      NSView *doc = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 500, 500)]);
+      [sv setDocumentView: doc];
+
+      /* Scrolling a 500x500 document in a 100x100 clip view to (300,300,50,50)
+         moves the visible rectangle. Checked against AppKit. */
+      [doc scrollRectToVisible: NSMakeRect(300, 300, 50, 50)];
+      PASS(NSEqualRects([sv documentVisibleRect], NSMakeRect(250, 250, 100, 100)),
+        "documentVisibleRect reflects a scroll");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSScrollView scroll")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSScrollView/structure.m
+++ b/Tests/gui/NSScrollView/structure.m
@@ -1,0 +1,59 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSScrollView.h>
+#import <AppKit/NSClipView.h>
+#import <AppKit/NSView.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSScrollView structure")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSScrollView *sv = AUTORELEASE([[NSScrollView alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+      NSView *doc = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 500, 500)]);
+      [sv setDocumentView: doc];
+
+      /* Document / clip-view structure. Checked against AppKit. */
+      PASS([sv documentView] == doc, "setDocumentView: round-trips");
+      PASS([[sv contentView] isKindOfClass: [NSClipView class]],
+        "contentView is an NSClipView");
+      PASS([doc superview] == [sv contentView],
+        "the document view's superview is the clip view");
+      PASS([doc enclosingScrollView] == sv,
+        "the document view's enclosingScrollView is the scroll view");
+
+      [sv setHasHorizontalScroller: YES];
+      PASS([sv hasHorizontalScroller], "setHasHorizontalScroller: round-trips");
+      [sv setHasVerticalScroller: YES];
+      PASS([sv hasVerticalScroller], "setHasVerticalScroller: round-trips");
+      [sv setBorderType: NSBezelBorder];
+      PASS([sv borderType] == NSBezelBorder, "setBorderType: round-trips");
+      [sv setLineScroll: 12.0];
+      PASS([sv lineScroll] == 12.0, "setLineScroll: round-trips");
+      [sv setScrollsDynamically: NO];
+      PASS([sv scrollsDynamically] == NO, "setScrollsDynamically: round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSScrollView structure")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for NSScrollView across three tiers.

structure.m checks the document and clip view wiring: setDocumentView: round-
trips, contentView is an NSClipView, the document's superview is the clip view
and its enclosingScrollView is the scroll view, and the scroller, border, line
scroll and dynamic-scroll settings round-trip.

geometry.m checks that with no scrollers and no border the content size equals
the frame size and the class frame/content size conversions are the identity.

scroll.m checks that documentVisibleRect reflects a scroll of the document.

rendering.m checks that the clip view draws its background.

The tests create views and carry the backend skip guard, so they skip cleanly
where no backend is installed.
