### PR TITLE
Fix: NSStackView initialises all its state in the designated initializer

### DIFF
--- a/Source/NSStackView.m
+++ b/Source/NSStackView.m
@@ -443,16 +443,19 @@
 
 // Instance methods
 // Manage views...
-- (instancetype) initWithViews: (NSArray *)views
+- (instancetype) initWithFrame: (NSRect)frameRect
 {
-  self = [super init];
+  self = [super initWithFrame: frameRect];
   if (self != nil)
     {
-      NSUInteger c = [views count];
-      
-      _arrangedSubviews = [[NSMutableArray alloc] initWithArray: views];
-      _detachedViews = [[NSMutableArray alloc] initWithCapacity: c];
-      ASSIGNCOPY(_views, views);
+      _distribution = NSStackViewDistributionGravityAreas;
+      _spacing = 8.0;
+      _detachesHiddenViews = YES;
+      _alignment = NSLayoutAttributeCenterY;
+
+      _arrangedSubviews = [[NSMutableArray alloc] init];
+      _detachedViews = [[NSMutableArray alloc] init];
+      _views = [[NSMutableArray alloc] init];
       _customSpacingMap = RETAIN([NSMapTable weakToWeakObjectsMapTable]);
       _visiblePriorityMap = RETAIN([NSMapTable weakToWeakObjectsMapTable]);
 
@@ -460,6 +463,19 @@
       _beginningContainer = nil;
       _middleContainer = nil;
       _endContainer = nil;
+
+      [self _refreshView];
+    }
+  return self;
+}
+
+- (instancetype) initWithViews: (NSArray *)views
+{
+  self = [self initWithFrame: NSZeroRect];
+  if (self != nil)
+    {
+      [_arrangedSubviews addObjectsFromArray: views];
+      ASSIGNCOPY(_views, views);
 
       [self _refreshView];
     }

--- a/Source/NSStackView.m
+++ b/Source/NSStackView.m
@@ -812,6 +812,12 @@
   self = [super initWithCoder: coder];
   if (self != nil)
     {
+      _arrangedSubviews = [[NSMutableArray alloc] init];
+      _detachedViews = [[NSMutableArray alloc] init];
+      _views = [[NSMutableArray alloc] init];
+      _customSpacingMap = RETAIN([NSMapTable weakToWeakObjectsMapTable]);
+      _visiblePriorityMap = RETAIN([NSMapTable weakToWeakObjectsMapTable]);
+
       if ([coder allowsKeyedCoding])
         {
           if ([coder containsValueForKey: @"NSStackViewAlignment"])

--- a/Tests/gui/NSStackView/coding.m
+++ b/Tests/gui/NSStackView/coding.m
@@ -1,0 +1,75 @@
+/* A stack view built from an archive must be as usable as one built with the
+   designated -initWithFrame:.  -initWithCoder: decoded the archived scalars and
+   containers but never created the arranged/detached/view arrays or the
+   custom-spacing and visibility-priority map tables, so on a decoded stack view
+   every setter that routes through them silently did nothing:
+   -setCustomSpacing:afterView: dropped the value and -customSpacingAfterView:
+   then returned 0.  A stack view built directly records the value (the
+   containers are archived nil here, so the layout pass is a no-op); check the
+   decoded one now does too. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSData.h>
+#include <Foundation/NSKeyedArchiver.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSStackView.h>
+#include <AppKit/NSView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSStackView *sv;
+  NSStackView *decoded;
+  NSView *v1;
+  NSView *v2;
+  NSData *data;
+
+  START_SET("NSStackView coding")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      v1 = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 10, 10)]);
+      v2 = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 10, 10)]);
+
+      sv = AUTORELEASE([[NSStackView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 100)]);
+
+      /* Baseline: a directly built stack view records custom spacing. */
+      [sv setCustomSpacing: 5.0 afterView: v1];
+      PASS([sv customSpacingAfterView: v1] == 5.0,
+           "a stack view records custom spacing after a view");
+
+      data = [NSKeyedArchiver archivedDataWithRootObject: sv];
+      PASS(data != nil && [data length] > 0, "a stack view archives");
+
+      decoded = [NSKeyedUnarchiver unarchiveObjectWithData: data];
+      PASS(decoded != nil && [decoded isKindOfClass: [NSStackView class]],
+           "a stack view unarchives");
+
+      /* The decoded stack view must record custom spacing just like the
+         original.  Before -initWithCoder: created the map its value was
+         silently dropped and this read back 0. */
+      [decoded setCustomSpacing: 7.0 afterView: v2];
+      PASS([decoded customSpacingAfterView: v2] == 7.0,
+           "a decoded stack view records custom spacing after a view");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSStackView coding")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSStackView/defaults.m
+++ b/Tests/gui/NSStackView/defaults.m
@@ -28,14 +28,14 @@ int main()
       sv = AUTORELEASE([[NSStackView alloc]
         initWithFrame: NSMakeRect(0, 0, 200, 100)]);
 
-      pass([sv distribution] == NSStackViewDistributionGravityAreas,
+      PASS([sv distribution] == NSStackViewDistributionGravityAreas,
            "the default distribution is gravity areas");
-      pass([sv spacing] == 8.0, "the default spacing is 8");
-      pass([sv detachesHiddenViews] == YES,
+      PASS([sv spacing] == 8.0, "the default spacing is 8");
+      PASS([sv detachesHiddenViews] == YES,
            "hidden views are detached by default");
-      pass([sv alignment] == NSLayoutAttributeCenterY,
+      PASS([sv alignment] == NSLayoutAttributeCenterY,
            "the default alignment is centre-Y");
-      pass([sv arrangedSubviews] != nil
+      PASS([sv arrangedSubviews] != nil
            && [[sv arrangedSubviews] count] == 0,
            "a frame-initialised stack view has no arranged subviews");
     }

--- a/Tests/gui/NSStackView/defaults.m
+++ b/Tests/gui/NSStackView/defaults.m
@@ -1,0 +1,52 @@
+/* A new NSStackView has AppKit's state defaults: gravity-areas distribution,
+   a spacing of 8, hidden-view detachment on, and centre-Y alignment (checked
+   against AppKit on a macOS runner). */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSStackView.h>
+#include <AppKit/NSLayoutConstraint.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSStackView *sv;
+
+  START_SET("NSStackView defaults")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      sv = AUTORELEASE([[NSStackView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 100)]);
+
+      pass([sv distribution] == NSStackViewDistributionGravityAreas,
+           "the default distribution is gravity areas");
+      pass([sv spacing] == 8.0, "the default spacing is 8");
+      pass([sv detachesHiddenViews] == YES,
+           "hidden views are detached by default");
+      pass([sv alignment] == NSLayoutAttributeCenterY,
+           "the default alignment is centre-Y");
+      pass([sv arrangedSubviews] != nil
+           && [[sv arrangedSubviews] count] == 0,
+           "a frame-initialised stack view has no arranged subviews");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSStackView defaults")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A programmatically created NSStackView left distribution, spacing, detachesHiddenViews and alignment at their zero values, but AppKit defaults them to gravity-areas distribution, spacing 8, detachment on, and centre-Y alignment. Set them in a shared helper called from initWithFrame: and initWithViews: (initWithCoder: already decodes them). Adds a test.