### PR TITLE
tests: add NSMatrix state, radio and rendering tests

### DIFF
--- a/Tests/gui/NSMatrix/radio.m
+++ b/Tests/gui/NSMatrix/radio.m
@@ -37,20 +37,20 @@ int main()
          numberOfRows: 2
       numberOfColumns: 2]);
 
-      pass([r numberOfRows] == 2, "the matrix has two rows");
-      pass([r numberOfColumns] == 2, "the matrix has two columns");
+      PASS([r numberOfRows] == 2, "the matrix has two rows");
+      PASS([r numberOfColumns] == 2, "the matrix has two columns");
 
       [r selectCellAtRow: 0 column: 0];
-      pass([r selectedRow] == 0, "selectedRow is 0 after selecting (0,0)");
-      pass([r selectedColumn] == 0, "selectedColumn is 0 after selecting (0,0)");
-      pass([r selectedCell] != nil, "there is a selected cell");
+      PASS([r selectedRow] == 0, "selectedRow is 0 after selecting (0,0)");
+      PASS([r selectedColumn] == 0, "selectedColumn is 0 after selecting (0,0)");
+      PASS([r selectedCell] != nil, "there is a selected cell");
 
       [r selectCellAtRow: 1 column: 1];
-      pass([r selectedRow] == 1, "selectedRow follows to 1");
-      pass([r selectedColumn] == 1, "selectedColumn follows to 1");
-      pass([[r cellAtRow: 0 column: 0] state] == NSOffState,
+      PASS([r selectedRow] == 1, "selectedRow follows to 1");
+      PASS([r selectedColumn] == 1, "selectedColumn follows to 1");
+      PASS([[r cellAtRow: 0 column: 0] state] == NSOffState,
            "radio mode turns the previously selected cell off");
-      pass([[r cellAtRow: 1 column: 1] state] == NSOnState,
+      PASS([[r cellAtRow: 1 column: 1] state] == NSOnState,
            "the newly selected cell is on");
 
       /* geometry from an explicit cell size and zero intercell spacing */
@@ -59,9 +59,9 @@ int main()
       {
         NSRect f00 = [r cellFrameAtRow: 0 column: 0];
         NSRect f11 = [r cellFrameAtRow: 1 column: 1];
-        pass(NSEqualRects(f00, NSMakeRect(0, 0, 40, 20)),
+        PASS(NSEqualRects(f00, NSMakeRect(0, 0, 40, 20)),
              "cellFrameAtRow:0 column:0 is the first cell rect");
-        pass(NSEqualRects(f11, NSMakeRect(40, 20, 40, 20)),
+        PASS(NSEqualRects(f11, NSMakeRect(40, 20, 40, 20)),
              "cellFrameAtRow:1 column:1 is offset by the cell size");
       }
     }

--- a/Tests/gui/NSMatrix/radio.m
+++ b/Tests/gui/NSMatrix/radio.m
@@ -1,0 +1,78 @@
+/* Coverage for NSMatrix radio-mode single selection and cell geometry:
+   selecting one cell turns the previously selected one off, selectedRow /
+   selectedColumn track the selection, and cellFrameAtRow:column: follows the
+   cell size and intercell spacing. Every assertion matches AppKit (checked on
+   a macOS runner) and passes on unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSMatrix.h>
+#include <AppKit/NSButtonCell.h>
+#include <AppKit/NSCell.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSMatrix *r;
+  NSButtonCell *proto;
+
+  START_SET("NSMatrix radio")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      proto = AUTORELEASE([[NSButtonCell alloc] init]);
+      r = AUTORELEASE([[NSMatrix alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)
+                 mode: NSRadioModeMatrix
+            prototype: proto
+         numberOfRows: 2
+      numberOfColumns: 2]);
+
+      pass([r numberOfRows] == 2, "the matrix has two rows");
+      pass([r numberOfColumns] == 2, "the matrix has two columns");
+
+      [r selectCellAtRow: 0 column: 0];
+      pass([r selectedRow] == 0, "selectedRow is 0 after selecting (0,0)");
+      pass([r selectedColumn] == 0, "selectedColumn is 0 after selecting (0,0)");
+      pass([r selectedCell] != nil, "there is a selected cell");
+
+      [r selectCellAtRow: 1 column: 1];
+      pass([r selectedRow] == 1, "selectedRow follows to 1");
+      pass([r selectedColumn] == 1, "selectedColumn follows to 1");
+      pass([[r cellAtRow: 0 column: 0] state] == NSOffState,
+           "radio mode turns the previously selected cell off");
+      pass([[r cellAtRow: 1 column: 1] state] == NSOnState,
+           "the newly selected cell is on");
+
+      /* geometry from an explicit cell size and zero intercell spacing */
+      [r setIntercellSpacing: NSMakeSize(0, 0)];
+      [r setCellSize: NSMakeSize(40, 20)];
+      {
+        NSRect f00 = [r cellFrameAtRow: 0 column: 0];
+        NSRect f11 = [r cellFrameAtRow: 1 column: 1];
+        pass(NSEqualRects(f00, NSMakeRect(0, 0, 40, 20)),
+             "cellFrameAtRow:0 column:0 is the first cell rect");
+        pass(NSEqualRects(f11, NSMakeRect(40, 20, 40, 20)),
+             "cellFrameAtRow:1 column:1 is offset by the cell size");
+      }
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSMatrix radio")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSMatrix/rendering.m
+++ b/Tests/gui/NSMatrix/rendering.m
@@ -1,0 +1,60 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSMatrix.h>
+#import <AppKit/NSButtonCell.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSMatrix rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 100, 60)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSButtonCell *proto = AUTORELEASE([[NSButtonCell alloc] init]);
+      NSMatrix *m = AUTORELEASE([[NSMatrix alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 60)
+                 mode: NSRadioModeMatrix
+            prototype: proto
+         numberOfRows: 2
+      numberOfColumns: 2]);
+      [w setContentView: m];
+
+      /* The matrix draws its cells without error and produces a bitmap of its
+         own size (a render regression lock, not a pixel comparison against
+         AppKit). */
+      [m lockFocus];
+      [m drawRect: [m bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 100, 60)]);
+      [m unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 100 && [rep pixelsHigh] == 60,
+        "a matrix renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSMatrix rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSMatrix/state.m
+++ b/Tests/gui/NSMatrix/state.m
@@ -1,0 +1,72 @@
+/* Coverage for NSMatrix scalar state: the intercell spacing, background and
+   selection-by-rect defaults and their round-trips, plus the empty counts and
+   no-selection start. Checked against AppKit on a macOS runner; the passing
+   assertions hold on unmodified GNUstep. The PROBE lines report the AppKit
+   defaults that may diverge on GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSMatrix.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSMatrix *m;
+
+  START_SET("NSMatrix state")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      m = AUTORELEASE([[NSMatrix alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+
+      /* matching defaults */
+      pass([m mode] == NSRadioModeMatrix, "the default mode is radio");
+      {
+        NSSize s = [m intercellSpacing];
+        pass(s.width == 1 && s.height == 1, "the default intercell spacing is 1x1");
+      }
+      pass([m drawsBackground] == NO, "a matrix does not draw its background by default");
+      pass([m drawsCellBackground] == NO,
+           "a matrix does not draw its cell background by default");
+      pass([m isSelectionByRect] == YES, "selection by rect is on by default");
+      pass([m numberOfRows] == 0, "a new matrix has no rows");
+      pass([m numberOfColumns] == 0, "a new matrix has no columns");
+      pass([m selectedRow] == -1, "no row is selected by default");
+      pass([m selectedColumn] == -1, "no column is selected by default");
+      pass([m allowsEmptySelection] == NO,
+           "empty selection is not allowed by default");
+
+      /* round-trips */
+      [m setMode: NSListModeMatrix];
+      pass([m mode] == NSListModeMatrix, "mode round-trips");
+      [m setSelectionByRect: NO];
+      pass([m isSelectionByRect] == NO, "selectionByRect round-trips");
+      [m setDrawsBackground: YES];
+      pass([m drawsBackground] == YES, "drawsBackground round-trips");
+      [m setIntercellSpacing: NSMakeSize(4, 6)];
+      {
+        NSSize s = [m intercellSpacing];
+        pass(s.width == 4 && s.height == 6, "intercellSpacing round-trips");
+      }
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSMatrix state")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSMatrix/state.m
+++ b/Tests/gui/NSMatrix/state.m
@@ -30,33 +30,33 @@ int main()
         initWithFrame: NSMakeRect(0, 0, 100, 100)]);
 
       /* matching defaults */
-      pass([m mode] == NSRadioModeMatrix, "the default mode is radio");
+      PASS([m mode] == NSRadioModeMatrix, "the default mode is radio");
       {
         NSSize s = [m intercellSpacing];
-        pass(s.width == 1 && s.height == 1, "the default intercell spacing is 1x1");
+        PASS(s.width == 1 && s.height == 1, "the default intercell spacing is 1x1");
       }
-      pass([m drawsBackground] == NO, "a matrix does not draw its background by default");
-      pass([m drawsCellBackground] == NO,
+      PASS([m drawsBackground] == NO, "a matrix does not draw its background by default");
+      PASS([m drawsCellBackground] == NO,
            "a matrix does not draw its cell background by default");
-      pass([m isSelectionByRect] == YES, "selection by rect is on by default");
-      pass([m numberOfRows] == 0, "a new matrix has no rows");
-      pass([m numberOfColumns] == 0, "a new matrix has no columns");
-      pass([m selectedRow] == -1, "no row is selected by default");
-      pass([m selectedColumn] == -1, "no column is selected by default");
-      pass([m allowsEmptySelection] == NO,
+      PASS([m isSelectionByRect] == YES, "selection by rect is on by default");
+      PASS([m numberOfRows] == 0, "a new matrix has no rows");
+      PASS([m numberOfColumns] == 0, "a new matrix has no columns");
+      PASS([m selectedRow] == -1, "no row is selected by default");
+      PASS([m selectedColumn] == -1, "no column is selected by default");
+      PASS([m allowsEmptySelection] == NO,
            "empty selection is not allowed by default");
 
       /* round-trips */
       [m setMode: NSListModeMatrix];
-      pass([m mode] == NSListModeMatrix, "mode round-trips");
+      PASS([m mode] == NSListModeMatrix, "mode round-trips");
       [m setSelectionByRect: NO];
-      pass([m isSelectionByRect] == NO, "selectionByRect round-trips");
+      PASS([m isSelectionByRect] == NO, "selectionByRect round-trips");
       [m setDrawsBackground: YES];
-      pass([m drawsBackground] == YES, "drawsBackground round-trips");
+      PASS([m drawsBackground] == YES, "drawsBackground round-trips");
       [m setIntercellSpacing: NSMakeSize(4, 6)];
       {
         NSSize s = [m intercellSpacing];
-        pass(s.width == 4 && s.height == 6, "intercellSpacing round-trips");
+        PASS(s.width == 4 && s.height == 6, "intercellSpacing round-trips");
       }
     }
   NS_HANDLER


### PR DESCRIPTION
Adds tests filling gaps in the existing NSMatrix coverage: the intercell spacing, background and selection-by-rect scalar defaults and round-trips, radio-mode single selection with selectedRow/selectedColumn and cell state, cell geometry from an explicit cell size, and a render regression lock. The assertions were checked against AppKit.