### PR TITLE
Fix: NSBrowser -path omits the trailing separator for an unselected column

### DIFF
--- a/Source/NSBrowser.m
+++ b/Source/NSBrowser.m
@@ -875,11 +875,6 @@ static BOOL browserUseBezels;
     {
       id cell = [self selectedCellInColumn: i];
 
-      if (i != 0)
-	{
-	  [separator appendString: _pathSeparator];
-	}
-
       string = [cell stringValue];
 
       if (string == nil)
@@ -888,10 +883,12 @@ static BOOL browserUseBezels;
 	     doesn't make sense to go with the path */
 	  break;
 	}
-      else
+
+      if (i != 0)
 	{
-	  [separator appendString: string];
+	  [separator appendString: _pathSeparator];
 	}
+      [separator appendString: string];
     }
   /*
    * We actually return a mutable string, but that's ok since a mutable

--- a/Tests/gui/NSBrowser/path.m
+++ b/Tests/gui/NSBrowser/path.m
@@ -1,0 +1,96 @@
+/* -[NSBrowser path] names the columns up to the selection.  When a branch is
+   selected its child column is loaded but nothing in it is selected yet, so
+   the path ends at the branch with no trailing separator; once a row in the
+   child column is selected the path names both.  Checked against AppKit on a
+   macOS runner.  The browser uses the theme and font backend, so the set is
+   skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSBrowser.h>
+#include <AppKit/NSBrowserCell.h>
+
+@interface BrowserContent : NSObject
+@end
+
+@implementation BrowserContent
+- (NSInteger) browser: (NSBrowser *)sender numberOfRowsInColumn: (NSInteger)column
+{
+  if (column == 0) return 3;
+  if (column == 1) return 2;
+  return 0;
+}
+- (void) browser: (NSBrowser *)sender
+  willDisplayCell: (id)cell
+            atRow: (NSInteger)row
+           column: (NSInteger)column
+{
+  if (column == 0)
+    {
+      [cell setStringValue: [NSString stringWithFormat: @"c0r%ld", (long)row]];
+      [cell setLeaf: (row == 2)];
+    }
+  else
+    {
+      [cell setStringValue: [NSString stringWithFormat: @"c1r%ld", (long)row]];
+      [cell setLeaf: YES];
+    }
+}
+@end
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSBrowser *browser;
+  BrowserContent *content;
+
+  START_SET("NSBrowser path")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      content = AUTORELEASE([BrowserContent new]);
+      browser = AUTORELEASE([[NSBrowser alloc]
+        initWithFrame: NSMakeRect(0, 0, 300, 200)]);
+      [browser setDelegate: content];
+      [browser loadColumnZero];
+
+      [browser selectRow: 0 inColumn: 0];
+      pass([[browser path] isEqualToString: @"/c0r0"],
+           "a selected branch ends the path with no trailing separator");
+
+      [browser selectRow: 0 inColumn: 1];
+      pass([[browser path] isEqualToString: @"/c0r0/c1r0"],
+           "a selected leaf extends the path with its branch");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSBrowser path")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSBrowser/path.m
+++ b/Tests/gui/NSBrowser/path.m
@@ -72,11 +72,11 @@ main(int argc, char **argv)
       [browser loadColumnZero];
 
       [browser selectRow: 0 inColumn: 0];
-      pass([[browser path] isEqualToString: @"/c0r0"],
+      PASS([[browser path] isEqualToString: @"/c0r0"],
            "a selected branch ends the path with no trailing separator");
 
       [browser selectRow: 0 inColumn: 1];
-      pass([[browser path] isEqualToString: @"/c0r0/c1r0"],
+      PASS([[browser path] isEqualToString: @"/c0r0/c1r0"],
            "a selected leaf extends the path with its branch");
     }
   NS_HANDLER


### PR DESCRIPTION
-[NSBrowser path] walked the loaded columns and appended the path separator before checking whether a column had a selected cell. When a branch is selected its child column is loaded but not yet selected, so the path gained a trailing separator ("/c0r0/" where AppKit returns "/c0r0").

The separator is now appended only when a selected cell follows, so the path ends at the last selected column. A multi-component selection is unaffected.

Added Tests/gui/NSBrowser/path.m, checked against AppKit on a macOS runner; backend-guarded.