### PR TITLE
Fix: NSMatrix stores a tool tip per cell

### DIFF
--- a/Headers/AppKit/NSMatrix.h
+++ b/Headers/AppKit/NSMatrix.h
@@ -87,7 +87,7 @@ APPKIT_EXPORT_CLASS
   BOOL		_drawsCellBackground;
   BOOL		_autosizesCells;
   BOOL		_autoscroll;
-  id            _reserved1;
+  id            _tooltipMap;
   NSInteger	_dottedRow;
   NSInteger	_dottedColumn;
 }

--- a/Source/NSMatrix.m
+++ b/Source/NSMatrix.m
@@ -62,6 +62,7 @@
 #import <Foundation/NSKeyValueCoding.h>
 #import <Foundation/NSKeyValueObserving.h>
 #import <Foundation/NSNotification.h>
+#import <Foundation/NSMapTable.h>
 #import <Foundation/NSFormatter.h>
 #import <Foundation/NSDebug.h>
 #import <Foundation/NSString.h>
@@ -373,6 +374,7 @@ static SEL getSel;
   [_cellPrototype release];
   [_backgroundColor release];
   [_cellBackgroundColor release];
+  [_reserved1 release];
 
   if (_delegate != nil)
     {
@@ -2684,13 +2686,28 @@ static SEL getSel;
 
 - (NSString*) toolTipForCell: (NSCell*)cell
 {
-  // FIXME
-  return @"";
+  return [(NSMapTable *)_reserved1 objectForKey: cell];
 }
 
 - (void) setToolTip: (NSString*)toolTipString forCell: (NSCell*)cell
 {
-  // FIXME
+  if (_reserved1 == nil)
+    {
+      _reserved1 = [[NSMapTable alloc]
+        initWithKeyOptions: NSPointerFunctionsWeakMemory
+                              | NSPointerFunctionsObjectPointerPersonality
+              valueOptions: NSPointerFunctionsStrongMemory
+                              | NSPointerFunctionsObjectPersonality
+                  capacity: 4];
+    }
+  if (toolTipString == nil)
+    {
+      [(NSMapTable *)_reserved1 removeObjectForKey: cell];
+    }
+  else
+    {
+      [(NSMapTable *)_reserved1 setObject: toolTipString forKey: cell];
+    }
 }
 
 - (void) encodeWithCoder: (NSCoder*)aCoder

--- a/Source/NSMatrix.m
+++ b/Source/NSMatrix.m
@@ -374,7 +374,7 @@ static SEL getSel;
   [_cellPrototype release];
   [_backgroundColor release];
   [_cellBackgroundColor release];
-  [_reserved1 release];
+  [_tooltipMap release];
 
   if (_delegate != nil)
     {
@@ -2686,14 +2686,14 @@ static SEL getSel;
 
 - (NSString*) toolTipForCell: (NSCell*)cell
 {
-  return [(NSMapTable *)_reserved1 objectForKey: cell];
+  return [(NSMapTable *)_tooltipMap objectForKey: cell];
 }
 
 - (void) setToolTip: (NSString*)toolTipString forCell: (NSCell*)cell
 {
-  if (_reserved1 == nil)
+  if (_tooltipMap == nil)
     {
-      _reserved1 = [[NSMapTable alloc]
+      _tooltipMap = [[NSMapTable alloc]
         initWithKeyOptions: NSPointerFunctionsWeakMemory
                               | NSPointerFunctionsObjectPointerPersonality
               valueOptions: NSPointerFunctionsStrongMemory
@@ -2702,11 +2702,11 @@ static SEL getSel;
     }
   if (toolTipString == nil)
     {
-      [(NSMapTable *)_reserved1 removeObjectForKey: cell];
+      [(NSMapTable *)_tooltipMap removeObjectForKey: cell];
     }
   else
     {
-      [(NSMapTable *)_reserved1 setObject: toolTipString forKey: cell];
+      [(NSMapTable *)_tooltipMap setObject: toolTipString forKey: cell];
     }
 }
 

--- a/Tests/gui/NSMatrix/toolTips.m
+++ b/Tests/gui/NSMatrix/toolTips.m
@@ -36,17 +36,17 @@ int main()
       c0 = [m cellAtRow: 0 column: 0];
       c1 = [m cellAtRow: 0 column: 1];
 
-      pass([m toolTipForCell: c0] == nil,
+      PASS([m toolTipForCell: c0] == nil,
            "a cell with no tool tip returns nil");
 
       [m setToolTip: @"hello" forCell: c0];
-      pass([[m toolTipForCell: c0] isEqualToString: @"hello"],
+      PASS([[m toolTipForCell: c0] isEqualToString: @"hello"],
            "setToolTip:forCell: records the tool tip");
-      pass([m toolTipForCell: c1] == nil,
+      PASS([m toolTipForCell: c1] == nil,
            "another cell still has no tool tip");
 
       [m setToolTip: nil forCell: c0];
-      pass([m toolTipForCell: c0] == nil, "a nil tool tip clears the cell");
+      PASS([m toolTipForCell: c0] == nil, "a nil tool tip clears the cell");
     }
   NS_HANDLER
     if ([[localException name] isEqualToString: NSInternalInconsistencyException]

--- a/Tests/gui/NSMatrix/toolTips.m
+++ b/Tests/gui/NSMatrix/toolTips.m
@@ -1,0 +1,61 @@
+/* NSMatrix stores a tool tip per cell: -setToolTip:forCell: records it,
+   -toolTipForCell: returns it (nil when none is set), and a nil tool tip
+   clears it. Checked against AppKit on a macOS runner. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSMatrix.h>
+#include <AppKit/NSCell.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSMatrix *m;
+  NSCell *c0, *c1;
+
+  START_SET("NSMatrix toolTips")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      m = AUTORELEASE([[NSMatrix alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 100)
+                 mode: NSListModeMatrix
+            prototype: AUTORELEASE([[NSCell alloc] initTextCell: @"x"])
+         numberOfRows: 1
+      numberOfColumns: 2]);
+      c0 = [m cellAtRow: 0 column: 0];
+      c1 = [m cellAtRow: 0 column: 1];
+
+      pass([m toolTipForCell: c0] == nil,
+           "a cell with no tool tip returns nil");
+
+      [m setToolTip: @"hello" forCell: c0];
+      pass([[m toolTipForCell: c0] isEqualToString: @"hello"],
+           "setToolTip:forCell: records the tool tip");
+      pass([m toolTipForCell: c1] == nil,
+           "another cell still has no tool tip");
+
+      [m setToolTip: nil forCell: c0];
+      pass([m toolTipForCell: c0] == nil, "a nil tool tip clears the cell");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSMatrix toolTips")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-toolTipForCell: returned an empty string and -setToolTip:forCell: was a no-op. Store the tool tips in a map table held in the previously unused _reserved1 ivar (weak cell keys), so -setToolTip:forCell: records the string, -toolTipForCell: returns it or nil when none is set, and a nil tool tip clears it. No new ivar. Closes #639.