### PR TITLE
tests: add NSCollectionView tests

### DIFF
--- a/Tests/gui/NSCollectionView/data.m
+++ b/Tests/gui/NSCollectionView/data.m
@@ -77,11 +77,11 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 400, 300)]);
       [cv setDataSource: two];
       [cv reloadData];
-      pass([cv numberOfSections] == 2,
+      PASS([cv numberOfSections] == 2,
            "the data source's section count is reported");
-      pass([cv numberOfItemsInSection: 0] == 3,
+      PASS([cv numberOfItemsInSection: 0] == 3,
            "the first section reports three items");
-      pass([cv numberOfItemsInSection: 1] == 2,
+      PASS([cv numberOfItemsInSection: 1] == 2,
            "the second section reports two items");
 
       /* A data source without the optional section method reports one section. */
@@ -90,9 +90,9 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 400, 300)]);
       [cv2 setDataSource: one];
       [cv2 reloadData];
-      pass([cv2 numberOfSections] == 1,
+      PASS([cv2 numberOfSections] == 1,
            "a data source without a section count reports one section");
-      pass([cv2 numberOfItemsInSection: 0] == 4,
+      PASS([cv2 numberOfItemsInSection: 0] == 4,
            "the single section reports its items");
     }
   NS_HANDLER

--- a/Tests/gui/NSCollectionView/data.m
+++ b/Tests/gui/NSCollectionView/data.m
@@ -1,0 +1,112 @@
+/* Coverage for NSCollectionView's data source: the section and item counts it
+   reports from a data source.  A two-section source (three items then two)
+   drives the counts; a second source omits the optional
+   numberOfSectionsInCollectionView: and so reports a single section.  GNUstep
+   reads the counts from the data source directly; AppKit reaches the same
+   counts once the view lays out (a windowless macOS process reports them as
+   not yet loaded), so the counts are checked against the data source here.
+   The view uses the theme and font backend, so the set is skipped when the
+   backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSIndexPath.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSCollectionView.h>
+#include <AppKit/NSCollectionViewItem.h>
+
+@interface TwoSections : NSObject <NSCollectionViewDataSource>
+@end
+@implementation TwoSections
+- (NSInteger) numberOfSectionsInCollectionView: (NSCollectionView *)cv { return 2; }
+- (NSInteger) collectionView: (NSCollectionView *)cv
+       numberOfItemsInSection: (NSInteger)section
+{
+  return section == 0 ? 3 : 2;
+}
+- (NSCollectionViewItem *) collectionView: (NSCollectionView *)cv
+        itemForRepresentedObjectAtIndexPath: (NSIndexPath *)indexPath
+{
+  return AUTORELEASE([[NSCollectionViewItem alloc] init]);
+}
+@end
+
+@interface OneSection : NSObject <NSCollectionViewDataSource>
+@end
+@implementation OneSection
+- (NSInteger) collectionView: (NSCollectionView *)cv
+       numberOfItemsInSection: (NSInteger)section
+{
+  return 4;
+}
+- (NSCollectionViewItem *) collectionView: (NSCollectionView *)cv
+        itemForRepresentedObjectAtIndexPath: (NSIndexPath *)indexPath
+{
+  return AUTORELEASE([[NSCollectionViewItem alloc] init]);
+}
+@end
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSCollectionView *cv;
+  TwoSections *two;
+  OneSection *one;
+
+  START_SET("NSCollectionView data")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      two = AUTORELEASE([TwoSections new]);
+      cv = AUTORELEASE([[NSCollectionView alloc]
+        initWithFrame: NSMakeRect(0, 0, 400, 300)]);
+      [cv setDataSource: two];
+      [cv reloadData];
+      pass([cv numberOfSections] == 2,
+           "the data source's section count is reported");
+      pass([cv numberOfItemsInSection: 0] == 3,
+           "the first section reports three items");
+      pass([cv numberOfItemsInSection: 1] == 2,
+           "the second section reports two items");
+
+      /* A data source without the optional section method reports one section. */
+      one = AUTORELEASE([OneSection new]);
+      NSCollectionView *cv2 = AUTORELEASE([[NSCollectionView alloc]
+        initWithFrame: NSMakeRect(0, 0, 400, 300)]);
+      [cv2 setDataSource: one];
+      [cv2 reloadData];
+      pass([cv2 numberOfSections] == 1,
+           "a data source without a section count reports one section");
+      pass([cv2 numberOfItemsInSection: 0] == 4,
+           "the single section reports its items");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSCollectionView data")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSCollectionView/state.m
+++ b/Tests/gui/NSCollectionView/state.m
@@ -1,0 +1,77 @@
+/* Coverage for NSCollectionView selection state: the defaults that match
+   AppKit (no multiple selection, not selectable, empty selection sets, no
+   layout) and the setter round-trips.  Checked against AppKit on a macOS
+   runner.  The view uses the theme and font backend, so the set is skipped
+   when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSIndexSet.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSCollectionView.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSCollectionView *cv;
+
+  START_SET("NSCollectionView state")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      cv = AUTORELEASE([[NSCollectionView alloc]
+        initWithFrame: NSMakeRect(0, 0, 400, 300)]);
+
+      /* Defaults that match AppKit. */
+      pass([cv allowsMultipleSelection] == NO,
+           "multiple selection is off by default");
+      pass([cv isSelectable] == NO, "the view is not selectable by default");
+      pass([cv selectionIndexes] != nil
+           && [[cv selectionIndexes] count] == 0,
+           "the default selection index set is empty");
+      pass([cv collectionViewLayout] == nil,
+           "there is no layout by default");
+
+      /* Setter round-trips. */
+      [cv setAllowsMultipleSelection: YES];
+      pass([cv allowsMultipleSelection] == YES,
+           "setAllowsMultipleSelection: round trips");
+      [cv setSelectable: YES];
+      pass([cv isSelectable] == YES, "setSelectable: round trips");
+      [cv setAllowsEmptySelection: YES];
+      pass([cv allowsEmptySelection] == YES,
+           "setAllowsEmptySelection: YES round trips");
+      [cv setAllowsEmptySelection: NO];
+      pass([cv allowsEmptySelection] == NO,
+           "setAllowsEmptySelection: NO round trips");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSCollectionView state")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSCollectionView/state.m
+++ b/Tests/gui/NSCollectionView/state.m
@@ -38,26 +38,26 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 400, 300)]);
 
       /* Defaults that match AppKit. */
-      pass([cv allowsMultipleSelection] == NO,
+      PASS([cv allowsMultipleSelection] == NO,
            "multiple selection is off by default");
-      pass([cv isSelectable] == NO, "the view is not selectable by default");
-      pass([cv selectionIndexes] != nil
+      PASS([cv isSelectable] == NO, "the view is not selectable by default");
+      PASS([cv selectionIndexes] != nil
            && [[cv selectionIndexes] count] == 0,
            "the default selection index set is empty");
-      pass([cv collectionViewLayout] == nil,
+      PASS([cv collectionViewLayout] == nil,
            "there is no layout by default");
 
       /* Setter round-trips. */
       [cv setAllowsMultipleSelection: YES];
-      pass([cv allowsMultipleSelection] == YES,
+      PASS([cv allowsMultipleSelection] == YES,
            "setAllowsMultipleSelection: round trips");
       [cv setSelectable: YES];
-      pass([cv isSelectable] == YES, "setSelectable: round trips");
+      PASS([cv isSelectable] == YES, "setSelectable: round trips");
       [cv setAllowsEmptySelection: YES];
-      pass([cv allowsEmptySelection] == YES,
+      PASS([cv allowsEmptySelection] == YES,
            "setAllowsEmptySelection: YES round trips");
       [cv setAllowsEmptySelection: NO];
-      pass([cv allowsEmptySelection] == NO,
+      PASS([cv allowsEmptySelection] == NO,
            "setAllowsEmptySelection: NO round trips");
     }
   NS_HANDLER


### PR DESCRIPTION
Adds coverage for NSCollectionView selection state (defaults that match AppKit and the setter round-trips) and its data-source-driven section and item counts. A two-section data source (three then two items) and a single-section source drive the counts. GNUstep reads the counts from the data source directly; AppKit reaches the same counts once the view lays out. Values were checked against AppKit on a macOS runner. The sets are backend-guarded and skip when no backend is available.