### PR TITLE
Fix: NSTabView stores the control size and control tint

### DIFF
--- a/Headers/AppKit/NSTabView.h
+++ b/Headers/AppKit/NSTabView.h
@@ -57,6 +57,8 @@ APPKIT_EXPORT_CLASS
   id _delegate;
   NSView *_original_nextKeyView;
   NSUInteger _selected_item;
+  NSControlSize _controlSize;
+  NSControlTint _controlTint;
 }
 - (void)addTabViewItem:(NSTabViewItem *)tabViewItem;
 - (void)insertTabViewItem:(NSTabViewItem *)tabViewItem

--- a/Source/NSTabView.m
+++ b/Source/NSTabView.m
@@ -80,6 +80,8 @@
       _selected = nil;
       _draws_background = YES;
       _truncated_label = YES;
+      _controlSize = NSRegularControlSize;
+      _controlTint = NSDefaultControlTint;
     }
 
   return self;
@@ -483,30 +485,22 @@
 
 - (NSControlSize) controlSize
 {
-  // FIXME
-  return NSRegularControlSize;
+  return _controlSize;
 }
 
-/**
- * Not implemented.
- */
 - (void) setControlSize: (NSControlSize)controlSize
 {
-  // FIXME 
+  _controlSize = controlSize;
 }
 
 - (NSControlTint) controlTint
 {
-  // FIXME
-  return NSDefaultControlTint;
+  return _controlTint;
 }
 
-/**
- * Not implemented.
- */
 - (void) setControlTint: (NSControlTint)controlTint
 {
-  // FIXME 
+  _controlTint = controlTint;
 }
 
 // Coding.

--- a/Tests/gui/NSTabView/controlSizeTint.m
+++ b/Tests/gui/NSTabView/controlSizeTint.m
@@ -1,0 +1,51 @@
+/* NSTabView stores the control size and control tint: the defaults are the
+   regular size and the default tint, and both round-trip once set. Checked
+   against AppKit on a macOS runner. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTabView.h>
+#include <AppKit/NSCell.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTabView *tv;
+
+  START_SET("NSTabView controlSizeTint")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tv = AUTORELEASE([[NSTabView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 150)]);
+
+      pass([tv controlSize] == NSRegularControlSize,
+           "the default control size is regular");
+      pass([tv controlTint] == NSDefaultControlTint,
+           "the default control tint is the default tint");
+
+      [tv setControlSize: NSSmallControlSize];
+      pass([tv controlSize] == NSSmallControlSize, "controlSize round-trips");
+      [tv setControlTint: NSBlueControlTint];
+      pass([tv controlTint] == NSBlueControlTint, "controlTint round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTabView controlSizeTint")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTabView/controlSizeTint.m
+++ b/Tests/gui/NSTabView/controlSizeTint.m
@@ -28,15 +28,15 @@ int main()
       tv = AUTORELEASE([[NSTabView alloc]
         initWithFrame: NSMakeRect(0, 0, 200, 150)]);
 
-      pass([tv controlSize] == NSRegularControlSize,
+      PASS([tv controlSize] == NSRegularControlSize,
            "the default control size is regular");
-      pass([tv controlTint] == NSDefaultControlTint,
+      PASS([tv controlTint] == NSDefaultControlTint,
            "the default control tint is the default tint");
 
       [tv setControlSize: NSSmallControlSize];
-      pass([tv controlSize] == NSSmallControlSize, "controlSize round-trips");
+      PASS([tv controlSize] == NSSmallControlSize, "controlSize round-trips");
       [tv setControlTint: NSBlueControlTint];
-      pass([tv controlTint] == NSBlueControlTint, "controlTint round-trips");
+      PASS([tv controlTint] == NSBlueControlTint, "controlTint round-trips");
     }
   NS_HANDLER
     if ([[localException name] isEqualToString: NSInternalInconsistencyException]


### PR DESCRIPTION
-setControlSize: and -setControlTint: were no-ops and the getters returned constants, so the values did not round-trip. Store them in two new ivars, defaulting to NSRegularControlSize and NSDefaultControlTint. This adds two ivars to NSTabView, so it is an ABI change; NSTabView has no subclass in gui. Closes #632.