### PR TITLE
Fix: NSTableView implements gridStyleMask and allowsTypeSelect

### DIFF
--- a/Headers/AppKit/NSTableView.h
+++ b/Headers/AppKit/NSTableView.h
@@ -120,7 +120,8 @@ APPKIT_EXPORT_CLASS
    */
   id                 _dataSource;
   NSMutableArray    *_tableColumns;
-  BOOL               _drawsGrid;
+  NSTableViewGridLineStyle _gridStyleMask;
+  BOOL               _allowsTypeSelect;
   NSColor           *_gridColor;
   NSColor           *_backgroundColor;
   NSTableViewSelectionHighlightStyle _selectionHighlightStyle;
@@ -285,6 +286,8 @@ APPKIT_EXPORT_CLASS
 /* Grid Drawing attributes */
 - (void) setDrawsGrid: (BOOL)flag;
 - (BOOL) drawsGrid;
+- (void) setAllowsTypeSelect: (BOOL)flag;
+- (BOOL) allowsTypeSelect;
 - (void) setGridColor: (NSColor *)aColor;
 - (NSColor *) gridColor;
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_3, GS_API_LATEST)

--- a/Source/NSOutlineView.m
+++ b/Source/NSOutlineView.m
@@ -1235,7 +1235,7 @@ static NSImage *unexpandable  = nil;
   newRect.origin.x += 3;
   newRect.size.width -= 3;
 
-  if (_drawsGrid)
+  if (_gridStyleMask != NSTableViewGridNone)
     {
       //newRect.origin.y += 1;
       //newRect.origin.x += 1;

--- a/Source/NSTableView.m
+++ b/Source/NSTableView.m
@@ -2045,7 +2045,8 @@ static void computeNewSelection
 - (void) _initDefaults
 {
   _isValidating     = NO;
-  _drawsGrid        = YES;
+  _gridStyleMask    = NSTableViewSolidVerticalGridLineMask | NSTableViewSolidHorizontalGridLineMask;
+  _allowsTypeSelect = YES;
   _rowHeight        = 16.0;
   _intercellSpacing = NSMakeSize (5.0, 2.0);
   ASSIGN(_selectedColumns, [NSMutableIndexSet indexSet]);
@@ -3296,12 +3297,22 @@ byExtendingSelection: (BOOL)flag
 
 - (void) setDrawsGrid: (BOOL)flag
 {
-  _drawsGrid = flag;
+  _gridStyleMask = flag ? (NSTableViewSolidVerticalGridLineMask | NSTableViewSolidHorizontalGridLineMask) : NSTableViewGridNone;
 }
 
 - (BOOL) drawsGrid
 {
-  return _drawsGrid;
+  return (_gridStyleMask != NSTableViewGridNone);
+}
+
+- (void) setAllowsTypeSelect: (BOOL)flag
+{
+  _allowsTypeSelect = flag;
+}
+
+- (BOOL) allowsTypeSelect
+{
+  return _allowsTypeSelect;
 }
 
 - (void) setGridColor: (NSColor *)aColor
@@ -3316,13 +3327,12 @@ byExtendingSelection: (BOOL)flag
 
 - (void) setGridStyleMask: (NSTableViewGridLineStyle)gridType
 {
-  // FIXME
+  _gridStyleMask = gridType;
 }
 
 - (NSTableViewGridLineStyle) gridStyleMask
 {
-  // FIXME
-  return 0;
+  return _gridStyleMask;
 }
 
 /*
@@ -4587,7 +4597,7 @@ This method is deprecated, use -columnIndexesInRect:. */
   frameRect.size.width -= _intercellSpacing.width;
 
   // We add some space to separate the cell from the grid
-  if (_drawsGrid)
+  if (_gridStyleMask != NSTableViewGridNone)
     {
       frameRect.size.width -= 4;
       frameRect.origin.x += 2;
@@ -5726,7 +5736,10 @@ This method is deprecated, use -columnIndexesInRect:. */
       number = _numberOfColumns;
       [aCoder encodeValueOfObjCType: @encode(int) at: &number];
 
-      [aCoder encodeValueOfObjCType: @encode(BOOL) at: &_drawsGrid];
+      {
+        BOOL drawsGrid = [self drawsGrid];
+        [aCoder encodeValueOfObjCType: @encode(BOOL) at: &drawsGrid];
+      }
       rowHeight = _rowHeight;
       [aCoder encodeValueOfObjCType: @encode(float) at: &rowHeight];
       [aCoder encodeValueOfObjCType: @encode(SEL) at: &_doubleAction];
@@ -5933,7 +5946,11 @@ This method is deprecated, use -columnIndexesInRect:. */
       _numberOfRows = number;
       [aDecoder decodeValueOfObjCType: @encode(int) at: &number];
       _numberOfColumns = number;
-      [aDecoder decodeValueOfObjCType: @encode(BOOL) at: &_drawsGrid];
+      {
+        BOOL drawsGrid;
+        [aDecoder decodeValueOfObjCType: @encode(BOOL) at: &drawsGrid];
+        [self setDrawsGrid: drawsGrid];
+      }
       [aDecoder decodeValueOfObjCType: @encode(float) at: &rowHeight];
       _rowHeight = rowHeight;
       [aDecoder decodeValueOfObjCType: @encode(SEL) at: &_doubleAction];
@@ -6508,7 +6525,7 @@ This method is deprecated, use -columnIndexesInRect:. */
 	  newRect.origin.x += 3;
 	  newRect.size.width -= 3;
 
-	  if (_drawsGrid)
+	  if (_gridStyleMask != NSTableViewGridNone)
 		{
 			//newRect.origin.y += 1;
 			//newRect.origin.x += 1;

--- a/Tests/gui/NSTableView/gridStyle.m
+++ b/Tests/gui/NSTableView/gridStyle.m
@@ -1,0 +1,62 @@
+/* NSTableView stores the grid style mask and keeps drawsGrid consistent with
+   it, and stores allowsTypeSelect. Setting a non-empty mask makes drawsGrid
+   YES; the none mask makes it NO; setDrawsGrid: YES sets the solid vertical and
+   horizontal mask and NO clears it. The relationships were checked against
+   AppKit on a macOS runner. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTableView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTableView *tv;
+
+  START_SET("NSTableView gridStyle")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tv = AUTORELEASE([[NSTableView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+
+      [tv setGridStyleMask: NSTableViewSolidHorizontalGridLineMask];
+      pass([tv gridStyleMask] == NSTableViewSolidHorizontalGridLineMask,
+           "gridStyleMask round-trips");
+      pass([tv drawsGrid] == YES, "a non-empty grid mask means drawsGrid is YES");
+
+      [tv setGridStyleMask: NSTableViewGridNone];
+      pass([tv drawsGrid] == NO, "the none grid mask means drawsGrid is NO");
+
+      [tv setDrawsGrid: YES];
+      pass([tv gridStyleMask] == (NSTableViewSolidVerticalGridLineMask
+                                  | NSTableViewSolidHorizontalGridLineMask),
+           "setDrawsGrid: YES sets the solid vertical and horizontal mask");
+      [tv setDrawsGrid: NO];
+      pass([tv gridStyleMask] == NSTableViewGridNone,
+           "setDrawsGrid: NO clears the grid mask");
+
+      pass([tv allowsTypeSelect] == YES, "type select is allowed by default");
+      [tv setAllowsTypeSelect: NO];
+      pass([tv allowsTypeSelect] == NO, "allowsTypeSelect round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTableView gridStyle")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTableView/gridStyle.m
+++ b/Tests/gui/NSTableView/gridStyle.m
@@ -30,24 +30,24 @@ int main()
         initWithFrame: NSMakeRect(0, 0, 200, 200)]);
 
       [tv setGridStyleMask: NSTableViewSolidHorizontalGridLineMask];
-      pass([tv gridStyleMask] == NSTableViewSolidHorizontalGridLineMask,
+      PASS([tv gridStyleMask] == NSTableViewSolidHorizontalGridLineMask,
            "gridStyleMask round-trips");
-      pass([tv drawsGrid] == YES, "a non-empty grid mask means drawsGrid is YES");
+      PASS([tv drawsGrid] == YES, "a non-empty grid mask means drawsGrid is YES");
 
       [tv setGridStyleMask: NSTableViewGridNone];
-      pass([tv drawsGrid] == NO, "the none grid mask means drawsGrid is NO");
+      PASS([tv drawsGrid] == NO, "the none grid mask means drawsGrid is NO");
 
       [tv setDrawsGrid: YES];
-      pass([tv gridStyleMask] == (NSTableViewSolidVerticalGridLineMask
+      PASS([tv gridStyleMask] == (NSTableViewSolidVerticalGridLineMask
                                   | NSTableViewSolidHorizontalGridLineMask),
            "setDrawsGrid: YES sets the solid vertical and horizontal mask");
       [tv setDrawsGrid: NO];
-      pass([tv gridStyleMask] == NSTableViewGridNone,
+      PASS([tv gridStyleMask] == NSTableViewGridNone,
            "setDrawsGrid: NO clears the grid mask");
 
-      pass([tv allowsTypeSelect] == YES, "type select is allowed by default");
+      PASS([tv allowsTypeSelect] == YES, "type select is allowed by default");
       [tv setAllowsTypeSelect: NO];
-      pass([tv allowsTypeSelect] == NO, "allowsTypeSelect round-trips");
+      PASS([tv allowsTypeSelect] == NO, "allowsTypeSelect round-trips");
     }
   NS_HANDLER
     if ([[localException name] isEqualToString: NSInternalInconsistencyException]


### PR DESCRIPTION
-setGridStyleMask: was a no-op, -gridStyleMask always returned 0, and -allowsTypeSelect / -setAllowsTypeSelect: were missing. Store the grid style in place of the old BOOL _drawsGrid ivar and derive -drawsGrid from it (a non-empty mask is YES; -setDrawsGrid: YES sets the solid vertical and horizontal mask), matching how AppKit relates the two. Add an _allowsTypeSelect ivar, defaulting to YES. NSOutlineView referenced the old ivar and is updated; the archive format is unchanged (a BOOL for drawsGrid). The default mask keeps GNUstep's current draw-the-grid behaviour rather than AppKit's none, to avoid changing every table's appearance; say if you would rather match AppKit's default. This changes the NSTableView ivar layout, so it is an ABI change. Closes #631.