### PR TITLE
Feature: Implement the Auto Layout constraint solver

### DIFF
--- a/Headers/AppKit/NSView.h
+++ b/Headers/AppKit/NSView.h
@@ -742,6 +742,10 @@ PACKAGE_SCOPE
 
 - (void) addConstraints: (NSArray*)constraints;
 
+- (void) removeConstraint: (NSLayoutConstraint *)constraint;
+
+- (void) removeConstraints: (NSArray*)constraints;
+
 @end
 
 @interface NSView (NSConstraintBasedLayoutAnchors)

--- a/Source/GSAutoLayoutEngine.h
+++ b/Source/GSAutoLayoutEngine.h
@@ -44,6 +44,9 @@
    NSMapTable *_internalConstraintsByViewIndex;
    NSMapTable *_supportingConstraintsByConstraint;
    int _viewCounter;
+   NSView *_contentView;
+   NSLayoutConstraint *_contentWidthConstraint;
+   NSLayoutConstraint *_contentHeightConstraint;
 }
 
 - (instancetype) initWithSolver: (GSCassowarySolver*)solver;
@@ -59,6 +62,10 @@
 - (NSRect) alignmentRectForView: (NSView *)view;
 
 - (NSArray *) constraintsForView: (NSView *)view;
+
+- (void) pinContentView: (NSView *)contentView;
+
+- (BOOL) updateContentViewSize;
 
 @end
 

--- a/Source/GSAutoLayoutEngine.h
+++ b/Source/GSAutoLayoutEngine.h
@@ -47,6 +47,11 @@
    NSView *_contentView;
    NSLayoutConstraint *_contentWidthConstraint;
    NSLayoutConstraint *_contentHeightConstraint;
+   /* While _batchDepth is above zero the solver constraints produced by a
+      group of layout constraints collect here, to be added or removed in one
+      call.  A group is either all additions or all removals. */
+   NSMutableArray *_batchedSolverConstraints;
+   int _batchDepth;
 }
 
 - (instancetype) initWithSolver: (GSCassowarySolver*)solver;

--- a/Source/GSAutoLayoutEngine.h
+++ b/Source/GSAutoLayoutEngine.h
@@ -30,6 +30,11 @@
 #ifndef _GS_AUTO_LAYOUT_ENGINE_H
 #define _GS_AUTO_LAYOUT_ENGINE_H
 
+/* Set when the first layout engine is created.  It stays set for the life of
+   the process, so a view path that only matters once constraints are in use
+   can test it before doing any further work. */
+extern BOOL GSAutoLayoutEngineExists;
+
 @interface GSAutoLayoutEngine : NSObject
 {
    GSCassowarySolver *_solver;

--- a/Source/GSAutoLayoutEngine.m
+++ b/Source/GSAutoLayoutEngine.m
@@ -1279,8 +1279,81 @@ typedef NSInteger GSLayoutViewAttribute;
     }
 }
 
+- (NSLayoutConstraint *) _pinConstraintForView: (NSView *)view
+                                      attribute: (NSLayoutAttribute)attribute
+                                       constant: (CGFloat)constant
+{
+  return [NSLayoutConstraint constraintWithItem: view
+                                      attribute: attribute
+                                      relatedBy: NSLayoutRelationEqual
+                                         toItem: nil
+                                      attribute: NSLayoutAttributeNotAnAttribute
+                                     multiplier: 1.0
+                                       constant: constant];
+}
+
+// Pin a view (normally a window content view) to its own bounds so that
+// constraints expressed against it resolve to absolute positions. The width
+// and height constraints are kept so they can track the view's size.
+- (void) pinContentView: (NSView *)contentView
+{
+  if (contentView == nil)
+    {
+      return;
+    }
+  ASSIGN(_contentView, contentView);
+
+  NSRect bounds = [contentView bounds];
+  NSLayoutConstraint *left = [self _pinConstraintForView: contentView
+                                               attribute: NSLayoutAttributeLeft
+                                                constant: NSMinX(bounds)];
+  NSLayoutConstraint *bottom = [self _pinConstraintForView: contentView
+                                                 attribute: NSLayoutAttributeBottom
+                                                  constant: NSMinY(bounds)];
+  ASSIGN(_contentWidthConstraint,
+         [self _pinConstraintForView: contentView
+                           attribute: NSLayoutAttributeWidth
+                            constant: NSWidth(bounds)]);
+  ASSIGN(_contentHeightConstraint,
+         [self _pinConstraintForView: contentView
+                           attribute: NSLayoutAttributeHeight
+                            constant: NSHeight(bounds)]);
+
+  [self addConstraint: left];
+  [self addConstraint: bottom];
+  [self addConstraint: _contentWidthConstraint];
+  [self addConstraint: _contentHeightConstraint];
+}
+
+- (BOOL) updateContentViewSize
+{
+  if (_contentView == nil)
+    {
+      return NO;
+    }
+
+  BOOL changed = NO;
+  NSRect bounds = [_contentView bounds];
+  if ([_contentWidthConstraint constant] != NSWidth(bounds))
+    {
+      [_contentWidthConstraint setConstant: NSWidth(bounds)];
+      [self updateConstraint: _contentWidthConstraint];
+      changed = YES;
+    }
+  if ([_contentHeightConstraint constant] != NSHeight(bounds))
+    {
+      [_contentHeightConstraint setConstant: NSHeight(bounds)];
+      [self updateConstraint: _contentHeightConstraint];
+      changed = YES;
+    }
+  return changed;
+}
+
 - (void) dealloc
 {
+    RELEASE(_contentView);
+    RELEASE(_contentWidthConstraint);
+    RELEASE(_contentHeightConstraint);
     RELEASE(_trackedViews);
     RELEASE(_viewAlignmentRectByViewIndex);
     RELEASE(_viewIndexByViewHash);

--- a/Source/GSAutoLayoutEngine.m
+++ b/Source/GSAutoLayoutEngine.m
@@ -224,8 +224,6 @@ typedef NSInteger GSLayoutViewAttribute;
 - (CGFloat) valueForView: (NSView *)view
                attribute: (GSLayoutViewAttribute)attribute;
 
-- (int) getConstantMultiplierForLayoutAttribute: (NSLayoutAttribute)attribute;
-
 @end
 
 @implementation GSAutoLayoutEngine
@@ -409,8 +407,7 @@ typedef NSInteger GSLayoutViewAttribute;
       op = GSCSConstraintOperationGreaterThanOrEqual;
       break;
     }
-  double constant =
-    [self getConstantMultiplierForLayoutAttribute: [constraint secondAttribute]] * [constraint constant];
+  double constant = [constraint constant];
 
   GSCSLinearExpression *rightExpression = [[GSCSLinearExpression alloc]
     initWithVariable: secondItemConstraintVariable
@@ -425,27 +422,6 @@ typedef NSInteger GSLayoutViewAttribute;
   RELEASE(strength);
 
   return newConstraint;
-}
-
-- (int) getConstantMultiplierForLayoutAttribute: (NSLayoutAttribute)attribute
-{
-  switch (attribute)
-    {
-    case NSLayoutAttributeTop:
-      return -1;
-    case NSLayoutAttributeBottom:
-      return 1;
-    case NSLayoutAttributeLeading:
-      return 1;
-    case NSLayoutAttributeTrailing:
-      return -1;
-    case NSLayoutAttributeLeft:
-      return 1;
-    case NSLayoutAttributeRight:
-      return -1;
-    default:
-      return 1;
-    }
 }
 
 - (GSCSVariable *) variableForView: (NSView *)view

--- a/Source/GSAutoLayoutEngine.m
+++ b/Source/GSAutoLayoutEngine.m
@@ -1145,8 +1145,20 @@ typedef NSInteger GSLayoutViewAttribute;
 - (BOOL) solverCanSolveAlignmentRectForView: (NSView *)view
                                    solution: (GSCSSolution *)solution
 {
-  // FIXME
-  return NO;
+  GSCSVariable *minX = [self getExistingVariableForView: view
+                                          withAttribute: GSLayoutAttributeMinX];
+  GSCSVariable *minY = [self getExistingVariableForView: view
+                                          withAttribute: GSLayoutAttributeMinY];
+  GSCSVariable *width = [self getExistingVariableForView: view
+                                           withAttribute: GSLayoutAttributeWidth];
+  GSCSVariable *height = [self getExistingVariableForView: view
+                                            withAttribute: GSLayoutAttributeHeight];
+
+  return minX != nil && minY != nil && width != nil && height != nil
+    && [solution resultForVariable: minX] != nil
+    && [solution resultForVariable: minY] != nil
+    && [solution resultForVariable: width] != nil
+    && [solution resultForVariable: height] != nil;
 }
 
 - (void) recordAlignmentRect: (NSRect)alignmentRect
@@ -1172,8 +1184,21 @@ typedef NSInteger GSLayoutViewAttribute;
 - (NSRect) solverAlignmentRectForView: (NSView *)view
                              solution: (GSCSSolution *)solution
 {
-  // FIXME Get view solution from solver
-  return NSZeroRect;
+  GSCSVariable *minX = [self getExistingVariableForView: view
+                                          withAttribute: GSLayoutAttributeMinX];
+  GSCSVariable *minY = [self getExistingVariableForView: view
+                                          withAttribute: GSLayoutAttributeMinY];
+  GSCSVariable *width = [self getExistingVariableForView: view
+                                           withAttribute: GSLayoutAttributeWidth];
+  GSCSVariable *height = [self getExistingVariableForView: view
+                                            withAttribute: GSLayoutAttributeHeight];
+
+  CGFloat x = [[solution resultForVariable: minX] doubleValue];
+  CGFloat y = [[solution resultForVariable: minY] doubleValue];
+  CGFloat w = [[solution resultForVariable: width] doubleValue];
+  CGFloat h = [[solution resultForVariable: height] doubleValue];
+
+  return NSMakeRect(x, y, w, h);
 }
 
 - (void) notifyViewsOfAlignmentRectChange: (NSArray *)viewsWithChanges
@@ -1185,8 +1210,12 @@ typedef NSInteger GSLayoutViewAttribute;
 
 - (NSRect) alignmentRectForView: (NSView *)view
 {
-  // FIXME Get alignment rect for view from solver
-  return NSZeroRect;
+  GSCSSolution *solution = [_solver solve];
+  if (![self solverCanSolveAlignmentRectForView: view solution: solution])
+    {
+      return NSZeroRect;
+    }
+  return [self solverAlignmentRectForView: view solution: solution];
 }
 
 - (void) addSupportingSolverConstraint: (GSCSConstraint *)supportingConstraint

--- a/Source/GSAutoLayoutEngine.m
+++ b/Source/GSAutoLayoutEngine.m
@@ -261,6 +261,9 @@ typedef NSInteger GSLayoutViewAttribute;
       ASSIGN(_constraintsByViewIndex, [NSMutableDictionary dictionary]);
 
       ASSIGN(_internalConstraintsByViewIndex, [NSMapTable strongToStrongObjectsMapTable]);
+
+      ASSIGN(_batchedSolverConstraints, [NSMutableArray array]);
+      _batchDepth = 0;
     }
   return self;
 }
@@ -273,11 +276,25 @@ typedef NSInteger GSLayoutViewAttribute;
   return self;
 }
 
+/* The solver reaches an optimal tableau once per call, and every tracked view
+   is measured against the solution afterwards, so a group of constraints is
+   handed over in one go rather than one at a time. */
 - (void) addConstraints: (NSArray *)constraints
 {
+  if ([constraints count] == 0)
+    {
+      return;
+    }
+
+  _batchDepth++;
   FOR_IN(NSLayoutConstraint *, constraint, constraints)
     [self addConstraint: constraint];
   END_FOR_IN(constraints);
+  _batchDepth--;
+
+  [_solver addConstraints: _batchedSolverConstraints];
+  [_batchedSolverConstraints removeAllObjects];
+  [self updateAlignmentRectsForTrackedViews];
 }
 
 - (void) addConstraint: (NSLayoutConstraint *)constraint
@@ -300,7 +317,10 @@ typedef NSInteger GSLayoutViewAttribute;
     }
 
   [self addSolverConstraint: solverConstraint];
-  [self updateAlignmentRectsForTrackedViews];
+  if (_batchDepth == 0)
+    {
+      [self updateAlignmentRectsForTrackedViews];
+    }
 
   [self addConstraintAgainstViewConstraintsArray: constraint];
 }
@@ -327,7 +347,10 @@ typedef NSInteger GSLayoutViewAttribute;
 
   [_supportingConstraintsByConstraint removeObjectForKey: solverConstraint];
 
-  [self updateAlignmentRectsForTrackedViews];
+  if (_batchDepth == 0)
+    {
+      [self updateAlignmentRectsForTrackedViews];
+    }
   [self removeConstraintAgainstViewConstraintsArray: constraint];
 
   /* The internal constraints of a view exist to support its own constraints,
@@ -345,9 +368,20 @@ typedef NSInteger GSLayoutViewAttribute;
 
 - (void) removeConstraints: (NSArray *)constraints
 {
+  if ([constraints count] == 0)
+    {
+      return;
+    }
+
+  _batchDepth++;
   FOR_IN(NSLayoutConstraint *, constraint, constraints)
     [self removeConstraint: constraint];
   END_FOR_IN(constraints);
+  _batchDepth--;
+
+  [_solver removeConstraints: _batchedSolverConstraints];
+  [_batchedSolverConstraints removeAllObjects];
+  [self updateAlignmentRectsForTrackedViews];
 }
 
 - (GSCSConstraint *) solverConstraintForConstraint:
@@ -1231,12 +1265,26 @@ typedef NSInteger GSLayoutViewAttribute;
 - (void) addSolverConstraint: (GSCSConstraint *)constraint
 {
   [_solverConstraints addObject: constraint];
-  [_solver addConstraint: constraint];
+  if (_batchDepth > 0)
+    {
+      [_batchedSolverConstraints addObject: constraint];
+    }
+  else
+    {
+      [_solver addConstraint: constraint];
+    }
 }
 
 - (void) removeSolverConstraint: (GSCSConstraint *)constraint
 {
-  [_solver removeConstraint: constraint];
+  if (_batchDepth > 0)
+    {
+      [_batchedSolverConstraints addObject: constraint];
+    }
+  else
+    {
+      [_solver removeConstraint: constraint];
+    }
   [_solverConstraints removeObject: constraint];
 }
 
@@ -1382,6 +1430,7 @@ typedef NSInteger GSLayoutViewAttribute;
     RELEASE(_constraintsByAutoLayoutConstaintHash);
     RELEASE(_internalConstraintsByViewIndex);
     RELEASE(_solverConstraints);
+    RELEASE(_batchedSolverConstraints);
     RELEASE(_variablesByKey);
     RELEASE(_solver);
 

--- a/Source/GSAutoLayoutEngine.m
+++ b/Source/GSAutoLayoutEngine.m
@@ -237,7 +237,14 @@ typedef NSInteger GSLayoutViewAttribute;
 
       ASSIGN(_variablesByKey, [NSMapTable strongToStrongObjectsMapTable]);
 
-      ASSIGN(_constraintsByAutoLayoutConstaintHash, [NSMapTable strongToStrongObjectsMapTable]);
+      /* Layout constraints are compared by value, so the solver constraint of
+         each one is kept against the object itself. */
+      ASSIGN(_constraintsByAutoLayoutConstaintHash,
+        [NSMapTable mapTableWithKeyOptions:
+                      NSPointerFunctionsObjectPointerPersonality
+                                | NSPointerFunctionsStrongMemory
+                      valueOptions: NSPointerFunctionsObjectPersonality
+                                | NSPointerFunctionsStrongMemory]);
 
       ASSIGN(_layoutConstraintsBySolverConstraint, [NSMapTable strongToStrongObjectsMapTable]);
 
@@ -318,17 +325,19 @@ typedef NSInteger GSLayoutViewAttribute;
       END_FOR_IN(internalConstraints);
     }
 
-  [_supportingConstraintsByConstraint setObject: nil forKey: solverConstraint];
+  [_supportingConstraintsByConstraint removeObjectForKey: solverConstraint];
 
   [self updateAlignmentRectsForTrackedViews];
   [self removeConstraintAgainstViewConstraintsArray: constraint];
 
-  if ([self hasConstraintsForView: [constraint firstItem]])
+  /* The internal constraints of a view exist to support its own constraints,
+     so they go when the last of those is removed. */
+  if (![self hasConstraintsForView: [constraint firstItem]])
     {
       [self removeInternalConstraintsForView: [constraint firstItem]];
     }
   if ([constraint secondItem] != nil &&
-      [self hasConstraintsForView: [constraint secondItem]])
+      ![self hasConstraintsForView: [constraint secondItem]])
     {
       [self removeInternalConstraintsForView: [constraint secondItem]];
     }
@@ -1006,7 +1015,7 @@ typedef NSInteger GSLayoutViewAttribute;
     [self removeSolverConstraint: constraint];
   END_FOR_IN(internalViewConstraints);
 
-  [_internalConstraintsByViewIndex setObject: nil forKey: view];
+  [_internalConstraintsByViewIndex removeObjectForKey: view];
 }
 
 - (BOOL) hasConstraintsForView: (NSView *)view
@@ -1039,13 +1048,16 @@ typedef NSInteger GSLayoutViewAttribute;
     {
       NSNumber *secondItemViewIndex =
         [self indexForView: [constraint secondItem]];
-      if ([_constraintsByViewIndex objectForKey: secondItemViewIndex])
+      NSMutableArray *constraintsForSecondItem =
+        [_constraintsByViewIndex objectForKey: secondItemViewIndex];
+
+      if (!constraintsForSecondItem)
         {
-          [_constraintsByViewIndex setObject: [NSMutableArray array]
+          constraintsForSecondItem = [NSMutableArray array];
+          [_constraintsByViewIndex setObject: constraintsForSecondItem
                                       forKey: secondItemViewIndex];
         }
-      [[_constraintsByViewIndex objectForKey: secondItemViewIndex]
-          addObject: constraint];
+      [constraintsForSecondItem addObject: constraint];
     }
 }
 
@@ -1057,8 +1069,12 @@ typedef NSInteger GSLayoutViewAttribute;
       [_constraintsByViewIndex objectForKey: firstItemViewIndex];
 
   NSUInteger indexOfConstraintInFirstItem =
-      [constraintsForFirstItem indexOfObject: constraint];
-  [constraintsForFirstItem removeObjectAtIndex: indexOfConstraintInFirstItem];
+      [constraintsForFirstItem indexOfObjectIdenticalTo: constraint];
+  if (indexOfConstraintInFirstItem != NSNotFound)
+    {
+      [constraintsForFirstItem
+          removeObjectAtIndex: indexOfConstraintInFirstItem];
+    }
 
   if ([constraint secondItem] != nil)
     {
@@ -1068,9 +1084,12 @@ typedef NSInteger GSLayoutViewAttribute;
           [_constraintsByViewIndex objectForKey: secondItemViewIndexIndex];
 
       NSUInteger indexOfConstraintInSecondItem =
-          [constraintsForSecondItem indexOfObject: constraint];
-      [constraintsForSecondItem
-          removeObjectAtIndex: indexOfConstraintInSecondItem];
+          [constraintsForSecondItem indexOfObjectIdenticalTo: constraint];
+      if (indexOfConstraintInSecondItem != NSNotFound)
+        {
+          [constraintsForSecondItem
+              removeObjectAtIndex: indexOfConstraintInSecondItem];
+        }
     }
 }
 

--- a/Source/GSAutoLayoutEngine.m
+++ b/Source/GSAutoLayoutEngine.m
@@ -226,6 +226,8 @@ typedef NSInteger GSLayoutViewAttribute;
 
 @end
 
+BOOL GSAutoLayoutEngineExists = NO;
+
 @implementation GSAutoLayoutEngine
 
 - (instancetype) initWithSolver: (GSCassowarySolver *)cassowarySolver;
@@ -233,6 +235,7 @@ typedef NSInteger GSLayoutViewAttribute;
   self = [super init];
   if (self != nil)
     {
+      GSAutoLayoutEngineExists = YES;
       ASSIGN(_solver, cassowarySolver);
 
       ASSIGN(_variablesByKey, [NSMapTable strongToStrongObjectsMapTable]);

--- a/Source/GSAutoLayoutVFLParser.m
+++ b/Source/GSAutoLayoutVFLParser.m
@@ -317,7 +317,9 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
                                       toItem: secondItem
                                    attribute: secondAttribute
                                   multiplier: 1.0
-                                    constant: viewSpacingConstant];
+                                    constant: (_isVerticalOrientation
+                                                ? -viewSpacingConstant
+                                                : viewSpacingConstant)];
 
   [_constraints addObject: viewSeparatorConstraint];
 }
@@ -366,7 +368,9 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
                                       toItem: secondItem
                                    attribute: firstAttribute
                                   multiplier: 1.0
-                                    constant: viewSpacingConstant];
+                                    constant: (_isVerticalOrientation
+                                                ? -viewSpacingConstant
+                                                : viewSpacingConstant)];
   [_constraints addObject: leadingConstraintToSuperview];
 }
 
@@ -413,7 +417,9 @@ NSInteger const GS_DEFAULT_SUPERVIEW_SPACING = 20;
                                       toItem: secondItem
                                    attribute: attribute
                                   multiplier: 1.0
-                                    constant: viewSpacingConstant];
+                                    constant: (_isVerticalOrientation
+                                                ? -viewSpacingConstant
+                                                : viewSpacingConstant)];
   [_constraints addObject: trailingConstraintToSuperview];
 }
 

--- a/Source/GSCSConstraint.m
+++ b/Source/GSCSConstraint.m
@@ -157,11 +157,12 @@ operator: (GSCSConstraintOperator) operator
         {
           [rhsExpression addVariable: lhs coefficient: -1];
         }
-      
+
+      GSCSConstraint *constraint = AUTORELEASE([[GSCSConstraint alloc]
+          initLinearInequityConstraintWithExpression: rhsExpression]);
       RELEASE(rhsExpression);
 
-      return AUTORELEASE([[GSCSConstraint alloc]
-          initLinearInequityConstraintWithExpression: rhsExpression]);
+      return constraint;
     }
 }
 

--- a/Source/GSCSEditInfo.h
+++ b/Source/GSCSEditInfo.h
@@ -33,7 +33,7 @@
   GSCSVariable *_variable;
   GSCSVariable *_plusVariable;
   GSCSVariable *_minusVariable;
-  NSInteger _previousConstant;
+  CGFloat _previousConstant;
 }
 
 #if GS_HAS_DECLARED_PROPERTIES
@@ -48,11 +48,19 @@
 - (GSCSVariable *) variable;
 #endif
 
+- (GSCSVariable *) plusVariable;
+
+- (GSCSVariable *) minusVariable;
+
+- (CGFloat) previousConstant;
+
+- (void) setPreviousConstant: (CGFloat)previousConstant;
+
 - (instancetype) initWithVariable: (GSCSVariable *)variable
                        constraint: (GSCSConstraint *)constraint
                      plusVariable: (GSCSVariable *)plusVariable
                     minusVariable: (GSCSVariable *)minusVariable
-                 previousConstant: (NSInteger)previousConstant;
+                 previousConstant: (CGFloat)previousConstant;
 
 @end
 

--- a/Source/GSCSEditInfo.m
+++ b/Source/GSCSEditInfo.m
@@ -28,15 +28,15 @@
                        constraint: (GSCSConstraint *)constraint
                      plusVariable: (GSCSVariable *)plusVariable
                     minusVariable: (GSCSVariable *)minusVariable
-                 previousConstant: (NSInteger)previousConstant
+                 previousConstant: (CGFloat)previousConstant
 {
   self = [super init];
   if (self != nil)
     {
-      _variable = variable;
-      _plusVariable = plusVariable;
-      _minusVariable = minusVariable;
-      _constraint = constraint;
+      ASSIGN(_variable, variable);
+      ASSIGN(_plusVariable, plusVariable);
+      ASSIGN(_minusVariable, minusVariable);
+      ASSIGN(_constraint, constraint);
       _previousConstant = previousConstant;
     }
 
@@ -51,6 +51,26 @@
 - (GSCSVariable*) variable
 {
   return _variable;
+}
+
+- (GSCSVariable*) plusVariable
+{
+  return _plusVariable;
+}
+
+- (GSCSVariable*) minusVariable
+{
+  return _minusVariable;
+}
+
+- (CGFloat) previousConstant
+{
+  return _previousConstant;
+}
+
+- (void) setPreviousConstant: (CGFloat)previousConstant
+{
+  _previousConstant = previousConstant;
 }
 
 - (void) dealloc

--- a/Source/GSCSTableau.m
+++ b/Source/GSCSTableau.m
@@ -265,7 +265,7 @@
   [expression removeVariable: term];
   [expression setConstant: (coefficieint * [newExpression constant]) +
                            [expression constant]];
-  NSArray *termVariables = [expression termVariables];
+  NSArray *termVariables = [newExpression termVariables];
   FOR_IN(GSCSVariable *, newExpressionTerm, termVariables)
     [self substituteOutTermInExpression: expression
                           newExpression: newExpression

--- a/Source/GSCSVariable.m
+++ b/Source/GSCSVariable.m
@@ -104,7 +104,7 @@
 
 - (BOOL) isRestricted
 {
-  return _type == GSCSVariableTypeExternal || _type == GSCSVariableTypeSlack;
+  return _type == GSCSVariableTypeDummy || _type == GSCSVariableTypeSlack;
 }
 
 - (NSString *) description

--- a/Source/GSCassowarySolver.h
+++ b/Source/GSCassowarySolver.h
@@ -22,12 +22,24 @@
 
 #import <Foundation/Foundation.h>
 #import "GSCSConstraint.h"
+#import "GSCSEditVariableManager.h"
 #import "GSCSSolution.h"
+#import "GSCSTableau.h"
 
 #ifndef _GS_CASSOWARY_SOLVER_H
 #define _GS_CASSOWARY_SOLVER_H
 
 @interface GSCassowarySolver : NSObject
+{
+  GSCSTableau *_tableau;
+  GSCSEditVariableManager *_editVariableManager;
+  NSMapTable *_markerVariables;
+  NSMapTable *_errorVariables;
+  NSMutableSet *_externalVariables;
+  NSInteger _artificialCounter;
+  NSInteger _slackCounter;
+  NSInteger _dummyCounter;
+}
 
 - (void) addConstraint: (GSCSConstraint*)constraint;
 

--- a/Source/GSCassowarySolver.m
+++ b/Source/GSCassowarySolver.m
@@ -21,6 +21,7 @@
 */
 
 #import "GSCassowarySolver.h"
+#import "GSCSEditInfo.h"
 #import "GSCSFloatComparator.h"
 #import "GSCSLinearExpression.h"
 #import "GSCSStrength.h"
@@ -53,6 +54,17 @@
 - (GSCSVariable *) exitVariableForMarker: (GSCSVariable *)marker;
 
 - (void) optimize: (GSCSVariable *)objective;
+
+- (GSCSEditInfo *) editInfoForVariable: (GSCSVariable *)variable;
+
+- (GSCSEditInfo *) addEditVariable: (GSCSVariable *)variable
+                          strength: (GSCSStrength *)strength;
+
+- (void) deltaEditConstant: (CGFloat)delta
+              plusVariable: (GSCSVariable *)plusVariable
+             minusVariable: (GSCSVariable *)minusVariable;
+
+- (void) dualOptimize;
 
 - (void) setExternalVariables;
 
@@ -210,7 +222,25 @@
 
 - (void) suggestEditVariable: (GSCSVariable *)variable equals: (CGFloat)value
 {
-  // FIXME Suggest edit variable
+  GSCSEditInfo *editInfo = [self editInfoForVariable: variable];
+  if (editInfo == nil)
+    {
+      editInfo = [self addEditVariable: variable
+                              strength: [GSCSStrength strengthStrong]];
+    }
+
+  CGFloat delta = value - [editInfo previousConstant];
+  [editInfo setPreviousConstant: value];
+
+  // The edit constraint expression is (targetValue - variable), so the sign of
+  // the change is the reverse of the classic (variable - targetValue) form.
+  [self deltaEditConstant: -delta
+             plusVariable: [editInfo plusVariable]
+            minusVariable: [editInfo minusVariable]];
+
+  [self dualOptimize];
+  [self setExternalVariables];
+  [[_tableau infeasibleRows] removeAllObjects];
 }
 
 // Build the augmented expression for a new constraint. Basic variables are
@@ -599,6 +629,147 @@
           [[NSException
              exceptionWithName: NSInternalInconsistencyException
                         reason: @"Objective function is unbounded"
+                      userInfo: nil] raise];
+          return;
+        }
+
+      [_tableau pivotWithEntryVariable: entryVariable
+                          exitVariable: exitVariable];
+      objectiveRow = [_tableau rowExpressionForVariable: objective];
+    }
+}
+
+- (GSCSEditInfo *) editInfoForVariable: (GSCSVariable *)variable
+{
+  NSArray *editInfos = [_editVariableManager editInfosForVariable: variable];
+  if ([editInfos count] > 0)
+    {
+      return [editInfos lastObject];
+    }
+  return nil;
+}
+
+// Register a variable for editing by adding a non-required equality constraint
+// pinning it to its current value. The constraint's error variables are used to
+// nudge the value in -suggestEditVariable:equals:.
+- (GSCSEditInfo *) addEditVariable: (GSCSVariable *)variable
+                          strength: (GSCSStrength *)strength
+{
+  GSCSConstraint *editConstraint = AUTORELEASE([[GSCSConstraint alloc]
+    initEditConstraintWithVariable: variable strength: strength]);
+  [self addConstraint: editConstraint];
+
+  GSCSVariable *plusVariable = [_markerVariables objectForKey: editConstraint];
+  NSArray *errors = [_errorVariables objectForKey: editConstraint];
+  GSCSVariable *minusVariable = nil;
+  FOR_IN(GSCSVariable *, errorVariable, errors)
+    if (errorVariable != plusVariable)
+      {
+        minusVariable = errorVariable;
+      }
+  END_FOR_IN(errors);
+
+  GSCSEditInfo *editInfo = AUTORELEASE([[GSCSEditInfo alloc]
+     initWithVariable: variable
+           constraint: editConstraint
+         plusVariable: plusVariable
+        minusVariable: minusVariable
+     previousConstant: [variable value]]);
+  [_editVariableManager addEditInfo: editInfo];
+  return editInfo;
+}
+
+// Apply a change to an edit constraint's constant by adjusting the constants of
+// the rows that reference its error variables, recording any rows that become
+// infeasible for the dual optimisation pass.
+- (void) deltaEditConstant: (CGFloat)delta
+              plusVariable: (GSCSVariable *)plusVariable
+             minusVariable: (GSCSVariable *)minusVariable
+{
+  GSCSLinearExpression *plusRow =
+    [_tableau rowExpressionForVariable: plusVariable];
+  if (plusRow != nil)
+    {
+      [plusRow setConstant: [plusRow constant] + delta];
+      if ([plusRow constant] < 0.0)
+        {
+          [[_tableau infeasibleRows] addObject: plusVariable];
+        }
+      return;
+    }
+
+  GSCSLinearExpression *minusRow =
+    [_tableau rowExpressionForVariable: minusVariable];
+  if (minusRow != nil)
+    {
+      [minusRow setConstant: [minusRow constant] - delta];
+      if ([minusRow constant] < 0.0)
+        {
+          [[_tableau infeasibleRows] addObject: minusVariable];
+        }
+      return;
+    }
+
+  NSSet *column = [_tableau columnForVariable: plusVariable];
+  FOR_IN(GSCSVariable *, basicVariable, column)
+    GSCSLinearExpression *row =
+      [_tableau rowExpressionForVariable: basicVariable];
+    CGFloat coefficient = [row coefficientForTerm: plusVariable];
+    [row setConstant: [row constant] + coefficient * delta];
+    if ([basicVariable isRestricted] && [row constant] < 0.0)
+      {
+        [[_tableau infeasibleRows] addObject: basicVariable];
+      }
+  END_FOR_IN(column);
+}
+
+// Restore feasibility after an edit by pivoting each infeasible row out of the
+// basis, choosing the entry variable that least degrades the objective.
+- (void) dualOptimize
+{
+  GSCSVariable *objective = [_tableau objective];
+  GSCSLinearExpression *objectiveRow =
+    [_tableau rowExpressionForVariable: objective];
+  NSMutableArray *infeasibleRows = [_tableau infeasibleRows];
+
+  while ([infeasibleRows count] > 0)
+    {
+      GSCSVariable *exitVariable = [infeasibleRows objectAtIndex: 0];
+      [infeasibleRows removeObjectAtIndex: 0];
+
+      if (![_tableau isBasicVariable: exitVariable])
+        {
+          continue;
+        }
+      GSCSLinearExpression *expression =
+        [_tableau rowExpressionForVariable: exitVariable];
+      if ([expression constant] >= 0.0)
+        {
+          continue;
+        }
+
+      GSCSVariable *entryVariable = nil;
+      CGFloat minRatio = DBL_MAX;
+      NSArray *termVariables = [expression termVariables];
+      FOR_IN(GSCSVariable *, variable, termVariables)
+        CGFloat coefficient = [expression coefficientForTerm: variable];
+        if (coefficient > 0.0 && [variable isPivotable])
+          {
+            CGFloat ratio =
+              [objectiveRow coefficientForTerm: variable] / coefficient;
+            if (ratio < minRatio)
+              {
+                minRatio = ratio;
+                entryVariable = variable;
+              }
+          }
+      END_FOR_IN(termVariables);
+
+      if (entryVariable == nil)
+        {
+          [[NSException
+             exceptionWithName: NSInternalInconsistencyException
+                        reason: @"Unable to restore feasibility after an edit"
                       userInfo: nil] raise];
           return;
         }

--- a/Source/GSCassowarySolver.m
+++ b/Source/GSCassowarySolver.m
@@ -1,19 +1,19 @@
 /* Copyright (C) 2023 Free Software Foundation, Inc.
-   
+
    By: Benjamin Johnson
    Date: 19-3-2023
    This file is part of the GNUstep Library.
-   
+
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
    License as published by the Free Software Foundation; either
    version 2.1 of the License, or (at your option) any later version.
-   
+
    This library is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
    Lesser General Public License for more details.
-   
+
    You should have received a copy of the GNU Lesser General Public
    License along with this library; if not, write to the Free
    Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
@@ -21,38 +21,617 @@
 */
 
 #import "GSCassowarySolver.h"
+#import "GSCSFloatComparator.h"
+#import "GSCSLinearExpression.h"
+#import "GSCSStrength.h"
+#import "GSCSVariable.h"
+#import "GSFastEnumeration.h"
+
+@interface GSCassowarySolver (PrivateMethods)
+
+- (GSCSLinearExpression *) expressionForNewConstraint: (GSCSConstraint *)constraint
+                                               marker: (GSCSVariable **)marker
+                                               errors: (NSArray **)errors;
+
+- (void) addVariable: (GSCSVariable *)variable
+         coefficient: (CGFloat)coefficient
+        toExpression: (GSCSLinearExpression *)expression;
+
+- (void) addExpression: (GSCSLinearExpression *)source
+            multiplier: (CGFloat)multiplier
+          toExpression: (GSCSLinearExpression *)destination;
+
+- (void) addErrorVariable: (GSCSVariable *)variable
+                 strength: (GSCSStrength *)strength;
+
+- (BOOL) tryAddingDirectly: (GSCSLinearExpression *)expression;
+
+- (GSCSVariable *) chooseSubject: (GSCSLinearExpression *)expression;
+
+- (void) addWithArtificialVariable: (GSCSLinearExpression *)expression;
+
+- (GSCSVariable *) exitVariableForMarker: (GSCSVariable *)marker;
+
+- (void) optimize: (GSCSVariable *)objective;
+
+- (void) setExternalVariables;
+
+@end
 
 @implementation GSCassowarySolver
 
-- (void) addConstraint: (GSCSConstraint*)constraint
+- (instancetype) init
 {
-  // FIXME Add constraint to solver
+  self = [super init];
+  if (self != nil)
+    {
+      _tableau = [[GSCSTableau alloc] init];
+      _editVariableManager = [[GSCSEditVariableManager alloc] init];
+      ASSIGN(_markerVariables, [NSMapTable strongToStrongObjectsMapTable]);
+      ASSIGN(_errorVariables, [NSMapTable strongToStrongObjectsMapTable]);
+      _externalVariables = [[NSMutableSet alloc] init];
+      _artificialCounter = 0;
+      _slackCounter = 0;
+      _dummyCounter = 0;
+    }
+  return self;
 }
 
-- (void) addConstraints: (NSArray*)constraints
+- (void) addConstraint: (GSCSConstraint *)constraint
 {
-  // FIXME Add constraints to solver
+  GSCSVariable *marker = nil;
+  NSArray *errors = nil;
+  GSCSLinearExpression *expression =
+    [self expressionForNewConstraint: constraint marker: &marker errors: &errors];
+
+  if (![self tryAddingDirectly: expression])
+    {
+      [self addWithArtificialVariable: expression];
+    }
+
+  if (marker != nil)
+    {
+      [_markerVariables setObject: marker forKey: constraint];
+    }
+  if (errors != nil)
+    {
+      [_errorVariables setObject: errors forKey: constraint];
+    }
+
+  [self optimize: [_tableau objective]];
+  [self setExternalVariables];
 }
 
-- (void) removeConstraint: (GSCSConstraint*)constraint
+- (void) addConstraints: (NSArray *)constraints
 {
-  // FIXME Remove constraint from solver
+  FOR_IN(GSCSConstraint *, constraint, constraints)
+    [self addConstraint: constraint];
+  END_FOR_IN(constraints);
 }
 
-- (void) removeConstraints: (NSArray*)constraints
+- (void) removeConstraint: (GSCSConstraint *)constraint
 {
-    // FIXME Remove constraints from solver
+  GSCSVariable *marker = [_markerVariables objectForKey: constraint];
+  if (marker == nil)
+    {
+      [[NSException
+         exceptionWithName: NSInvalidArgumentException
+                    reason: @"Constraint was not previously added to the solver"
+                  userInfo: nil] raise];
+      return;
+    }
+
+  GSCSVariable *objective = [_tableau objective];
+  GSCSLinearExpression *objectiveRow =
+    [_tableau rowExpressionForVariable: objective];
+
+  // Take the error variables of this constraint back out of the objective.
+  NSArray *errors = [_errorVariables objectForKey: constraint];
+  if (errors != nil)
+    {
+      CGFloat weight = [[constraint strength] strength];
+      FOR_IN(GSCSVariable *, errorVariable, errors)
+        GSCSLinearExpression *errorRow =
+          [_tableau rowExpressionForVariable: errorVariable];
+        if (errorRow == nil)
+          {
+            [_tableau addVariable: errorVariable
+                     toExpression: objectiveRow
+                  withCoefficient: -weight
+                          subject: objective];
+          }
+        else
+          {
+            [_tableau addNewExpression: errorRow
+                          toExpression: objectiveRow
+                                     n: -weight
+                               subject: objective];
+          }
+      END_FOR_IN(errors);
+    }
+
+  RETAIN(marker);
+  [_markerVariables removeObjectForKey: constraint];
+
+  // If the marker is not basic, pivot it into the basis so its row can be
+  // removed.
+  if ([_tableau rowExpressionForVariable: marker] == nil)
+    {
+      GSCSVariable *exitVariable = [self exitVariableForMarker: marker];
+      if (exitVariable != nil)
+        {
+          [_tableau pivotWithEntryVariable: marker exitVariable: exitVariable];
+        }
+    }
+
+  if ([_tableau rowExpressionForVariable: marker] != nil)
+    {
+      [_tableau removeRowForVariable: marker];
+    }
+  if ([_tableau hasColumnForVariable: marker])
+    {
+      [_tableau removeColumn: marker];
+    }
+
+  if (errors != nil)
+    {
+      FOR_IN(GSCSVariable *, errorVariable, errors)
+        if (errorVariable != marker)
+          {
+            [_tableau removeColumn: errorVariable];
+          }
+      END_FOR_IN(errors);
+      [_errorVariables removeObjectForKey: constraint];
+    }
+  RELEASE(marker);
+
+  [self optimize: objective];
+  [self setExternalVariables];
 }
 
-- (GSCSSolution*) solve
+- (void) removeConstraints: (NSArray *)constraints
 {
-    // FIXME Return correct solution
-    return [[GSCSSolution alloc] init];
+  FOR_IN(GSCSConstraint *, constraint, constraints)
+    [self removeConstraint: constraint];
+  END_FOR_IN(constraints);
 }
 
-- (void) suggestEditVariable: (GSCSVariable*)variable equals: (CGFloat)value
+- (GSCSSolution *) solve
 {
-    // FIXME Suggest edit variable
+  [self setExternalVariables];
+
+  GSCSSolution *solution = AUTORELEASE([[GSCSSolution alloc] init]);
+  FOR_IN(GSCSVariable *, variable, _externalVariables)
+    [solution setResult: [variable value] forVariable: variable];
+  END_FOR_IN(_externalVariables);
+
+  return solution;
+}
+
+- (void) suggestEditVariable: (GSCSVariable *)variable equals: (CGFloat)value
+{
+  // FIXME Suggest edit variable
+}
+
+// Build the augmented expression for a new constraint. Basic variables are
+// replaced by their current row expressions; slack, dummy and error variables
+// are introduced according to the constraint relation and strength. The marker
+// variable (and error variables, if any) are returned so the constraint can be
+// removed later.
+- (GSCSLinearExpression *) expressionForNewConstraint: (GSCSConstraint *)constraint
+                                               marker: (GSCSVariable **)markerOut
+                                               errors: (NSArray **)errorsOut
+{
+  GSCSLinearExpression *constraintExpression = [constraint expression];
+  GSCSLinearExpression *expression = AUTORELEASE([[GSCSLinearExpression alloc]
+    initWithConstant: [constraintExpression constant]]);
+
+  NSArray *termVariables = [constraintExpression termVariables];
+  FOR_IN(GSCSVariable *, variable, termVariables)
+    CGFloat coefficient = [constraintExpression coefficientForTerm: variable];
+    GSCSLinearExpression *row = [_tableau rowExpressionForVariable: variable];
+    if (row == nil)
+      {
+        [self addVariable: variable
+              coefficient: coefficient
+             toExpression: expression];
+        if ([variable isExternal])
+          {
+            [_externalVariables addObject: variable];
+          }
+      }
+    else
+      {
+        [self addExpression: row
+                 multiplier: coefficient
+               toExpression: expression];
+      }
+  END_FOR_IN(termVariables);
+
+  GSCSVariable *marker = nil;
+  NSMutableArray *errors = nil;
+  GSCSStrength *strength = [constraint strength];
+
+  if ([constraint isInequality])
+    {
+      _slackCounter++;
+      GSCSVariable *slack = [GSCSVariable slackVariableWithName:
+        [NSString stringWithFormat: @"s%ld", (long) _slackCounter]];
+      [self addVariable: slack coefficient: -1.0 toExpression: expression];
+      marker = slack;
+
+      if (![constraint isRequired])
+        {
+          _slackCounter++;
+          GSCSVariable *eMinus = [GSCSVariable slackVariableWithName:
+            [NSString stringWithFormat: @"em%ld", (long) _slackCounter]];
+          [self addVariable: eMinus coefficient: 1.0 toExpression: expression];
+          [self addErrorVariable: eMinus strength: strength];
+          errors = [NSMutableArray arrayWithObject: eMinus];
+        }
+    }
+  else
+    {
+      if ([constraint isRequired])
+        {
+          _dummyCounter++;
+          GSCSVariable *dummy = [GSCSVariable dummyVariableWithName:
+            [NSString stringWithFormat: @"d%ld", (long) _dummyCounter]];
+          [self addVariable: dummy coefficient: 1.0 toExpression: expression];
+          marker = dummy;
+        }
+      else
+        {
+          _slackCounter++;
+          GSCSVariable *ePlus = [GSCSVariable slackVariableWithName:
+            [NSString stringWithFormat: @"ep%ld", (long) _slackCounter]];
+          _slackCounter++;
+          GSCSVariable *eMinus = [GSCSVariable slackVariableWithName:
+            [NSString stringWithFormat: @"em%ld", (long) _slackCounter]];
+          [self addVariable: ePlus coefficient: -1.0 toExpression: expression];
+          [self addVariable: eMinus coefficient: 1.0 toExpression: expression];
+          marker = ePlus;
+          [self addErrorVariable: ePlus strength: strength];
+          [self addErrorVariable: eMinus strength: strength];
+          errors = [NSMutableArray arrayWithObjects: ePlus, eMinus, nil];
+        }
+    }
+
+  if ([expression constant] < 0.0)
+    {
+      [expression normalize];
+    }
+
+  *markerOut = marker;
+  *errorsOut = errors;
+  return expression;
+}
+
+// Accumulating add of a single term into an expression that is not yet in the
+// tableau. GSCSLinearExpression -addVariable:coefficient: overwrites an
+// existing coefficient rather than summing, so the running total is computed
+// here.
+- (void) addVariable: (GSCSVariable *)variable
+         coefficient: (CGFloat)coefficient
+        toExpression: (GSCSLinearExpression *)expression
+{
+  CGFloat existing = [expression isTermForVariable: variable]
+    ? [expression coefficientForTerm: variable] : 0.0;
+  CGFloat updated = existing + coefficient;
+  if ([GSCSFloatComparator isApproxiatelyZero: updated])
+    {
+      [expression removeVariable: variable];
+    }
+  else
+    {
+      [expression addVariable: variable coefficient: updated];
+    }
+}
+
+- (void) addExpression: (GSCSLinearExpression *)source
+            multiplier: (CGFloat)multiplier
+          toExpression: (GSCSLinearExpression *)destination
+{
+  [destination setConstant:
+    [destination constant] + multiplier * [source constant]];
+  NSArray *termVariables = [source termVariables];
+  FOR_IN(GSCSVariable *, variable, termVariables)
+    [self addVariable: variable
+          coefficient: multiplier * [source coefficientForTerm: variable]
+         toExpression: destination];
+  END_FOR_IN(termVariables);
+}
+
+- (void) addErrorVariable: (GSCSVariable *)variable
+                 strength: (GSCSStrength *)strength
+{
+  GSCSVariable *objective = [_tableau objective];
+  GSCSLinearExpression *objectiveRow =
+    [_tableau rowExpressionForVariable: objective];
+  [_tableau addVariable: variable
+           toExpression: objectiveRow
+        withCoefficient: [strength strength]
+                subject: objective];
+}
+
+- (BOOL) tryAddingDirectly: (GSCSLinearExpression *)expression
+{
+  GSCSVariable *subject = [self chooseSubject: expression];
+  if (subject == nil)
+    {
+      return NO;
+    }
+
+  [expression newSubject: subject];
+  if ([_tableau hasColumnForVariable: subject])
+    {
+      [_tableau substituteOutVariable: subject forExpression: expression];
+    }
+  [_tableau addRowForVariable: subject equalsExpression: expression];
+  return YES;
+}
+
+// Select the variable that will become basic for a new row, following the
+// Cassowary chooseSubject procedure: prefer an unrestricted variable, then a
+// restricted variable not yet used elsewhere, and finally handle the all-dummy
+// case.
+- (GSCSVariable *) chooseSubject: (GSCSLinearExpression *)expression
+{
+  GSCSVariable *subject = nil;
+  BOOL foundUnrestricted = NO;
+  BOOL foundNewRestricted = NO;
+  GSCSVariable *objective = [_tableau objective];
+  NSArray *termVariables = [expression termVariables];
+
+  FOR_IN(GSCSVariable *, variable, termVariables)
+    CGFloat coefficient = [expression coefficientForTerm: variable];
+    if (foundUnrestricted)
+      {
+        if (![variable isRestricted])
+          {
+            if (![_tableau hasColumnForVariable: variable])
+              {
+                return variable;
+              }
+          }
+      }
+    else
+      {
+        if ([variable isRestricted])
+          {
+            if (!foundNewRestricted && ![variable isDummy] && coefficient < 0.0)
+              {
+                NSSet *column = [_tableau columnForVariable: variable];
+                if (column == nil || [column count] == 0
+                    || ([column count] == 1
+                        && [column containsObject: objective]))
+                  {
+                    subject = variable;
+                    foundNewRestricted = YES;
+                  }
+              }
+          }
+        else
+          {
+            subject = variable;
+            foundUnrestricted = YES;
+          }
+      }
+  END_FOR_IN(termVariables);
+
+  if (subject != nil)
+    {
+      return subject;
+    }
+
+  CGFloat coefficient = 0.0;
+  FOR_IN(GSCSVariable *, variable, termVariables)
+    if (![variable isDummy])
+      {
+        return nil;
+      }
+    if (![_tableau hasColumnForVariable: variable])
+      {
+        subject = variable;
+        coefficient = [expression coefficientForTerm: variable];
+      }
+  END_FOR_IN(termVariables);
+
+  if (![GSCSFloatComparator isApproxiatelyZero: [expression constant]])
+    {
+      return nil;
+    }
+  if (coefficient > 0.0)
+    {
+      [expression normalize];
+    }
+  return subject;
+}
+
+// Add a row that has no valid subject by first minimising an artificial
+// objective. If the artificial objective cannot reach zero the required
+// constraints are unsatisfiable.
+- (void) addWithArtificialVariable: (GSCSLinearExpression *)expression
+{
+  _artificialCounter++;
+  GSCSVariable *artificial = [GSCSVariable slackVariableWithName:
+    [NSString stringWithFormat: @"a%ld", (long) _artificialCounter]];
+  GSCSVariable *artificialObjective =
+    [GSCSVariable objectiveVariableWithName: @"az"];
+  GSCSLinearExpression *artificialObjectiveRow = AUTORELEASE([expression copy]);
+
+  [_tableau addRowForVariable: artificialObjective
+             equalsExpression: artificialObjectiveRow];
+  [_tableau addRowForVariable: artificial equalsExpression: expression];
+
+  [self optimize: artificialObjective];
+
+  GSCSLinearExpression *optimizedRow =
+    [_tableau rowExpressionForVariable: artificialObjective];
+  if (![GSCSFloatComparator isApproxiatelyZero: [optimizedRow constant]])
+    {
+      [_tableau removeRowForVariable: artificialObjective];
+      [_tableau removeColumn: artificial];
+      [[NSException
+         exceptionWithName: NSInvalidArgumentException
+                    reason: @"Cannot satisfy the required constraints"
+                  userInfo: nil] raise];
+      return;
+    }
+
+  GSCSLinearExpression *artificialRow =
+    [_tableau rowExpressionForVariable: artificial];
+  if (artificialRow != nil)
+    {
+      if ([artificialRow isConstant])
+        {
+          [_tableau removeRowForVariable: artificial];
+          [_tableau removeRowForVariable: artificialObjective];
+          return;
+        }
+      GSCSVariable *entryVariable = [artificialRow anyPivotableVariable];
+      [_tableau pivotWithEntryVariable: entryVariable
+                          exitVariable: artificial];
+    }
+
+  [_tableau removeRowForVariable: artificialObjective];
+  [_tableau removeColumn: artificial];
+}
+
+// Choose the variable that leaves the basis when a marker is removed. Restricted
+// rows in the marker's column are preferred (first by the -constant/coefficient
+// ratio over negative coefficients, then by the constant/coefficient ratio);
+// otherwise any non-objective row in the column is used.
+- (GSCSVariable *) exitVariableForMarker: (GSCSVariable *)marker
+{
+  NSSet *column = [_tableau columnForVariable: marker];
+  if (column == nil)
+    {
+      return nil;
+    }
+
+  GSCSVariable *exitVariable = nil;
+  CGFloat minRatio = 0.0;
+
+  FOR_IN(GSCSVariable *, variable, column)
+    if ([variable isRestricted])
+      {
+        GSCSLinearExpression *row = [_tableau rowExpressionForVariable: variable];
+        CGFloat coefficient = [row coefficientForTerm: marker];
+        if (coefficient < 0.0)
+          {
+            CGFloat ratio = -[row constant] / coefficient;
+            if (exitVariable == nil || ratio < minRatio)
+              {
+                minRatio = ratio;
+                exitVariable = variable;
+              }
+          }
+      }
+  END_FOR_IN(column);
+  if (exitVariable != nil)
+    {
+      return exitVariable;
+    }
+
+  FOR_IN(GSCSVariable *, variable, column)
+    if ([variable isRestricted])
+      {
+        GSCSLinearExpression *row = [_tableau rowExpressionForVariable: variable];
+        CGFloat coefficient = [row coefficientForTerm: marker];
+        CGFloat ratio = [row constant] / coefficient;
+        if (exitVariable == nil || ratio < minRatio)
+          {
+            minRatio = ratio;
+            exitVariable = variable;
+          }
+      }
+  END_FOR_IN(column);
+  if (exitVariable != nil)
+    {
+      return exitVariable;
+    }
+
+  GSCSVariable *objective = [_tableau objective];
+  FOR_IN(GSCSVariable *, variable, column)
+    if (variable != objective)
+      {
+        exitVariable = variable;
+      }
+  END_FOR_IN(column);
+
+  return exitVariable;
+}
+
+// Drive the objective row to its optimum by repeatedly pivoting in the
+// pivotable column with the most negative coefficient.
+- (void) optimize: (GSCSVariable *)objective
+{
+  GSCSLinearExpression *objectiveRow =
+    [_tableau rowExpressionForVariable: objective];
+
+  while (YES)
+    {
+      GSCSVariable *entryVariable = nil;
+      CGFloat mostNegative = -1.0e-8;
+      NSArray *termVariables = [objectiveRow termVariables];
+      FOR_IN(GSCSVariable *, variable, termVariables)
+        if ([variable isPivotable])
+          {
+            CGFloat coefficient = [objectiveRow coefficientForTerm: variable];
+            if (coefficient < mostNegative)
+              {
+                mostNegative = coefficient;
+                entryVariable = variable;
+              }
+          }
+      END_FOR_IN(termVariables);
+
+      if (entryVariable == nil)
+        {
+          return;
+        }
+
+      GSCSVariable *exitVariable =
+        [_tableau findPivotableExitVariable: entryVariable];
+      if (exitVariable == nil)
+        {
+          [[NSException
+             exceptionWithName: NSInternalInconsistencyException
+                        reason: @"Objective function is unbounded"
+                      userInfo: nil] raise];
+          return;
+        }
+
+      [_tableau pivotWithEntryVariable: entryVariable
+                          exitVariable: exitVariable];
+      objectiveRow = [_tableau rowExpressionForVariable: objective];
+    }
+}
+
+- (void) setExternalVariables
+{
+  FOR_IN(GSCSVariable *, variable, _externalVariables)
+    GSCSLinearExpression *row = [_tableau rowExpressionForVariable: variable];
+    if (row != nil)
+      {
+        [variable setValue: [row constant]];
+      }
+    else
+      {
+        [variable setValue: 0.0];
+      }
+  END_FOR_IN(_externalVariables);
+}
+
+- (void) dealloc
+{
+  RELEASE(_tableau);
+  RELEASE(_editVariableManager);
+  RELEASE(_markerVariables);
+  RELEASE(_errorVariables);
+  RELEASE(_externalVariables);
+  [super dealloc];
 }
 
 @end

--- a/Source/GSCassowarySolver.m
+++ b/Source/GSCassowarySolver.m
@@ -57,6 +57,10 @@
 
 - (GSCSEditInfo *) editInfoForVariable: (GSCSVariable *)variable;
 
+- (void) registerEditInfoForConstraint: (GSCSConstraint *)constraint
+                                marker: (GSCSVariable *)marker
+                                errors: (NSArray *)errors;
+
 - (GSCSEditInfo *) addEditVariable: (GSCSVariable *)variable
                           strength: (GSCSStrength *)strength;
 
@@ -108,6 +112,12 @@
   if (errors != nil)
     {
       [_errorVariables setObject: errors forKey: constraint];
+    }
+  if ([constraint isEditConstraint] && marker != nil)
+    {
+      [self registerEditInfoForConstraint: constraint
+                                   marker: marker
+                                   errors: errors];
     }
 
   [self optimize: [_tableau objective]];
@@ -649,34 +659,47 @@
   return nil;
 }
 
-// Register a variable for editing by adding a non-required equality constraint
-// pinning it to its current value. The constraint's error variables are used to
-// nudge the value in -suggestEditVariable:equals:.
-- (GSCSEditInfo *) addEditVariable: (GSCSVariable *)variable
-                          strength: (GSCSStrength *)strength
+// Record the edit information for an edit constraint as it is added, so that a
+// later -suggestEditVariable:equals: adjusts this constraint rather than adding
+// a second, conflicting one.
+- (void) registerEditInfoForConstraint: (GSCSConstraint *)constraint
+                                marker: (GSCSVariable *)marker
+                                errors: (NSArray *)errors
 {
-  GSCSConstraint *editConstraint = AUTORELEASE([[GSCSConstraint alloc]
-    initEditConstraintWithVariable: variable strength: strength]);
-  [self addConstraint: editConstraint];
+  GSCSVariable *editVariable = [constraint variable];
+  if (editVariable == nil
+      || [_editVariableManager editInfoForConstraint: constraint] != nil)
+    {
+      return;
+    }
 
-  GSCSVariable *plusVariable = [_markerVariables objectForKey: editConstraint];
-  NSArray *errors = [_errorVariables objectForKey: editConstraint];
   GSCSVariable *minusVariable = nil;
   FOR_IN(GSCSVariable *, errorVariable, errors)
-    if (errorVariable != plusVariable)
+    if (errorVariable != marker)
       {
         minusVariable = errorVariable;
       }
   END_FOR_IN(errors);
 
   GSCSEditInfo *editInfo = AUTORELEASE([[GSCSEditInfo alloc]
-     initWithVariable: variable
-           constraint: editConstraint
-         plusVariable: plusVariable
+     initWithVariable: editVariable
+           constraint: constraint
+         plusVariable: marker
         minusVariable: minusVariable
-     previousConstant: [variable value]]);
+     previousConstant: [editVariable value]]);
   [_editVariableManager addEditInfo: editInfo];
-  return editInfo;
+}
+
+// Register a variable for editing by adding a non-required equality constraint
+// pinning it to its current value. -addConstraint: records the edit info; the
+// error variables are used to nudge the value in -suggestEditVariable:equals:.
+- (GSCSEditInfo *) addEditVariable: (GSCSVariable *)variable
+                          strength: (GSCSStrength *)strength
+{
+  GSCSConstraint *editConstraint = AUTORELEASE([[GSCSConstraint alloc]
+    initEditConstraintWithVariable: variable strength: strength]);
+  [self addConstraint: editConstraint];
+  return [self editInfoForVariable: variable];
 }
 
 // Apply a change to an edit constraint's constant by adjusting the constants of

--- a/Source/GSCassowarySolver.m
+++ b/Source/GSCassowarySolver.m
@@ -34,6 +34,12 @@
                                                marker: (GSCSVariable **)marker
                                                errors: (NSArray **)errors;
 
+- (void) addConstraintToTableau: (GSCSConstraint *)constraint;
+
+- (void) removeConstraintFromTableau: (GSCSConstraint *)constraint;
+
+- (void) resolve;
+
 - (void) addVariable: (GSCSVariable *)variable
          coefficient: (CGFloat)coefficient
         toExpression: (GSCSLinearExpression *)expression;
@@ -93,7 +99,7 @@
   return self;
 }
 
-- (void) addConstraint: (GSCSConstraint *)constraint
+- (void) addConstraintToTableau: (GSCSConstraint *)constraint
 {
   GSCSVariable *marker = nil;
   NSArray *errors = nil;
@@ -119,19 +125,35 @@
                                    marker: marker
                                    errors: errors];
     }
+}
 
+- (void) resolve
+{
   [self optimize: [_tableau objective]];
   [self setExternalVariables];
 }
 
-- (void) addConstraints: (NSArray *)constraints
+- (void) addConstraint: (GSCSConstraint *)constraint
 {
-  FOR_IN(GSCSConstraint *, constraint, constraints)
-    [self addConstraint: constraint];
-  END_FOR_IN(constraints);
+  [self addConstraintToTableau: constraint];
+  [self resolve];
 }
 
-- (void) removeConstraint: (GSCSConstraint *)constraint
+- (void) addConstraints: (NSArray *)constraints
+{
+  if ([constraints count] == 0)
+    {
+      return;
+    }
+
+  FOR_IN(GSCSConstraint *, constraint, constraints)
+    [self addConstraintToTableau: constraint];
+  END_FOR_IN(constraints);
+
+  [self resolve];
+}
+
+- (void) removeConstraintFromTableau: (GSCSConstraint *)constraint
 {
   GSCSVariable *marker = [_markerVariables objectForKey: constraint];
   if (marker == nil)
@@ -206,16 +228,26 @@
       [_errorVariables removeObjectForKey: constraint];
     }
   RELEASE(marker);
+}
 
-  [self optimize: objective];
-  [self setExternalVariables];
+- (void) removeConstraint: (GSCSConstraint *)constraint
+{
+  [self removeConstraintFromTableau: constraint];
+  [self resolve];
 }
 
 - (void) removeConstraints: (NSArray *)constraints
 {
+  if ([constraints count] == 0)
+    {
+      return;
+    }
+
   FOR_IN(GSCSConstraint *, constraint, constraints)
-    [self removeConstraint: constraint];
+    [self removeConstraintFromTableau: constraint];
   END_FOR_IN(constraints);
+
+  [self resolve];
 }
 
 - (GSCSSolution *) solve

--- a/Source/NSControl.m
+++ b/Source/NSControl.m
@@ -679,6 +679,18 @@ static NSNotificationCenter *nc;
   [self setFrameSize: [_cell cellSize]];
 }
 
+/** <p>Returns the natural size of the control's cell, used by the constraint
+    based layout system as the control's intrinsic content size.</p>
+ */
+- (NSSize) intrinsicContentSize
+{
+  if (_cell == nil)
+    {
+      return [super intrinsicContentSize];
+    }
+  return [_cell cellSize];
+}
+
 /** <p>Returns whether the NSControl's cell is opaque</p>
  */
 - (BOOL) isOpaque

--- a/Source/NSLayoutConstraint.m
+++ b/Source/NSLayoutConstraint.m
@@ -34,12 +34,18 @@
 #import "NSWindowPrivate.h"
 #import "AppKit/NSWindow.h"
 #import "AppKit/NSApplication.h"
-#import "NSAutoresizingMaskLayoutConstraint.h" 
+#import "NSAutoresizingMaskLayoutConstraint.h"
+#import "AppKit/NSLayoutGuide.h"
 #import "GSFastEnumeration.h"
 #import "GSAutoLayoutVFLParser.h"
 #import "GSAutoLayoutEngine.h"
 
+@interface NSView (GSAutoLayoutInstall)
+- (void) removeConstraint: (NSLayoutConstraint *)constraint;
+@end
+
 static NSMutableArray *activeConstraints = nil;
+static NSMapTable *installedContainers = nil;
 // static NSNotificationCenter *nc = nil;
 
 @implementation NSLayoutConstraint
@@ -50,6 +56,10 @@ static NSMutableArray *activeConstraints = nil;
     {
       [self setVersion: 1];
       activeConstraints = [[NSMutableArray alloc] initWithCapacity: 10];
+      installedContainers =
+        [[NSMapTable alloc] initWithKeyOptions: NSMapTableObjectPointerPersonality
+                                  valueOptions: NSMapTableWeakMemory
+                                      capacity: 10];
       // nc = [NSNotificationCenter defaultCenter];
 
       // [nc addObserver: self
@@ -226,15 +236,92 @@ static NSMutableArray *activeConstraints = nil;
   return r;
 }
 
++ (NSView *) _viewForLayoutItem: (id)item
+{
+  if (item == nil)
+    {
+      return nil;
+    }
+  if ([item isKindOfClass: [NSView class]])
+    {
+      return item;
+    }
+  if ([item respondsToSelector: @selector(owningView)])
+    {
+      return [item owningView];
+    }
+  return nil;
+}
+
+// The view that owns a constraint is the nearest ancestor shared by its two
+// items (or the single item for a non-relational constraint). The constraint is
+// handed to that view's per-window layout engine.
++ (NSView *) _containerViewForConstraint: (NSLayoutConstraint *)constraint
+{
+  NSView *firstView = [self _viewForLayoutItem: [constraint firstItem]];
+  NSView *secondView = [self _viewForLayoutItem: [constraint secondItem]];
+
+  if (secondView == nil)
+    {
+      return firstView;
+    }
+  if (firstView == nil)
+    {
+      return secondView;
+    }
+  if (firstView == secondView)
+    {
+      return firstView;
+    }
+  return [firstView ancestorSharedWithView: secondView];
+}
+
++ (void) _installConstraintIfPossible: (NSLayoutConstraint *)constraint
+{
+  if ([installedContainers objectForKey: constraint] != nil)
+    {
+      return;
+    }
+  NSView *container = [self _containerViewForConstraint: constraint];
+  if (container != nil && [container window] != nil)
+    {
+      [container addConstraint: constraint];
+      [installedContainers setObject: container forKey: constraint];
+    }
+}
+
++ (void) _installPendingConstraintsForView: (NSView *)view
+{
+  NSUInteger i, count = [activeConstraints count];
+  for (i = 0; i < count; i++)
+    {
+      [self _installConstraintIfPossible: [activeConstraints objectAtIndex: i]];
+    }
+}
+
 + (void) _activateConstraint: (NSLayoutConstraint *)constraint
 {
-  // [activeConstraints addObject: constraint];
-  // activeConstraints = [[activeConstraints sortedArrayUsingSelector: @selector(compare:)] mutableCopy];
+  if ([activeConstraints indexOfObjectIdenticalTo: constraint] == NSNotFound)
+    {
+      [activeConstraints addObject: constraint];
+    }
+  [self _installConstraintIfPossible: constraint];
 }
 
 + (void) _removeConstraint: (NSLayoutConstraint *)constraint
 {
-  [activeConstraints removeObject: constraint];
+  NSUInteger index = [activeConstraints indexOfObjectIdenticalTo: constraint];
+  if (index != NSNotFound)
+    {
+      [activeConstraints removeObjectAtIndex: index];
+    }
+
+  NSView *container = [installedContainers objectForKey: constraint];
+  if (container != nil)
+    {
+      [container removeConstraint: constraint];
+      [installedContainers removeObjectForKey: constraint];
+    }
 }
 
 + (NSArray *) constraintsWithVisualFormat: (NSString *)fmt 
@@ -274,13 +361,11 @@ static NSMutableArray *activeConstraints = nil;
       _multiplier = multiplier;
       _constant = constant;
       _priority = priority;
-      
-      [NSLayoutConstraint _activateConstraint: self];
     }
   return self;
 }
 
-+ (instancetype) constraintWithItem: (id)view1 
++ (instancetype) constraintWithItem: (id)view1
                           attribute: (NSLayoutAttribute)attr1 
                           relatedBy: (NSLayoutRelation)relation 
                              toItem: (id)view2 

--- a/Source/NSLayoutConstraint.m
+++ b/Source/NSLayoutConstraint.m
@@ -742,11 +742,40 @@ static NSMapTable *installedContainers = nil;
   [[self contentView] _layoutViewAndSubViews];
 }
 
+static NSLayoutConstraint *
+GSContentViewPin(NSView *view, NSLayoutAttribute attribute, CGFloat constant)
+{
+  return [NSLayoutConstraint constraintWithItem: view
+                                      attribute: attribute
+                                      relatedBy: NSLayoutRelationEqual
+                                         toItem: nil
+                                      attribute: NSLayoutAttributeNotAnAttribute
+                                     multiplier: 1.0
+                                       constant: constant];
+}
+
 - (void) _bootstrapAutoLayout
 {
   GSAutoLayoutEngine *layoutEngine = [[GSAutoLayoutEngine alloc] init];
   [self _setLayoutEngine: layoutEngine];
   RELEASE(layoutEngine);
+
+  // Pin the content view to its own bounds so subview constraints resolve to
+  // absolute positions in the content view's coordinate system. Without this
+  // the content view's origin and size are left undetermined by the solver.
+  NSView *contentView = [self contentView];
+  if (contentView != nil)
+    {
+      NSRect bounds = [contentView bounds];
+      [layoutEngine addConstraint:
+        GSContentViewPin(contentView, NSLayoutAttributeLeft, NSMinX(bounds))];
+      [layoutEngine addConstraint:
+        GSContentViewPin(contentView, NSLayoutAttributeBottom, NSMinY(bounds))];
+      [layoutEngine addConstraint:
+        GSContentViewPin(contentView, NSLayoutAttributeWidth, NSWidth(bounds))];
+      [layoutEngine addConstraint:
+        GSContentViewPin(contentView, NSLayoutAttributeHeight, NSHeight(bounds))];
+    }
 }
 
-@end 
+@end

--- a/Source/NSLayoutConstraint.m
+++ b/Source/NSLayoutConstraint.m
@@ -742,18 +742,6 @@ static NSMapTable *installedContainers = nil;
   [[self contentView] _layoutViewAndSubViews];
 }
 
-static NSLayoutConstraint *
-GSContentViewPin(NSView *view, NSLayoutAttribute attribute, CGFloat constant)
-{
-  return [NSLayoutConstraint constraintWithItem: view
-                                      attribute: attribute
-                                      relatedBy: NSLayoutRelationEqual
-                                         toItem: nil
-                                      attribute: NSLayoutAttributeNotAnAttribute
-                                     multiplier: 1.0
-                                       constant: constant];
-}
-
 - (void) _bootstrapAutoLayout
 {
   GSAutoLayoutEngine *layoutEngine = [[GSAutoLayoutEngine alloc] init];
@@ -763,19 +751,7 @@ GSContentViewPin(NSView *view, NSLayoutAttribute attribute, CGFloat constant)
   // Pin the content view to its own bounds so subview constraints resolve to
   // absolute positions in the content view's coordinate system. Without this
   // the content view's origin and size are left undetermined by the solver.
-  NSView *contentView = [self contentView];
-  if (contentView != nil)
-    {
-      NSRect bounds = [contentView bounds];
-      [layoutEngine addConstraint:
-        GSContentViewPin(contentView, NSLayoutAttributeLeft, NSMinX(bounds))];
-      [layoutEngine addConstraint:
-        GSContentViewPin(contentView, NSLayoutAttributeBottom, NSMinY(bounds))];
-      [layoutEngine addConstraint:
-        GSContentViewPin(contentView, NSLayoutAttributeWidth, NSWidth(bounds))];
-      [layoutEngine addConstraint:
-        GSContentViewPin(contentView, NSLayoutAttributeHeight, NSHeight(bounds))];
-    }
+  [layoutEngine pinContentView: [self contentView]];
 }
 
 @end

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -672,6 +672,11 @@ GSSetDragTypes(NSView* obj, NSArray *types)
   _needsUpdateConstraints = YES;
   _translatesAutoresizingMaskIntoConstraints = YES;
 
+  _huggingPriorities.horizontal = NSLayoutPriorityDefaultLow;
+  _huggingPriorities.vertical = NSLayoutPriorityDefaultLow;
+  _compressionPriorities.horizontal = NSLayoutPriorityDefaultHigh;
+  _compressionPriorities.vertical = NSLayoutPriorityDefaultHigh;
+
   return self;
 }
 

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -1274,7 +1274,10 @@ static NSSize _computeScale(NSSize fs, NSSize bs)
         }
       [self resetCursorRects];
       [self resizeSubviewsWithOldSize: old_size];
-      [self _autoLayoutContentViewResized];
+      if (GSAutoLayoutEngineExists)
+        {
+          [self _autoLayoutContentViewResized];
+        }
       if (_post_frame_changes)
         {
           [nc postNotificationName: NSViewFrameDidChangeNotification
@@ -1369,7 +1372,10 @@ static NSSize _computeScale(NSSize fs, NSSize bs)
         }
       [self resetCursorRects];
       [self resizeSubviewsWithOldSize: old_size];
-      [self _autoLayoutContentViewResized];
+      if (GSAutoLayoutEngineExists)
+        {
+          [self _autoLayoutContentViewResized];
+        }
       if (_post_frame_changes)
         {
           [nc postNotificationName: NSViewFrameDidChangeNotification

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -1269,6 +1269,7 @@ static NSSize _computeScale(NSSize fs, NSSize bs)
         }
       [self resetCursorRects];
       [self resizeSubviewsWithOldSize: old_size];
+      [self _autoLayoutContentViewResized];
       if (_post_frame_changes)
         {
           [nc postNotificationName: NSViewFrameDidChangeNotification
@@ -1363,6 +1364,7 @@ static NSSize _computeScale(NSSize fs, NSSize bs)
         }
       [self resetCursorRects];
       [self resizeSubviewsWithOldSize: old_size];
+      [self _autoLayoutContentViewResized];
       if (_post_frame_changes)
         {
           [nc postNotificationName: NSViewFrameDidChangeNotification
@@ -5424,6 +5426,26 @@ static NSView* findByTag(NSView *view, NSInteger aTag, NSUInteger *level)
 - (void) _layoutEngineDidChangeAlignmentRect
 {
   [[self superview] setNeedsLayout: YES];
+}
+
+// When a window content view that drives Auto Layout is resized, refresh the
+// content view size in the engine and lay the constrained subtree out again.
+- (void) _autoLayoutContentViewResized
+{
+  NSWindow *window = [self window];
+  if (window == nil || [window contentView] != self)
+    {
+      return;
+    }
+  GSAutoLayoutEngine *engine = [window _layoutEngine];
+  if (engine == nil)
+    {
+      return;
+    }
+  if ([engine updateContentViewSize])
+    {
+      [self _layoutViewAndSubViews];
+    }
 }
 
 - (GSAutoLayoutEngine*) _getOrCreateLayoutEngine

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -88,6 +88,10 @@
 #import "NSViewPrivate.h"
 #import "NSWindowPrivate.h"
 
+@interface NSLayoutConstraint (GSPrivate)
++ (void) _installPendingConstraintsForView: (NSView *)view;
+@end
+
 /*
  * We need a fast array that can store objects without retain/release ...
  */
@@ -384,6 +388,10 @@ GSSetDragTypes(NSView* obj, NSArray *types)
   if (vc != nil)
     {
       [vc _viewDidMoveToWindow];
+    }
+  if ([self window] != nil)
+    {
+      [NSLayoutConstraint _installPendingConstraintsForView: self];
     }
   if (_rFlags.has_subviews)
     {

--- a/Source/NSViewPrivate.h
+++ b/Source/NSViewPrivate.h
@@ -49,6 +49,8 @@
 
 - (void) _layoutEngineDidChangeAlignmentRect;
 
+- (void) _autoLayoutContentViewResized;
+
 @end
 
 #endif // _GNUstep_H_NSViewPrivate

--- a/Tests/gui/NSLayoutConstraint/activation.m
+++ b/Tests/gui/NSLayoutConstraint/activation.m
@@ -1,0 +1,98 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSLayoutConstraint.h>
+#import <AppKit/NSLayoutAnchor.h>
+
+static NSLayoutConstraint *
+pin(NSView *view, NSLayoutAttribute attribute, CGFloat constant)
+{
+  return [NSLayoutConstraint constraintWithItem: view
+                                      attribute: attribute
+                                      relatedBy: NSLayoutRelationEqual
+                                         toItem: nil
+                                      attribute: NSLayoutAttributeNotAnAttribute
+                                     multiplier: 1.0
+                                       constant: constant];
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSLayoutConstraint activation")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 300, 200)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSView *content = [w contentView];
+
+      NSView *sub = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 0, 0)]);
+      [sub setTranslatesAutoresizingMaskIntoConstraints: NO];
+      [content addSubview: sub];
+
+      /* Pin the content view origin so the subview position is fully
+         determined. */
+      [pin(content, NSLayoutAttributeLeft, 0.0) setActive: YES];
+      [pin(content, NSLayoutAttributeBottom, 0.0) setActive: YES];
+
+      NSLayoutConstraint *width =
+        [[sub widthAnchor] constraintEqualToConstant: 120.0];
+      NSLayoutConstraint *height =
+        [[sub heightAnchor] constraintEqualToConstant: 80.0];
+      NSLayoutConstraint *left =
+        [[sub leftAnchor] constraintEqualToAnchor: [content leftAnchor]
+                                         constant: 20.0];
+      NSLayoutConstraint *bottom =
+        [[sub bottomAnchor] constraintEqualToAnchor: [content bottomAnchor]
+                                           constant: 10.0];
+      [width setActive: YES];
+      [height setActive: YES];
+      [left setActive: YES];
+      [bottom setActive: YES];
+
+      PASS([width isActive] && [height isActive]
+        && [left isActive] && [bottom isActive],
+        "setActive: YES marks a constraint active");
+
+      [w layoutIfNeeded];
+
+      NSRect f = [sub frame];
+      PASS(fabs(f.size.width - 120.0) < 0.01,
+        "an active width constraint sets the solved width");
+      PASS(fabs(f.size.height - 80.0) < 0.01,
+        "an active height constraint sets the solved height");
+      PASS(fabs(f.origin.x - 20.0) < 0.01,
+        "an active leading constraint sets the solved origin x");
+      PASS(fabs(f.origin.y - 10.0) < 0.01,
+        "an active bottom constraint sets the solved origin y");
+
+      [width setActive: NO];
+      PASS([width isActive] == NO,
+        "setActive: NO marks a constraint inactive");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSLayoutConstraint activation")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSLayoutConstraint/activation.m
+++ b/Tests/gui/NSLayoutConstraint/activation.m
@@ -7,18 +7,6 @@
 #import <AppKit/NSLayoutConstraint.h>
 #import <AppKit/NSLayoutAnchor.h>
 
-static NSLayoutConstraint *
-pin(NSView *view, NSLayoutAttribute attribute, CGFloat constant)
-{
-  return [NSLayoutConstraint constraintWithItem: view
-                                      attribute: attribute
-                                      relatedBy: NSLayoutRelationEqual
-                                         toItem: nil
-                                      attribute: NSLayoutAttributeNotAnAttribute
-                                     multiplier: 1.0
-                                       constant: constant];
-}
-
 int
 main(int argc, const char **argv)
 {
@@ -46,11 +34,8 @@ main(int argc, const char **argv)
       [sub setTranslatesAutoresizingMaskIntoConstraints: NO];
       [content addSubview: sub];
 
-      /* Pin the content view origin so the subview position is fully
-         determined. */
-      [pin(content, NSLayoutAttributeLeft, 0.0) setActive: YES];
-      [pin(content, NSLayoutAttributeBottom, 0.0) setActive: YES];
-
+      /* The content view is pinned to its own bounds automatically, so the
+         subview position and size below are fully determined. */
       NSLayoutConstraint *width =
         [[sub widthAnchor] constraintEqualToConstant: 120.0];
       NSLayoutConstraint *height =

--- a/Tests/gui/NSLayoutConstraint/activation.m
+++ b/Tests/gui/NSLayoutConstraint/activation.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSLayoutConstraint activation")
 
   NS_DURING
@@ -78,6 +77,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSLayoutConstraint activation")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLayoutConstraint/batch.m
+++ b/Tests/gui/NSLayoutConstraint/batch.m
@@ -1,0 +1,151 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSLayoutConstraint.h>
+#import <AppKit/NSLayoutAnchor.h>
+
+static NSArray *
+constraintsForSubview(NSView *sub, NSView *content)
+{
+  return [NSArray arrayWithObjects:
+    [[sub leftAnchor] constraintEqualToAnchor: [content leftAnchor]
+                                     constant: 20.0],
+    [[sub bottomAnchor] constraintEqualToAnchor: [content bottomAnchor]
+                                       constant: 10.0],
+    [[sub widthAnchor] constraintEqualToAnchor: [content widthAnchor]
+                                      constant: -50.0],
+    [[sub heightAnchor] constraintEqualToAnchor: [content heightAnchor]
+                                       constant: -25.0],
+    nil];
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("NSLayoutConstraint batched add and remove")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w1 = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 300, 200)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSView *content1 = [w1 contentView];
+      NSView *sub1 = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 0, 0)]);
+      NSArray *batched;
+      NSRect batchedFrame;
+
+      [sub1 setTranslatesAutoresizingMaskIntoConstraints: NO];
+      [content1 addSubview: sub1];
+
+      batched = constraintsForSubview(sub1, content1);
+      [content1 addConstraints: batched];
+      [w1 layoutIfNeeded];
+      batchedFrame = [sub1 frame];
+
+      PASS(fabs(batchedFrame.size.width - 250.0) < 0.01
+        && fabs(batchedFrame.size.height - 175.0) < 0.01,
+        "a batch of constraints sizes the subview");
+      PASS(fabs(batchedFrame.origin.x - 20.0) < 0.01
+        && fabs(batchedFrame.origin.y - 10.0) < 0.01,
+        "a batch of constraints positions the subview");
+
+      /* The same constraints added one at a time must reach the same
+         solution. */
+      {
+        NSWindow *w2 = AUTORELEASE([[NSWindow alloc]
+          initWithContentRect: NSMakeRect(0, 0, 300, 200)
+                    styleMask: NSWindowStyleMaskBorderless
+                      backing: NSBackingStoreBuffered
+                        defer: NO]);
+        NSView *content2 = [w2 contentView];
+        NSView *sub2 = AUTORELEASE([[NSView alloc]
+          initWithFrame: NSMakeRect(0, 0, 0, 0)]);
+        NSEnumerator *en;
+        NSLayoutConstraint *c;
+        NSRect singleFrame;
+
+        [sub2 setTranslatesAutoresizingMaskIntoConstraints: NO];
+        [content2 addSubview: sub2];
+
+        en = [constraintsForSubview(sub2, content2) objectEnumerator];
+        while ((c = [en nextObject]) != nil)
+          {
+            [content2 addConstraint: c];
+          }
+        [w2 layoutIfNeeded];
+        singleFrame = [sub2 frame];
+
+        PASS(NSEqualRects(batchedFrame, singleFrame),
+          "a batch reaches the same frame as the same constraints added singly");
+      }
+
+      /* Resizing after a batched add reflows through the same engine. */
+      [w1 setContentSize: NSMakeSize(400, 300)];
+      PASS(fabs(NSWidth([sub1 frame]) - 350.0) < 0.01
+        && fabs(NSHeight([sub1 frame]) - 275.0) < 0.01,
+        "a batched subview reflows on resize");
+
+      /* A batched removal must leave the same state as removing the same
+         constraints one at a time. */
+      {
+        NSWindow *w3 = AUTORELEASE([[NSWindow alloc]
+          initWithContentRect: NSMakeRect(0, 0, 300, 200)
+                    styleMask: NSWindowStyleMaskBorderless
+                      backing: NSBackingStoreBuffered
+                        defer: NO]);
+        NSView *content3 = [w3 contentView];
+        NSView *sub3 = AUTORELEASE([[NSView alloc]
+          initWithFrame: NSMakeRect(0, 0, 0, 0)]);
+        NSArray *singly;
+        NSEnumerator *en;
+        NSLayoutConstraint *c;
+
+        [sub3 setTranslatesAutoresizingMaskIntoConstraints: NO];
+        [content3 addSubview: sub3];
+        singly = constraintsForSubview(sub3, content3);
+        [content3 addConstraints: singly];
+        [w3 setContentSize: NSMakeSize(400, 300)];
+        [w3 layoutIfNeeded];
+
+        [content1 removeConstraints: batched];
+
+        en = [singly objectEnumerator];
+        while ((c = [en nextObject]) != nil)
+          {
+            [content3 removeConstraint: c];
+          }
+
+        PASS(NSEqualRects([sub1 frame], [sub3 frame]),
+          "a batched removal leaves the same frame as removing singly");
+
+        [w1 setContentSize: NSMakeSize(500, 400)];
+        [w1 layoutIfNeeded];
+        [w3 setContentSize: NSMakeSize(500, 400)];
+        [w3 layoutIfNeeded];
+        PASS(NSEqualRects([sub1 frame], [sub3 frame]),
+          "a batched removal reflows the same as removing singly");
+      }
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSLayoutConstraint batched add and remove")
+  return 0;
+}

--- a/Tests/gui/NSLayoutConstraint/edgeInsets.m
+++ b/Tests/gui/NSLayoutConstraint/edgeInsets.m
@@ -1,0 +1,67 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSLayoutConstraint.h>
+#import <AppKit/NSLayoutAnchor.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSLayoutConstraint edge insets")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 300, 200)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSView *content = [w contentView];
+
+      NSView *sub = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 0, 0)]);
+      [sub setTranslatesAutoresizingMaskIntoConstraints: NO];
+      [content addSubview: sub];
+
+      /* Inset on all four edges. The trailing (right) and top constants are
+         negative offsets from the container edges. */
+      [[[sub leftAnchor] constraintEqualToAnchor: [content leftAnchor]
+                                        constant: 20.0] setActive: YES];
+      [[[sub rightAnchor] constraintEqualToAnchor: [content rightAnchor]
+                                         constant: -30.0] setActive: YES];
+      [[[sub bottomAnchor] constraintEqualToAnchor: [content bottomAnchor]
+                                          constant: 10.0] setActive: YES];
+      [[[sub topAnchor] constraintEqualToAnchor: [content topAnchor]
+                                       constant: -15.0] setActive: YES];
+
+      [w layoutIfNeeded];
+
+      NSRect f = [sub frame];
+      PASS(fabs(f.origin.x - 20.0) < 0.01, "left anchor insets the origin x");
+      PASS(fabs(f.origin.y - 10.0) < 0.01, "bottom anchor insets the origin y");
+      PASS(fabs(f.size.width - 250.0) < 0.01,
+        "a negative right anchor constant insets the width");
+      PASS(fabs(f.size.height - 175.0) < 0.01,
+        "a negative top anchor constant insets the height");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSLayoutConstraint edge insets")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSLayoutConstraint/edgeInsets.m
+++ b/Tests/gui/NSLayoutConstraint/edgeInsets.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSLayoutConstraint edge insets")
 
   NS_DURING
@@ -62,6 +61,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSLayoutConstraint edge insets")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLayoutConstraint/intrinsicSize.m
+++ b/Tests/gui/NSLayoutConstraint/intrinsicSize.m
@@ -1,0 +1,69 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSButton.h>
+#import <AppKit/NSLayoutConstraint.h>
+#import <AppKit/NSLayoutAnchor.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSLayoutConstraint intrinsic content size")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 300, 200)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSView *content = [w contentView];
+
+      NSButton *button = AUTORELEASE([[NSButton alloc]
+        initWithFrame: NSMakeRect(0, 0, 0, 0)]);
+      [button setTitle: @"Click Me"];
+      [button setTranslatesAutoresizingMaskIntoConstraints: NO];
+      [content addSubview: button];
+
+      NSSize intrinsic = [button intrinsicContentSize];
+      PASS(intrinsic.width > 0.0 && intrinsic.height > 0.0,
+        "a control reports a positive intrinsic content size");
+
+      /* Only position constraints: the button should adopt its intrinsic
+         content size in both dimensions. */
+      [[[button leftAnchor] constraintEqualToAnchor: [content leftAnchor]
+                                           constant: 20.0] setActive: YES];
+      [[[button bottomAnchor] constraintEqualToAnchor: [content bottomAnchor]
+                                             constant: 20.0] setActive: YES];
+
+      [w layoutIfNeeded];
+
+      NSRect f = [button frame];
+      PASS(fabs(f.size.width - intrinsic.width) < 0.5,
+        "the button width matches its intrinsic content width");
+      PASS(fabs(f.size.height - intrinsic.height) < 0.5,
+        "the button height matches its intrinsic content height");
+      PASS(fabs(f.origin.x - 20.0) < 0.5 && fabs(f.origin.y - 20.0) < 0.5,
+        "the button keeps its position constraints");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSLayoutConstraint intrinsic content size")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSLayoutConstraint/intrinsicSize.m
+++ b/Tests/gui/NSLayoutConstraint/intrinsicSize.m
@@ -11,7 +11,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSLayoutConstraint intrinsic content size")
 
   NS_DURING
@@ -64,6 +63,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSLayoutConstraint intrinsic content size")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLayoutConstraint/resize.m
+++ b/Tests/gui/NSLayoutConstraint/resize.m
@@ -1,0 +1,72 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSLayoutConstraint.h>
+#import <AppKit/NSLayoutAnchor.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSLayoutConstraint resize reflow")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 300, 200)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSView *content = [w contentView];
+
+      NSView *sub = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 0, 0)]);
+      [sub setTranslatesAutoresizingMaskIntoConstraints: NO];
+      [content addSubview: sub];
+
+      /* Subview sized relative to the content view, inset from two edges. */
+      [[[sub leftAnchor] constraintEqualToAnchor: [content leftAnchor]
+                                        constant: 20.0] setActive: YES];
+      [[[sub bottomAnchor] constraintEqualToAnchor: [content bottomAnchor]
+                                          constant: 10.0] setActive: YES];
+      [[[sub widthAnchor] constraintEqualToAnchor: [content widthAnchor]
+                                         constant: -50.0] setActive: YES];
+      [[[sub heightAnchor] constraintEqualToAnchor: [content heightAnchor]
+                                          constant: -25.0] setActive: YES];
+
+      [w layoutIfNeeded];
+      NSRect before = [sub frame];
+      PASS(fabs(before.size.width - 250.0) < 0.01
+        && fabs(before.size.height - 175.0) < 0.01,
+        "the subview tracks the initial content size");
+
+      /* Resizing the window reflows the subview without an explicit layout. */
+      [w setContentSize: NSMakeSize(400, 300)];
+      NSRect after = [sub frame];
+      PASS(fabs(after.origin.x - 20.0) < 0.01
+        && fabs(after.origin.y - 10.0) < 0.01,
+        "the subview keeps its insets after a resize");
+      PASS(fabs(after.size.width - 350.0) < 0.01
+        && fabs(after.size.height - 275.0) < 0.01,
+        "the subview reflows to the new content size");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSLayoutConstraint resize reflow")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSLayoutConstraint/resize.m
+++ b/Tests/gui/NSLayoutConstraint/resize.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSLayoutConstraint resize reflow")
 
   NS_DURING
@@ -67,6 +66,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSLayoutConstraint resize reflow")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLayoutConstraint/visualFormat.m
+++ b/Tests/gui/NSLayoutConstraint/visualFormat.m
@@ -1,0 +1,84 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSLayoutConstraint.h>
+
+static NSView *
+addSubview(NSView *content)
+{
+  NSView *v = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 0, 0)]);
+  [v setTranslatesAutoresizingMaskIntoConstraints: NO];
+  [content addSubview: v];
+  return v;
+}
+
+static void
+activateFormat(NSString *format, NSDictionary *views)
+{
+  [NSLayoutConstraint activateConstraints:
+    [NSLayoutConstraint constraintsWithVisualFormat: format
+                                            options: 0
+                                            metrics: nil
+                                              views: views]];
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSLayoutConstraint visual format")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 300, 200)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSView *content = [w contentView];
+
+      NSView *a = addSubview(content);
+      activateFormat(@"H:|-20-[a(100)]", [NSDictionary dictionaryWithObject: a forKey: @"a"]);
+
+      NSView *b = addSubview(content);
+      activateFormat(@"H:|-20-[b]-30-|", [NSDictionary dictionaryWithObject: b forKey: @"b"]);
+
+      NSView *c = addSubview(content);
+      activateFormat(@"V:|-10-[c]-20-|", [NSDictionary dictionaryWithObject: c forKey: @"c"]);
+
+      [w layoutIfNeeded];
+
+      NSRect fa = [a frame];
+      PASS(fabs(fa.origin.x - 20.0) < 0.01 && fabs(fa.size.width - 100.0) < 0.01,
+        "H:|-20-[a(100)] places a at x=20 with width 100");
+
+      NSRect fb = [b frame];
+      PASS(fabs(fb.origin.x - 20.0) < 0.01 && fabs(fb.size.width - 250.0) < 0.01,
+        "H:|-20-[b]-30-| insets b by 20 and 30 (width 250)");
+
+      NSRect fc = [c frame];
+      PASS(fabs(fc.origin.y - 20.0) < 0.01 && fabs(fc.size.height - 170.0) < 0.01,
+        "V:|-10-[c]-20-| insets c by 10 top and 20 bottom (height 170)");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSLayoutConstraint visual format")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSLayoutConstraint/visualFormat.m
+++ b/Tests/gui/NSLayoutConstraint/visualFormat.m
@@ -30,7 +30,6 @@ activateFormat(NSString *format, NSDictionary *views)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSLayoutConstraint visual format")
 
   NS_DURING
@@ -79,6 +78,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSLayoutConstraint visual format")
-  DESTROY(arp);
   return 0;
 }


### PR DESCRIPTION
GSCassowarySolver was a stub, so activating layout constraints produced no solution and constrained views laid out to a zero rect. This implements the solver and wires up activation so the anchor and NSLayoutConstraint APIs actually position views.

Changes:

- GSCassowarySolver: implement the simplex orchestration on top of GSCSTableau. Adding and removing required and non-required constraints, the artificial-variable path, objective optimisation, edit variables (suggestEditVariable:equals:), and reading the external variable values back out as a GSCSSolution.
- GSCSVariable: -isRestricted classified external variables as restricted and dummy variables as unrestricted, the reverse of the classification the tableau relies on for infeasible-row detection and exit-variable selection.
- GSCSTableau: -substituteOutTerm:withExpression:inExpression:subject: folded in the terms of the expression being modified instead of the terms of the substituting expression.
- GSCSEditInfo: retain the objects it stores, expose the error variables and previous constant, and track the constant as a CGFloat so fractional values are preserved.
- GSAutoLayoutEngine: -alignmentRectForView: and its helpers returned NSZeroRect; return the solved minX, minY, width and height for a view.
- NSLayoutConstraint: -setActive:, +activateConstraints: and the anchor methods now install a constraint against the layout engine of the view that owns it (the nearest ancestor shared by its two items) and remove it on deactivation. Constraints activated before their view has a window are installed once it moves into one. A constraint created with a factory method or initialiser is inactive until activated, matching AppKit.
- NSWindow: when the layout engine is created, the content view is pinned to its own bounds, so subview constraints resolve to absolute positions without the application constraining the root view.
- GSAutoLayoutEngine / GSAutoLayoutVFLParser: the engine multiplied a relational constraint's constant by -1 for the right, top and trailing attributes, which inverted the constant for anchor constraints and for those attributes in a visual format string. The constant is now applied as written, and the visual format parser negates the spacing for vertical arrangements.
- Resizing a window reflows its constrained subviews: the engine keeps the content view's size constraints and refreshes them from the current bounds, and a content view lays its constrained subtree out again when its frame changes.
- NSControl reports an intrinsic content size (its cell size), and NSView initialises the content hugging and compression resistance priorities, so a control can be laid out from its content without an explicit size constraint. This also fixed a freed-expression use in GSCSConstraint's inequality factory and a duplicate edit constraint in the solver, both first reached once the intrinsic size constraints run.

The GSCSVariable, GSCSTableau and GSCSEditInfo errors were never reached while the solver was stubbed.

The added gui tests drive subviews through the anchor and visual-format APIs and check the solved frames; they skip when no display is available.

Closes #540.
