### PR TITLE
tests: add NSTabView tests

### DIFF
--- a/Tests/gui/NSTabView/defaults.m
+++ b/Tests/gui/NSTabView/defaults.m
@@ -1,0 +1,69 @@
+/* Coverage for NSTabView scalar state: the type, background, truncation and
+   font defaults and their setter round-trips, plus the control-size and
+   control-tint getter defaults. Every assertion matches AppKit (checked on a
+   macOS runner) and passes on unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSFont.h>
+#include <AppKit/NSTabView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTabView *tv;
+
+  START_SET("NSTabView defaults")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tv = AUTORELEASE([[NSTabView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+
+      pass([tv tabViewType] == NSTopTabsBezelBorder,
+           "the default tab view type is NSTopTabsBezelBorder");
+      pass([tv font] != nil, "a tab view has a font");
+      pass([tv controlSize] == NSRegularControlSize,
+           "the default control size is regular");
+      pass([tv controlTint] == NSDefaultControlTint,
+           "the default control tint is the default tint");
+
+      [tv setTabViewType: NSNoTabsNoBorder];
+      pass([tv tabViewType] == NSNoTabsNoBorder, "tabViewType round-trips");
+
+      [tv setDrawsBackground: YES];
+      pass([tv drawsBackground] == YES, "drawsBackground round-trips to YES");
+      [tv setDrawsBackground: NO];
+      pass([tv drawsBackground] == NO, "drawsBackground round-trips to NO");
+
+      [tv setAllowsTruncatedLabels: YES];
+      pass([tv allowsTruncatedLabels] == YES,
+           "allowsTruncatedLabels round-trips to YES");
+      [tv setAllowsTruncatedLabels: NO];
+      pass([tv allowsTruncatedLabels] == NO,
+           "allowsTruncatedLabels round-trips to NO");
+
+      [tv setFont: [NSFont boldSystemFontOfSize: 12]];
+      pass([[tv font] isEqual: [NSFont boldSystemFontOfSize: 12]],
+           "font round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTabView defaults")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTabView/delegate.m
+++ b/Tests/gui/NSTabView/delegate.m
@@ -1,0 +1,106 @@
+/* Coverage for the NSTabView delegate: didSelect fires on selection,
+   tabViewDidChangeNumberOfTabViewItems fires when the item count changes, and
+   a shouldSelect of NO keeps the current selection. Every assertion matches
+   AppKit (checked on a macOS runner) and passes on unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSView.h>
+#include <AppKit/NSTabView.h>
+#include <AppKit/NSTabViewItem.h>
+
+@interface Recorder : NSObject
+{
+@public
+  NSString *lastDidSelect;
+  int changeCount;
+  BOOL vetoB;
+}
+@end
+
+@implementation Recorder
+- (BOOL) tabView: (NSTabView *)tv shouldSelectTabViewItem: (NSTabViewItem *)it
+{
+  if (vetoB && [[it label] isEqualToString: @"B"])
+    return NO;
+  return YES;
+}
+- (void) tabView: (NSTabView *)tv didSelectTabViewItem: (NSTabViewItem *)it
+{
+  ASSIGN(lastDidSelect, [it label]);
+}
+- (void) tabViewDidChangeNumberOfTabViewItems: (NSTabView *)tv
+{
+  changeCount++;
+}
+@end
+
+static NSTabViewItem *
+mk(NSString *ident, NSString *label)
+{
+  NSTabViewItem *it = AUTORELEASE([[NSTabViewItem alloc]
+    initWithIdentifier: ident]);
+  [it setLabel: label];
+  [it setView: AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(0, 0, 50, 50)])];
+  return it;
+}
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTabView *tv;
+  Recorder *rec;
+
+  START_SET("NSTabView delegate")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tv = AUTORELEASE([[NSTabView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+      rec = AUTORELEASE([Recorder new]);
+      [tv setDelegate: rec];
+      pass([tv delegate] == rec, "delegate round-trips");
+
+      [tv addTabViewItem: mk(@"ia", @"A")];
+      [tv addTabViewItem: mk(@"ib", @"B")];
+      pass(rec->changeCount == 2,
+           "tabViewDidChangeNumberOfTabViewItems: fires on each add");
+
+      [tv selectTabViewItemAtIndex: 1];
+      pass([rec->lastDidSelect isEqualToString: @"B"],
+           "didSelectTabViewItem: reports the newly selected item");
+
+      /* veto keeps the current selection */
+      tv = AUTORELEASE([[NSTabView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+      rec = AUTORELEASE([Recorder new]);
+      rec->vetoB = YES;
+      [tv setDelegate: rec];
+      [tv addTabViewItem: mk(@"pa", @"A")];
+      [tv addTabViewItem: mk(@"pb", @"B")];
+      [tv selectTabViewItemAtIndex: 1];
+      pass([[[tv selectedTabViewItem] label] isEqualToString: @"A"],
+           "a shouldSelect of NO keeps the current selection");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTabView delegate")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTabView/rendering.m
+++ b/Tests/gui/NSTabView/rendering.m
@@ -1,0 +1,69 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSTabView.h>
+#import <AppKit/NSTabViewItem.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+static NSTabViewItem *
+mk(NSString *ident, NSString *label)
+{
+  NSTabViewItem *it = AUTORELEASE([[NSTabViewItem alloc]
+    initWithIdentifier: ident]);
+  [it setLabel: label];
+  [it setView: AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(0, 0, 50, 50)])];
+  return it;
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSTabView rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 120, 100)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSTabView *tv = AUTORELEASE([[NSTabView alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 100)]);
+      [tv addTabViewItem: mk(@"a", @"A")];
+      [tv addTabViewItem: mk(@"b", @"B")];
+      [w setContentView: tv];
+
+      /* The tab view draws its bezel, tabs and selected item's view without
+         error and produces a bitmap of its own size (a render regression
+         lock, not a pixel comparison against AppKit). */
+      [tv lockFocus];
+      [tv drawRect: [tv bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 120, 100)]);
+      [tv unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 120 && [rep pixelsHigh] == 100,
+        "a tab view renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTabView rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTabView/selection.m
+++ b/Tests/gui/NSTabView/selection.m
@@ -1,0 +1,95 @@
+/* Coverage for NSTabView selection: selectTabViewItemAtIndex:, the
+   first / last / next / previous movers, selectedTabViewItem, and the
+   NSTabState transitions on the items. Every assertion matches AppKit
+   (checked on a macOS runner) and passes on unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSView.h>
+#include <AppKit/NSTabView.h>
+#include <AppKit/NSTabViewItem.h>
+
+static NSTabViewItem *
+mk(NSString *ident, NSString *label)
+{
+  NSTabViewItem *it = AUTORELEASE([[NSTabViewItem alloc]
+    initWithIdentifier: ident]);
+  [it setLabel: label];
+  [it setView: AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(0, 0, 50, 50)])];
+  return it;
+}
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTabView *tv;
+  NSTabViewItem *a, *b, *c;
+
+  START_SET("NSTabView selection")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tv = AUTORELEASE([[NSTabView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+      a = mk(@"ia", @"A");
+      b = mk(@"ib", @"B");
+      c = mk(@"ic", @"C");
+      [tv addTabViewItem: a];
+      [tv addTabViewItem: b];
+      [tv addTabViewItem: c];
+
+      /* the selected item is NSSelectedTab, the others NSBackgroundTab */
+      pass([a tabState] == NSSelectedTab,
+           "the selected item's tabState is NSSelectedTab");
+      pass([b tabState] == NSBackgroundTab,
+           "an unselected item's tabState is NSBackgroundTab");
+
+      [tv selectTabViewItemAtIndex: 2];
+      pass([tv selectedTabViewItem] == c,
+           "selectTabViewItemAtIndex: 2 selects c");
+      pass([c tabState] == NSSelectedTab, "c becomes NSSelectedTab");
+      pass([a tabState] == NSBackgroundTab,
+           "the previously selected a returns to NSBackgroundTab");
+
+      [tv selectFirstTabViewItem: nil];
+      pass([tv selectedTabViewItem] == a, "selectFirstTabViewItem: selects a");
+      [tv selectLastTabViewItem: nil];
+      pass([tv selectedTabViewItem] == c, "selectLastTabViewItem: selects c");
+
+      [tv selectFirstTabViewItem: nil];
+      [tv selectNextTabViewItem: nil];
+      pass([tv selectedTabViewItem] == b,
+           "selectNextTabViewItem: moves from a to b");
+      [tv selectPreviousTabViewItem: nil];
+      pass([tv selectedTabViewItem] == a,
+           "selectPreviousTabViewItem: moves from b to a");
+
+      /* removing the selected item leaves a valid selection */
+      [tv selectTabViewItemAtIndex: 1];
+      [tv removeTabViewItem: b];
+      pass([tv numberOfTabViewItems] == 2, "the item count drops after remove");
+      pass([tv selectedTabViewItem] != nil,
+           "a selection survives removing the selected item");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTabView selection")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTabView/structure.m
+++ b/Tests/gui/NSTabView/structure.m
@@ -1,0 +1,94 @@
+/* Coverage for NSTabView membership: add / insert / remove, the item counts
+   and indices, the item-to-tab-view wiring, and that the first item added
+   becomes the selection. Every assertion matches AppKit (checked on a macOS
+   runner) and passes on unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSView.h>
+#include <AppKit/NSTabView.h>
+#include <AppKit/NSTabViewItem.h>
+
+static NSTabViewItem *
+mk(NSString *ident, NSString *label)
+{
+  NSTabViewItem *it = AUTORELEASE([[NSTabViewItem alloc]
+    initWithIdentifier: ident]);
+  [it setLabel: label];
+  [it setView: AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(0, 0, 50, 50)])];
+  return it;
+}
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTabView *tv;
+  NSTabViewItem *a, *b, *c, *d;
+
+  START_SET("NSTabView structure")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tv = AUTORELEASE([[NSTabView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+
+      pass([tv numberOfTabViewItems] == 0, "a new tab view has no items");
+      pass([tv selectedTabViewItem] == nil,
+           "a new tab view has no selection");
+
+      a = mk(@"ia", @"A");
+      b = mk(@"ib", @"B");
+      c = mk(@"ic", @"C");
+
+      [tv addTabViewItem: a];
+      pass([tv selectedTabViewItem] == a,
+           "the first item added becomes the selection");
+      pass([a tabView] == tv, "an added item points back at the tab view");
+      pass([[a view] superview] != nil,
+           "an added item's view is placed in the view hierarchy");
+
+      [tv addTabViewItem: b];
+      [tv addTabViewItem: c];
+      pass([tv numberOfTabViewItems] == 3, "three items were added");
+      pass([tv indexOfTabViewItem: b] == 1, "indexOfTabViewItem: finds b at 1");
+      pass([tv tabViewItemAtIndex: 1] == b, "tabViewItemAtIndex: 1 is b");
+      pass([tv indexOfTabViewItemWithIdentifier: @"ic"] == 2,
+           "indexOfTabViewItemWithIdentifier: finds ic at 2");
+      pass([[tv tabViewItems] count] == 3, "tabViewItems has three entries");
+      pass([tv selectedTabViewItem] == a,
+           "later adds do not change the selection");
+
+      /* insert at an index */
+      d = mk(@"id", @"D");
+      [tv insertTabViewItem: d atIndex: 1];
+      pass([tv numberOfTabViewItems] == 4, "insert raises the count");
+      pass([tv tabViewItemAtIndex: 1] == d, "inserted item lands at its index");
+      pass([tv indexOfTabViewItem: b] == 2, "insert shifts later items up");
+
+      /* remove */
+      [tv removeTabViewItem: d];
+      pass([tv numberOfTabViewItems] == 3, "remove lowers the count");
+      pass([tv indexOfTabViewItem: b] == 1, "remove shifts later items down");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTabView structure")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for NSTabView: membership (add, insert, remove, indices, item wiring), selection and NSTabState transitions, the scalar state defaults and round-trips, the delegate callbacks including a shouldSelect veto, and a render regression lock. NSTabViewItem already has tests, so this covers the container class. The assertions were checked against AppKit.