### PR TITLE
Fix: NSOutlineView autoresizesOutlineColumn default and accessor name

### DIFF
--- a/Headers/AppKit/NSOutlineView.h
+++ b/Headers/AppKit/NSOutlineView.h
@@ -54,6 +54,7 @@ APPKIT_EXPORT_CLASS
 
 // Instance methods
 - (BOOL) autoResizesOutlineColumn;
+- (BOOL) autoresizesOutlineColumn;
 - (BOOL) autosaveExpandedItems;
 - (void) collapseItem: (id)item;
 - (void) collapseItem: (id)item collapseChildren: (BOOL)collapseChildren;

--- a/Source/NSOutlineView.m
+++ b/Source/NSOutlineView.m
@@ -256,6 +256,11 @@ static NSImage *unexpandable  = nil;
   return _autoResizesOutlineColumn;
 }
 
+- (BOOL) autoresizesOutlineColumn
+{
+  return _autoResizesOutlineColumn;
+}
+
 /**
  * Causes the outline column, the column containing the expand/collapse
  * gadget, to resize based on the amount of space needed by widest content.
@@ -2146,7 +2151,7 @@ Also returns the child index relative to this parent. */
 				   64);
 
   _indentationMarkerFollowsCell = YES;
-  _autoResizesOutlineColumn = NO;
+  _autoResizesOutlineColumn = YES;
   _autosaveExpandedItems = NO;
   _indentationPerLevel = 10.0;
 }

--- a/Tests/gui/NSOutlineView/autoresizesOutlineColumnDefault.m
+++ b/Tests/gui/NSOutlineView/autoresizesOutlineColumnDefault.m
@@ -1,0 +1,45 @@
+/* A new NSOutlineView autoresizes its outline column, as AppKit does. It
+   round-trips once set. Checked against AppKit on a macOS runner. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSOutlineView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSOutlineView *ov;
+
+  START_SET("NSOutlineView autoresizesOutlineColumnDefault")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      ov = AUTORELEASE([[NSOutlineView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+      pass([ov autoresizesOutlineColumn] == YES,
+           "a new outline view autoresizes its outline column");
+
+      [ov setAutoresizesOutlineColumn: NO];
+      pass([ov autoresizesOutlineColumn] == NO,
+           "autoresizesOutlineColumn round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSOutlineView autoresizesOutlineColumnDefault")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Two issues with the outline-column autoresizing property. The default was NO, but AppKit autoresizes the outline column by default (YES). The getter was also named -autoResizesOutlineColumn, which matches neither AppKit nor the -setAutoresizesOutlineColumn: setter, so AppKit-compatible code calling -autoresizesOutlineColumn did not compile. Set the default to YES and add the AppKit-spelled getter (the old name is kept). Adds a test.