### PR TITLE
tests: add NSSplitView tests

### DIFF
--- a/Tests/gui/NSSplitView/rendering.m
+++ b/Tests/gui/NSSplitView/rendering.m
@@ -1,0 +1,60 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSSplitView.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSplitView rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 120, 100)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSSplitView *sv = AUTORELEASE([[NSSplitView alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 100)]);
+      [sv addSubview: AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 45)])];
+      [sv addSubview: AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 45)])];
+      [sv adjustSubviews];
+      [w setContentView: sv];
+
+      /* The split view draws its subviews and divider without error and
+         produces a bitmap of its own size (a render regression lock, not a
+         pixel comparison against AppKit). */
+      [sv lockFocus];
+      [sv drawRect: [sv bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 120, 100)]);
+      [sv unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 120 && [rep pixelsHigh] == 100,
+        "a split view renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSSplitView rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSSplitView/state.m
+++ b/Tests/gui/NSSplitView/state.m
@@ -1,0 +1,69 @@
+/* Coverage for NSSplitView scalar state: the orientation, divider style,
+   divider colour, autosave name and delegate defaults and round-trips. The
+   AppKit-comparable assertions were checked on a macOS runner; the pane
+   splitter flag is a GNUstep extension and is only round-tripped. All pass on
+   unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSColor.h>
+#include <AppKit/NSSplitView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSSplitView *sv;
+
+  START_SET("NSSplitView state")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      sv = AUTORELEASE([[NSSplitView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 100)]);
+
+      pass([sv isVertical] == NO, "a split view is horizontal by default");
+      pass([sv dividerStyle] == NSSplitViewDividerStyleThick,
+           "the default divider style is thick");
+      pass([sv dividerColor] != nil, "a split view has a divider colour");
+      pass([sv autosaveName] == nil, "the default autosave name is nil");
+      pass([sv delegate] == nil, "the default delegate is nil");
+
+      [sv setVertical: YES];
+      pass([sv isVertical] == YES, "isVertical round-trips");
+      [sv setDividerStyle: NSSplitViewDividerStyleThin];
+      pass([sv dividerStyle] == NSSplitViewDividerStyleThin,
+           "dividerStyle round-trips to thin");
+      [sv setDividerStyle: NSSplitViewDividerStylePaneSplitter];
+      pass([sv dividerStyle] == NSSplitViewDividerStylePaneSplitter,
+           "dividerStyle round-trips to pane splitter");
+      [sv setAutosaveName: @"mySplit"];
+      pass([[sv autosaveName] isEqualToString: @"mySplit"],
+           "autosaveName round-trips");
+
+      /* isPaneSplitter is a GNUstep extension */
+      [sv setIsPaneSplitter: NO];
+      pass([sv isPaneSplitter] == NO, "isPaneSplitter round-trips to NO");
+      [sv setIsPaneSplitter: YES];
+      pass([sv isPaneSplitter] == YES, "isPaneSplitter round-trips to YES");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSSplitView state")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSSplitView/structure.m
+++ b/Tests/gui/NSSplitView/structure.m
@@ -1,0 +1,56 @@
+/* Coverage for NSSplitView subview membership: added subviews are present and
+   uncollapsed, the minimum position of the first divider is 0, and
+   adjustSubviews runs without error. Every assertion matches AppKit (checked
+   on a macOS runner) and passes on unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSView.h>
+#include <AppKit/NSSplitView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSSplitView *sv;
+  NSView *a, *b;
+
+  START_SET("NSSplitView structure")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      sv = AUTORELEASE([[NSSplitView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 100)]);
+      a = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 200, 40)]);
+      b = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 200, 40)]);
+      [sv addSubview: a];
+      [sv addSubview: b];
+      [sv adjustSubviews];
+
+      pass([[sv subviews] count] == 2, "two added subviews are present");
+      pass([sv isSubviewCollapsed: a] == NO,
+           "an added subview is not collapsed");
+      pass([sv isSubviewCollapsed: b] == NO,
+           "the second added subview is not collapsed");
+      pass([sv minPossiblePositionOfDividerAtIndex: 0] == 0,
+           "the minimum position of the first divider is 0");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSSplitView structure")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for NSSplitView: the orientation, divider style, divider colour, autosave name and delegate defaults and round-trips (plus the GNUstep isPaneSplitter flag), subview membership and collapse state, the minimum divider position, and a render regression lock. The AppKit-comparable assertions were checked against AppKit.