### PR TITLE
Fix: NSTabView defaults drawsBackground and allowsTruncatedLabels to YES

### DIFF
--- a/Source/NSTabView.m
+++ b/Source/NSTabView.m
@@ -78,7 +78,8 @@
       ASSIGN(_items, [NSMutableArray array]);
       ASSIGN(_font, [NSFont systemFontOfSize: 0]);
       _selected = nil;
-      //_truncated_label = NO;
+      _draws_background = YES;
+      _truncated_label = YES;
     }
 
   return self;

--- a/Tests/gui/NSTabView/backgroundDefault.m
+++ b/Tests/gui/NSTabView/backgroundDefault.m
@@ -1,0 +1,43 @@
+/* A default NSTabView draws its background and allows truncated labels, as
+   AppKit does. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTabView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTabView *tv;
+
+  START_SET("NSTabView backgroundDefault")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tv = AUTORELEASE([[NSTabView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+      pass([tv drawsBackground] == YES,
+           "a new tab view draws its background");
+      pass([tv allowsTruncatedLabels] == YES,
+           "a new tab view allows truncated labels");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTabView backgroundDefault")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A new NSTabView left drawsBackground and allowsTruncatedLabels at NO, but AppKit defaults both to YES. Set them in the designated initializer. Adds a test for the two defaults.