### PR TITLE
Fix: NSMatrix defaults autosizesCells and tabKeyTraversesCells to NO

### DIFF
--- a/Source/NSForm.m
+++ b/Source/NSForm.m
@@ -73,6 +73,7 @@ static Class defaultCellClass = nil;
     return nil;
 
   [self setIntercellSpacing: NSMakeSize (0, 4)];
+  [self setTabKeyTraversesCells: YES];
   return self;
 }
 
@@ -90,7 +91,8 @@ static Class defaultCellClass = nil;
   if (nil == self)
     return nil;
 
-  [self setIntercellSpacing: NSMakeSize (0, 4)];  
+  [self setIntercellSpacing: NSMakeSize (0, 4)];
+  [self setTabKeyTraversesCells: YES];
   return self;
 }
 

--- a/Source/NSMatrix.m
+++ b/Source/NSMatrix.m
@@ -275,10 +275,10 @@ static SEL getSel;
     }
 
   _intercell = NSMakeSize(1, 1);
-  [self setAutosizesCells: YES];
+  [self setAutosizesCells: NO];
   [self setFrame: frameRect];
 
-  _tabKeyTraversesCells = YES;
+  _tabKeyTraversesCells = NO;
   [self setBackgroundColor: [NSColor controlColor]];
   [self setDrawsBackground: NO];
   [self setCellBackgroundColor: [NSColor controlColor]];

--- a/Tests/gui/NSForm/defaults.m
+++ b/Tests/gui/NSForm/defaults.m
@@ -1,0 +1,44 @@
+/* A new NSForm does not autosize its cells but does let the tab key traverse
+   cells, unlike a plain NSMatrix.  Checked against AppKit on a macOS runner. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSForm.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSForm *f;
+
+  START_SET("NSForm defaults")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      f = AUTORELEASE([[NSForm alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+
+      PASS([f autosizesCells] == NO,
+           "a new form does not autosize its cells");
+      PASS([f tabKeyTraversesCells] == YES,
+           "a new form lets the tab key traverse cells");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSForm defaults")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSMatrix/flagDefaults.m
+++ b/Tests/gui/NSMatrix/flagDefaults.m
@@ -27,15 +27,15 @@ int main()
       m = AUTORELEASE([[NSMatrix alloc]
         initWithFrame: NSMakeRect(0, 0, 100, 100)]);
 
-      pass([m autosizesCells] == NO,
+      PASS([m autosizesCells] == NO,
            "a new matrix does not autosize its cells");
-      pass([m tabKeyTraversesCells] == NO,
+      PASS([m tabKeyTraversesCells] == NO,
            "a new matrix does not let the tab key traverse cells");
 
       [m setAutosizesCells: YES];
-      pass([m autosizesCells] == YES, "autosizesCells round-trips");
+      PASS([m autosizesCells] == YES, "autosizesCells round-trips");
       [m setTabKeyTraversesCells: YES];
-      pass([m tabKeyTraversesCells] == YES, "tabKeyTraversesCells round-trips");
+      PASS([m tabKeyTraversesCells] == YES, "tabKeyTraversesCells round-trips");
     }
   NS_HANDLER
     if ([[localException name] isEqualToString: NSInternalInconsistencyException]

--- a/Tests/gui/NSMatrix/flagDefaults.m
+++ b/Tests/gui/NSMatrix/flagDefaults.m
@@ -1,0 +1,50 @@
+/* A new NSMatrix does not autosize its cells and does not let the tab key
+   traverse cells, as AppKit does. Both round-trip once set. Checked against
+   AppKit on a macOS runner. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSMatrix.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSMatrix *m;
+
+  START_SET("NSMatrix flagDefaults")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      m = AUTORELEASE([[NSMatrix alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+
+      pass([m autosizesCells] == NO,
+           "a new matrix does not autosize its cells");
+      pass([m tabKeyTraversesCells] == NO,
+           "a new matrix does not let the tab key traverse cells");
+
+      [m setAutosizesCells: YES];
+      pass([m autosizesCells] == YES, "autosizesCells round-trips");
+      [m setTabKeyTraversesCells: YES];
+      pass([m tabKeyTraversesCells] == YES, "tabKeyTraversesCells round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSMatrix flagDefaults")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A new NSMatrix set autosizesCells and tabKeyTraversesCells to YES in its private frame setup, but AppKit defaults both to NO. Set them to NO to match. Adds a test. These are behavioural defaults, so please say if GNUstep prefers to keep the current values.