### PR TITLE
tests: add NSStackView tests

### DIFF
--- a/Tests/gui/NSStackView/rendering.m
+++ b/Tests/gui/NSStackView/rendering.m
@@ -1,0 +1,55 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSStackView.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSStackView rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 120, 100)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSStackView *sv = AUTORELEASE([[NSStackView alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 100)]);
+      [w setContentView: sv];
+
+      /* The stack view draws without error and produces a bitmap of its own
+         size (a render regression lock, not a pixel comparison against
+         AppKit). */
+      [sv lockFocus];
+      [sv drawRect: [sv bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 120, 100)]);
+      [sv unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 120 && [rep pixelsHigh] == 100,
+        "a stack view renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSStackView rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSStackView/state.m
+++ b/Tests/gui/NSStackView/state.m
@@ -1,0 +1,50 @@
+/* Coverage for the NSStackView read-only state that does not depend on the
+   layout pass: the default orientation, delegate, arranged-subview list and
+   the deprecated hasEqualSpacing flag. Every assertion matches AppKit (checked
+   on a macOS runner) and passes on unmodified GNUstep. The scalar setter
+   round-trips and the remaining AppKit defaults are exercised by the fix
+   branches that make them work. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSStackView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSStackView *sv;
+
+  START_SET("NSStackView state")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      sv = AUTORELEASE([[NSStackView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 100)]);
+
+      pass([sv orientation] == NSUserInterfaceLayoutOrientationHorizontal,
+           "a stack view is horizontal by default");
+      pass([sv delegate] == nil, "the default delegate is nil");
+      pass([[sv arrangedSubviews] count] == 0,
+           "a new stack view has no arranged subviews");
+      pass([sv hasEqualSpacing] == NO, "hasEqualSpacing is NO by default");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSStackView state")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for the NSStackView state that does not depend on the layout pass: the default orientation, delegate, arranged-subview list and the deprecated hasEqualSpacing flag, plus a render regression lock. The scalar setter round-trips and the remaining AppKit defaults need code fixes and are covered on separate branches. The assertions were checked against AppKit.