### PR TITLE
tests: add NSClipView tests

### DIFF
--- a/Tests/gui/NSClipView/constrain.m
+++ b/Tests/gui/NSClipView/constrain.m
@@ -1,0 +1,54 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSClipView.h>
+#import <AppKit/NSView.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSClipView constrain")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSClipView *clip = AUTORELEASE([[NSClipView alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+      NSView *doc = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 500, 500)]);
+      [clip setDocumentView: doc];
+
+      PASS(NSEqualRects([clip documentRect], NSMakeRect(0, 0, 500, 500)),
+        "documentRect is the document frame");
+
+      /* constrainScrollPoint: clamps a proposed origin to the valid scroll
+         range (0..400 for a 500x500 document in a 100x100 clip view). Checked
+         against AppKit. */
+      PASS(NSEqualPoints([clip constrainScrollPoint: NSMakePoint(300, 300)],
+                         NSMakePoint(300, 300)),
+        "constrainScrollPoint: leaves an in-range point unchanged");
+      PASS(NSEqualPoints([clip constrainScrollPoint: NSMakePoint(600, 600)],
+                         NSMakePoint(400, 400)),
+        "constrainScrollPoint: clamps a point past the maximum");
+      PASS(NSEqualPoints([clip constrainScrollPoint: NSMakePoint(-50, -50)],
+                         NSMakePoint(0, 0)),
+        "constrainScrollPoint: clamps a negative point to zero");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSClipView constrain")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSClipView/rendering.m
+++ b/Tests/gui/NSClipView/rendering.m
@@ -1,0 +1,61 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSClipView.h>
+#import <AppKit/NSColor.h>
+#import <AppKit/NSGraphics.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSClipView rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 16, 16)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSClipView *clip = AUTORELEASE([[NSClipView alloc]
+        initWithFrame: NSMakeRect(0, 0, 16, 16)]);
+      [clip setDrawsBackground: YES];
+      [clip setBackgroundColor: [NSColor redColor]];
+      [w setContentView: clip];
+
+      /* The clip view fills its background (a regression lock, not a pixel
+         comparison against AppKit). */
+      NSRect b = [clip bounds];
+      [clip lockFocus];
+      [clip drawRect: b];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: b]);
+      [clip unlockFocus];
+
+      NSColor *c = [[rep colorAtX: [rep pixelsWide] / 2 y: [rep pixelsHigh] / 2]
+        colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+      PASS(c != nil && [c redComponent] > 0.9
+        && [c greenComponent] < 0.1 && [c blueComponent] < 0.1,
+        "a clip view renders its background red");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSClipView rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSClipView/scroll.m
+++ b/Tests/gui/NSClipView/scroll.m
@@ -1,0 +1,43 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSClipView.h>
+#import <AppKit/NSView.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSClipView scroll")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSClipView *clip = AUTORELEASE([[NSClipView alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+      NSView *doc = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 500, 500)]);
+      [clip setDocumentView: doc];
+
+      /* scrollToPoint: moves the visible rectangle. Checked against AppKit. */
+      [clip scrollToPoint: NSMakePoint(200, 200)];
+      PASS(NSEqualRects([clip documentVisibleRect], NSMakeRect(200, 200, 100, 100)),
+        "scrollToPoint: moves the visible rectangle");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSClipView scroll")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSClipView/state.m
+++ b/Tests/gui/NSClipView/state.m
@@ -1,0 +1,52 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSClipView.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSColor.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSClipView state")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSClipView *clip = AUTORELEASE([[NSClipView alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+      NSView *doc = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 500, 500)]);
+      [clip setDocumentView: doc];
+
+      /* Document and state round-trips. Checked against AppKit. */
+      PASS([clip documentView] == doc, "setDocumentView: round-trips");
+      PASS([doc superview] == clip,
+        "the document view's superview is the clip view");
+
+      [clip setCopiesOnScroll: NO];
+      PASS([clip copiesOnScroll] == NO, "setCopiesOnScroll: round-trips");
+      [clip setDrawsBackground: NO];
+      PASS([clip drawsBackground] == NO, "setDrawsBackground: round-trips");
+      [clip setBackgroundColor: [NSColor redColor]];
+      PASS([[clip backgroundColor] isEqual: [NSColor redColor]],
+        "setBackgroundColor: round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSClipView state")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for NSClipView across three tiers.

state.m checks that setDocumentView: round-trips (and the document's superview is
the clip view) and that copiesOnScroll, drawsBackground and backgroundColor
round-trip.

constrain.m checks documentRect and that constrainScrollPoint: clamps a proposed
origin to the valid scroll range: an in-range point is unchanged, a point past
the maximum clamps to the maximum, and a negative point clamps to zero.

scroll.m checks that scrollToPoint: moves the visible rectangle.

rendering.m checks that the clip view draws its background.

The tests create views and carry the backend skip guard, so they skip cleanly
where no backend is installed.
