### PR TITLE
Fix: NSTableView disallows column selection by default

### DIFF
--- a/Source/NSTableView.m
+++ b/Source/NSTableView.m
@@ -2052,7 +2052,7 @@ static void computeNewSelection
   ASSIGN(_selectedRows, [NSMutableIndexSet indexSet]);
   _allowsEmptySelection = YES;
   _allowsMultipleSelection = NO;
-  _allowsColumnSelection = YES;
+  _allowsColumnSelection = NO;
   _allowsColumnResizing = YES;
   _allowsColumnReordering = YES;
   _autoresizesAllColumnsToFit = NO;

--- a/Tests/gui/NSTableView/columnSelectionDefault.m
+++ b/Tests/gui/NSTableView/columnSelectionDefault.m
@@ -1,0 +1,45 @@
+/* A new NSTableView does not allow column selection, as AppKit does. It
+   round-trips once set. Checked against AppKit on a macOS runner. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTableView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTableView *tv;
+
+  START_SET("NSTableView columnSelectionDefault")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tv = AUTORELEASE([[NSTableView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+      pass([tv allowsColumnSelection] == NO,
+           "a new table does not allow column selection");
+
+      [tv setAllowsColumnSelection: YES];
+      pass([tv allowsColumnSelection] == YES,
+           "allowsColumnSelection round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTableView columnSelectionDefault")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A new NSTableView set allowsColumnSelection to YES, but AppKit defaults it to NO. Set it to NO in the initializer defaults. Adds a test.