### PR TITLE
tests: add NSOutlineView tests

### DIFF
--- a/Tests/gui/NSOutlineView/rendering.m
+++ b/Tests/gui/NSOutlineView/rendering.m
@@ -1,0 +1,86 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSGeometry.h>
+#import <Foundation/NSString.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSOutlineView.h>
+#import <AppKit/NSTableColumn.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+@interface RTree : NSObject
+@end
+@implementation RTree
+- (NSArray *) childrenOf: (id)item
+{
+  if (item == nil) return [NSArray arrayWithObjects: @"A", @"B", nil];
+  if ([item isEqual: @"A"]) return [NSArray arrayWithObjects: @"A1", nil];
+  return [NSArray array];
+}
+- (NSInteger) outlineView: (NSOutlineView *)ov numberOfChildrenOfItem: (id)item
+{ return [[self childrenOf: item] count]; }
+- (id) outlineView: (NSOutlineView *)ov child: (NSInteger)i ofItem: (id)item
+{ return [[self childrenOf: item] objectAtIndex: i]; }
+- (BOOL) outlineView: (NSOutlineView *)ov isItemExpandable: (id)item
+{ return [[self childrenOf: item] count] > 0; }
+- (id) outlineView: (NSOutlineView *)ov
+       objectValueForTableColumn: (NSTableColumn *)col
+       byItem: (id)item
+{ return item; }
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSOutlineView rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 120, 80)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSOutlineView *ov = AUTORELEASE([[NSOutlineView alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 80)]);
+      NSTableColumn *col = AUTORELEASE([[NSTableColumn alloc]
+        initWithIdentifier: @"c"]);
+      [col setWidth: 100.0];
+      [ov addTableColumn: col];
+      [ov setOutlineTableColumn: col];
+      [ov setDataSource: AUTORELEASE([RTree new])];
+      [ov reloadData];
+      [ov expandItem: @"A"];
+      [w setContentView: ov];
+
+      /* The outline draws its rows and disclosure markers without error and
+         produces a bitmap of its own size (a render regression lock, not a
+         pixel comparison against AppKit). */
+      [ov lockFocus];
+      [ov drawRect: [ov bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 120, 80)]);
+      [ov unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 120 && [rep pixelsHigh] == 80,
+        "an outline view renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSOutlineView rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSOutlineView/state.m
+++ b/Tests/gui/NSOutlineView/state.m
@@ -1,0 +1,58 @@
+/* Coverage for NSOutlineView scalar state: the indentation-marker, autosave
+   and outline-column defaults, and the indentation / marker / autosave
+   round-trips. The indentationPerLevel default value is theme dependent and is
+   only round-tripped. Checked against AppKit on a macOS runner; all pass on
+   unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSOutlineView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSOutlineView *ov;
+
+  START_SET("NSOutlineView state")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      ov = AUTORELEASE([[NSOutlineView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+
+      pass([ov indentationMarkerFollowsCell] == YES,
+           "the indentation marker follows the cell by default");
+      pass([ov autosaveExpandedItems] == NO,
+           "expanded items are not autosaved by default");
+      pass([ov outlineTableColumn] == nil,
+           "the outline table column is nil by default");
+
+      [ov setIndentationPerLevel: 24.0];
+      pass([ov indentationPerLevel] == 24.0, "indentationPerLevel round-trips");
+      [ov setIndentationMarkerFollowsCell: NO];
+      pass([ov indentationMarkerFollowsCell] == NO,
+           "indentationMarkerFollowsCell round-trips");
+      [ov setAutosaveExpandedItems: YES];
+      pass([ov autosaveExpandedItems] == YES,
+           "autosaveExpandedItems round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSOutlineView state")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSOutlineView/tree.m
+++ b/Tests/gui/NSOutlineView/tree.m
@@ -1,0 +1,98 @@
+/* Coverage for NSOutlineView's item tree: expand and collapse, the row/item
+   mapping, levels and parent, driven by a small tree data source. Every
+   assertion matches AppKit (checked on a macOS runner) and passes on
+   unmodified GNUstep.
+
+   Tree: root has A and B; A has A1 and A2; B and the leaves have no children. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSOutlineView.h>
+#include <AppKit/NSTableColumn.h>
+
+@interface Tree : NSObject
+@end
+@implementation Tree
+- (NSArray *) childrenOf: (id)item
+{
+  if (item == nil) return [NSArray arrayWithObjects: @"A", @"B", nil];
+  if ([item isEqual: @"A"]) return [NSArray arrayWithObjects: @"A1", @"A2", nil];
+  return [NSArray array];
+}
+- (NSInteger) outlineView: (NSOutlineView *)ov numberOfChildrenOfItem: (id)item
+{ return [[self childrenOf: item] count]; }
+- (id) outlineView: (NSOutlineView *)ov child: (NSInteger)i ofItem: (id)item
+{ return [[self childrenOf: item] objectAtIndex: i]; }
+- (BOOL) outlineView: (NSOutlineView *)ov isItemExpandable: (id)item
+{ return [[self childrenOf: item] count] > 0; }
+- (id) outlineView: (NSOutlineView *)ov
+       objectValueForTableColumn: (NSTableColumn *)col
+       byItem: (id)item
+{ return item; }
+@end
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSOutlineView *ov;
+  NSTableColumn *col;
+  Tree *ds;
+
+  START_SET("NSOutlineView tree")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      ov = AUTORELEASE([[NSOutlineView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+      col = AUTORELEASE([[NSTableColumn alloc] initWithIdentifier: @"c"]);
+      [col setWidth: 100.0];
+      [ov addTableColumn: col];
+      [ov setOutlineTableColumn: col];
+      pass([ov outlineTableColumn] == col, "outlineTableColumn round-trips");
+      ds = AUTORELEASE([Tree new]);
+      [ov setDataSource: ds];
+      [ov reloadData];
+
+      pass([ov numberOfRows] == 2, "a collapsed tree shows its two roots");
+      pass([ov isExpandable: @"A"] == YES, "A is expandable");
+      pass([ov isExpandable: @"B"] == NO, "B is not expandable");
+      pass([ov isItemExpanded: @"A"] == NO, "A is collapsed to start");
+      pass([[ov itemAtRow: 0] isEqual: @"A"], "row 0 is A");
+      pass([ov rowForItem: @"B"] == 1, "B is at row 1 while collapsed");
+      pass([ov levelForRow: 0] == 0, "a root is at level 0");
+
+      [ov expandItem: @"A"];
+      pass([ov numberOfRows] == 4, "expanding A reveals its two children");
+      pass([ov isItemExpanded: @"A"] == YES, "A is expanded");
+      pass([[ov itemAtRow: 1] isEqual: @"A1"], "row 1 is A1 after expanding");
+      pass([ov levelForItem: @"A1"] == 1, "A1 is at level 1");
+      pass([ov levelForRow: 1] == 1, "row 1 is at level 1");
+      pass([[ov parentForItem: @"A1"] isEqual: @"A"], "A1's parent is A");
+      pass([ov rowForItem: @"B"] == 3, "B moves to row 3 after expanding A");
+
+      [ov collapseItem: @"A"];
+      pass([ov numberOfRows] == 2, "collapsing A hides its children");
+      pass([ov isItemExpanded: @"A"] == NO, "A is collapsed again");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSOutlineView tree")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for NSOutlineView covering the indentation-marker, autosave and outline-column state defaults and round-trips, the item tree (expand, collapse, itemAtRow, rowForItem, levelForRow, levelForItem, parentForItem, isExpandable, isItemExpanded) driven by a tree data source, and a render regression lock. The indentationPerLevel default value is theme dependent and is only round-tripped. The assertions were checked against AppKit.