### PR TITLE
tests: add NSTableView tests

### DIFF
--- a/Tests/gui/NSTableView/columns.m
+++ b/Tests/gui/NSTableView/columns.m
@@ -1,0 +1,75 @@
+/* Coverage for NSTableView column management: add, the identifier lookup and
+   back-pointer, tableColumns membership, move and remove. Every assertion
+   matches AppKit (checked on a macOS runner) and passes on unmodified
+   GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTableView.h>
+#include <AppKit/NSTableColumn.h>
+
+static NSTableColumn *
+mkcol(NSString *ident)
+{
+  NSTableColumn *c = AUTORELEASE([[NSTableColumn alloc]
+    initWithIdentifier: ident]);
+  [c setWidth: 50.0];
+  return c;
+}
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTableView *tv;
+  NSTableColumn *c1, *c2;
+
+  START_SET("NSTableView columns")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tv = AUTORELEASE([[NSTableView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+      c1 = mkcol(@"c1");
+      c2 = mkcol(@"c2");
+
+      [tv addTableColumn: c1];
+      [tv addTableColumn: c2];
+      pass([tv numberOfColumns] == 2, "two columns were added");
+      pass([c1 tableView] == tv, "an added column points back at the table");
+      pass([tv columnWithIdentifier: @"c2"] == 1,
+           "columnWithIdentifier: finds c2 at index 1");
+      pass([[tv tableColumns] containsObject: c1],
+           "tableColumns contains an added column");
+      pass([[tv tableColumns] objectAtIndex: 0] == c1,
+           "the first column is the first one added");
+
+      [tv moveColumn: 0 toColumn: 1];
+      pass([[tv tableColumns] objectAtIndex: 0] == c2,
+           "moveColumn:toColumn: reorders the columns");
+
+      [tv removeTableColumn: c1];
+      pass([tv numberOfColumns] == 1, "removeTableColumn: lowers the count");
+      pass([[tv tableColumns] objectAtIndex: 0] == c2,
+           "the remaining column is the one not removed");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTableView columns")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTableView/rendering.m
+++ b/Tests/gui/NSTableView/rendering.m
@@ -1,0 +1,72 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <Foundation/NSString.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSTableView.h>
+#import <AppKit/NSTableColumn.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+@interface RTVDS : NSObject
+@end
+@implementation RTVDS
+- (NSInteger) numberOfRowsInTableView: (NSTableView *)tv { return 3; }
+- (id) tableView: (NSTableView *)tv
+       objectValueForTableColumn: (NSTableColumn *)col
+       row: (NSInteger)row
+{ return [NSString stringWithFormat: @"r%ld", (long)row]; }
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSTableView rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 120, 80)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSTableView *tv = AUTORELEASE([[NSTableView alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 80)]);
+      NSTableColumn *col = AUTORELEASE([[NSTableColumn alloc]
+        initWithIdentifier: @"a"]);
+      [col setWidth: 100.0];
+      [tv addTableColumn: col];
+      [tv setDataSource: AUTORELEASE([RTVDS new])];
+      [tv reloadData];
+      [w setContentView: tv];
+
+      /* The table draws its rows and grid without error and produces a bitmap
+         of its own size (a render regression lock, not a pixel comparison
+         against AppKit). */
+      [tv lockFocus];
+      [tv drawRect: [tv bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 120, 80)]);
+      [tv unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 120 && [rep pixelsHigh] == 80,
+        "a table renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTableView rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTableView/selection.m
+++ b/Tests/gui/NSTableView/selection.m
@@ -1,0 +1,81 @@
+/* Coverage for NSTableView row selection driven by a data source: multiple
+   selection, isRowSelected:, selectedRow, deselectRow: and deselectAll:. Every
+   assertion matches AppKit (checked on a macOS runner) and passes on
+   unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSIndexSet.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTableView.h>
+#include <AppKit/NSTableColumn.h>
+
+@interface TVDS : NSObject
+@end
+@implementation TVDS
+- (NSInteger) numberOfRowsInTableView: (NSTableView *)tv { return 5; }
+- (id) tableView: (NSTableView *)tv
+       objectValueForTableColumn: (NSTableColumn *)col
+       row: (NSInteger)row
+{ return [NSString stringWithFormat: @"r%ld", (long)row]; }
+@end
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTableView *tv;
+  TVDS *ds;
+  NSTableColumn *col;
+
+  START_SET("NSTableView selection")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tv = AUTORELEASE([[NSTableView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+      col = AUTORELEASE([[NSTableColumn alloc] initWithIdentifier: @"a"]);
+      [col setWidth: 50.0];
+      [tv addTableColumn: col];
+      ds = AUTORELEASE([TVDS new]);
+      [tv setDataSource: ds];
+      [tv reloadData];
+      pass([tv numberOfRows] == 5, "the data source drives numberOfRows");
+
+      [tv setAllowsMultipleSelection: YES];
+      [tv selectRowIndexes: [NSIndexSet indexSetWithIndex: 1]
+        byExtendingSelection: NO];
+      [tv selectRowIndexes: [NSIndexSet indexSetWithIndex: 3]
+        byExtendingSelection: YES];
+      pass([tv numberOfSelectedRows] == 2, "two rows are selected");
+      pass([tv isRowSelected: 1] == YES, "row 1 is selected");
+      pass([tv isRowSelected: 0] == NO, "row 0 is not selected");
+      pass([tv selectedRow] == 3, "selectedRow is the last selected row");
+
+      [tv deselectRow: 1];
+      pass([tv isRowSelected: 1] == NO, "deselectRow: clears that row");
+      pass([tv numberOfSelectedRows] == 1, "one row remains selected");
+
+      [tv deselectAll: nil];
+      pass([tv numberOfSelectedRows] == 0, "deselectAll: clears the selection");
+      pass([tv selectedRow] == -1, "selectedRow is -1 after deselectAll:");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTableView selection")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTableView/state.m
+++ b/Tests/gui/NSTableView/state.m
@@ -1,0 +1,81 @@
+/* Coverage for NSTableView scalar state: the selection and column flag
+   defaults, the header/corner/colour accessors, and the setter round-trips.
+   Machine dependent geometry (rowHeight, intercellSpacing) is not asserted for
+   its value, only that it round-trips. Checked against AppKit on a macOS
+   runner; all pass on unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSColor.h>
+#include <AppKit/NSTableView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTableView *tv;
+
+  START_SET("NSTableView state")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tv = AUTORELEASE([[NSTableView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+
+      pass([tv allowsColumnReordering] == YES,
+           "columns are reorderable by default");
+      pass([tv allowsColumnResizing] == YES,
+           "columns are resizable by default");
+      pass([tv allowsMultipleSelection] == NO,
+           "multiple selection is off by default");
+      pass([tv allowsEmptySelection] == YES,
+           "empty selection is allowed by default");
+      pass([tv usesAlternatingRowBackgroundColors] == NO,
+           "alternating row colours are off by default");
+      pass([tv headerView] != nil, "a table has a header view");
+      pass([tv cornerView] != nil, "a table has a corner view");
+      pass([tv backgroundColor] != nil, "a table has a background colour");
+      pass([tv gridColor] != nil, "a table has a grid colour");
+      pass([tv numberOfColumns] == 0, "a new table has no columns");
+      pass([tv numberOfRows] == 0, "a new table with no data source has no rows");
+      pass([tv selectedRow] == -1, "no row is selected by default");
+      pass([tv selectedColumn] == -1, "no column is selected by default");
+      pass([tv numberOfSelectedRows] == 0, "no rows are selected by default");
+
+      /* round-trips */
+      [tv setRowHeight: 24.0];
+      pass([tv rowHeight] == 24.0, "rowHeight round-trips");
+      [tv setAllowsMultipleSelection: YES];
+      pass([tv allowsMultipleSelection] == YES,
+           "allowsMultipleSelection round-trips");
+      [tv setUsesAlternatingRowBackgroundColors: YES];
+      pass([tv usesAlternatingRowBackgroundColors] == YES,
+           "usesAlternatingRowBackgroundColors round-trips");
+      [tv setBackgroundColor: [NSColor redColor]];
+      pass([[tv backgroundColor] isEqual: [NSColor redColor]],
+           "backgroundColor round-trips");
+      [tv setIntercellSpacing: NSMakeSize(4, 6)];
+      {
+        NSSize s = [tv intercellSpacing];
+        pass(s.width == 4 && s.height == 6, "intercellSpacing round-trips");
+      }
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTableView state")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for NSTableView covering the scalar state defaults and round-trips, column management (add, identifier lookup, back-pointer, move, remove), data-source-driven row selection (multiple selection, isRowSelected:, selectedRow, deselect), and a render regression lock. Machine dependent geometry (rowHeight, intercellSpacing values and the derived rects) is not asserted. The assertions were checked against AppKit.