### PR TITLE
Fix: NSWindow cascade offset uses the theme title bar height

### DIFF
--- a/Source/NSWindow.m
+++ b/Source/NSWindow.m
@@ -2087,8 +2087,7 @@ titleWithRepresentedFilename(NSString *representedFilename)
 
   /* The next window in a cascade is offset down and to the right by the
      height of a standard title bar. */
-  delta = [NSWindow frameRectForContentRect: NSMakeRect(0, 0, 100, 100)
-                                  styleMask: NSTitledWindowMask].size.height - 100.0;
+  delta = [[GSTheme theme] titlebarHeight];
   topLeftPoint.x += delta;
   topLeftPoint.y -= delta;
 


### PR DESCRIPTION
cascadeTopLeftFromPoint: derived its offset from +frameRectForContentRect:styleMask:, which adds a title bar only when the backend draws client-side decorations. With server-side decorations that delta is zero, so the window did not cascade at all. Use the theme's titlebarHeight directly, which is the same value with client-side decorations and non-zero regardless of the decoration mode. This is what the headless test run in the cairo CI lane needs.