### PR TITLE
tests: add NSBox tests

### DIFF
--- a/Tests/gui/NSBox/contentView.m
+++ b/Tests/gui/NSBox/contentView.m
@@ -1,0 +1,44 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSBox.h>
+#import <AppKit/NSView.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSBox content view")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSBox *box = AUTORELEASE([[NSBox alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+
+      /* Content view wiring. Checked against AppKit. */
+      PASS([box contentView] != nil, "a box has a content view by default");
+
+      NSView *cv = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 20, 20)]);
+      [box setContentView: cv];
+      PASS([box contentView] == cv, "setContentView: round-trips");
+      PASS([cv superview] == box, "the content view's superview is the box");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSBox content view")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSBox/rendering.m
+++ b/Tests/gui/NSBox/rendering.m
@@ -1,0 +1,64 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSBox.h>
+#import <AppKit/NSColor.h>
+#import <AppKit/NSGraphics.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSBox rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 16, 16)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSBox *box = AUTORELEASE([[NSBox alloc]
+        initWithFrame: NSMakeRect(0, 0, 16, 16)]);
+      [box setBoxType: NSBoxCustom];
+      [box setBorderType: NSNoBorder];
+      [box setTitlePosition: NSNoTitle];
+      [box setTransparent: NO];
+      [box setFillColor: [NSColor redColor]];
+      [w setContentView: box];
+
+      /* A custom box fills its fill colour (a regression lock, not a pixel
+         comparison against AppKit). */
+      NSRect b = [box bounds];
+      [box lockFocus];
+      [box drawRect: b];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: b]);
+      [box unlockFocus];
+
+      NSColor *c = [[rep colorAtX: [rep pixelsWide] / 2 y: [rep pixelsHigh] / 2]
+        colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+      PASS(c != nil && [c redComponent] > 0.9
+        && [c greenComponent] < 0.1 && [c blueComponent] < 0.1,
+        "a custom box renders its fill colour red");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSBox rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSBox/state.m
+++ b/Tests/gui/NSBox/state.m
@@ -1,0 +1,58 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSBox.h>
+#import <AppKit/NSColor.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSBox state")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSBox *box = AUTORELEASE([[NSBox alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+
+      /* State round-trips. Checked against AppKit. */
+      [box setTitle: @"Hi"];
+      PASS([[box title] isEqualToString: @"Hi"], "setTitle: round-trips");
+      [box setTitlePosition: NSAtTop];
+      PASS([box titlePosition] == NSAtTop, "setTitlePosition: round-trips");
+      [box setBoxType: NSBoxCustom];
+      PASS([box boxType] == NSBoxCustom, "setBoxType: round-trips");
+      [box setBorderType: NSLineBorder];
+      PASS([box borderType] == NSLineBorder, "setBorderType: round-trips");
+      [box setContentViewMargins: NSMakeSize(8, 6)];
+      PASS(NSEqualSizes([box contentViewMargins], NSMakeSize(8, 6)),
+        "setContentViewMargins: round-trips");
+      [box setFillColor: [NSColor redColor]];
+      PASS([[box fillColor] isEqual: [NSColor redColor]], "setFillColor: round-trips");
+      [box setBorderColor: [NSColor blueColor]];
+      PASS([[box borderColor] isEqual: [NSColor blueColor]], "setBorderColor: round-trips");
+      [box setBorderWidth: 3.0];
+      PASS([box borderWidth] == 3.0, "setBorderWidth: round-trips");
+      [box setCornerRadius: 5.0];
+      PASS([box cornerRadius] == 5.0, "setCornerRadius: round-trips");
+      [box setTransparent: YES];
+      PASS([box isTransparent] == YES, "setTransparent: round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSBox state")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for NSBox across three tiers.

state.m checks that title, titlePosition, boxType, borderType, contentViewMargins,
fillColor, borderColor, borderWidth, cornerRadius and transparent round-trip.

contentView.m checks that a box has a content view by default, setContentView:
round-trips, and the content view's superview is the box.

rendering.m checks that a custom box fills its fill colour.

The tests create views and carry the backend skip guard, so they skip cleanly
where no backend is installed.
