### PR TITLE
Fix: NSCollectionView initialises its AppKit selection and background defaults

### DIFF
--- a/Source/NSCollectionView.m
+++ b/Source/NSCollectionView.m
@@ -295,6 +295,7 @@ static NSString *_placeholderItem = nil;
 
   DESTROY (_backgroundColors);
   DESTROY (_selectionIndexes);
+  DESTROY (_selectionIndexPaths);
   DESTROY (_items);
 
   // Managing items.
@@ -324,6 +325,10 @@ static NSString *_placeholderItem = nil;
   _content = [[NSArray alloc] init];
   _items = [[NSMutableArray alloc] init];
   _selectionIndexes = [[NSIndexSet alloc] init];
+  _selectionIndexPaths = [[NSSet alloc] init];
+  _allowsEmptySelection = YES;
+  _backgroundColors = [[NSArray alloc] initWithObjects:
+    [NSColor controlBackgroundColor], nil];
   _draggingOnIndex = NSNotFound;
 
   // 10.11 variables

--- a/Tests/gui/NSCollectionView/defaults.m
+++ b/Tests/gui/NSCollectionView/defaults.m
@@ -1,0 +1,64 @@
+/* A new NSCollectionView carries AppKit's selection and background defaults:
+   empty selection is allowed, the selection index paths are an empty set (not
+   nil) and there is a non-empty backgroundColors array.  Checked against
+   AppKit on a macOS runner.  The view uses the theme and font backend, so the
+   set is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSSet.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSCollectionView.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSCollectionView *cv;
+
+  START_SET("NSCollectionView defaults")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      cv = AUTORELEASE([[NSCollectionView alloc]
+        initWithFrame: NSMakeRect(0, 0, 400, 300)]);
+
+      pass([cv allowsEmptySelection] == YES,
+           "empty selection is allowed by default");
+      pass([cv selectionIndexPaths] != nil,
+           "the default selection index paths set is not nil");
+      pass([[cv selectionIndexPaths] count] == 0,
+           "the default selection index paths set is empty");
+      pass([cv backgroundColors] != nil
+           && [[cv backgroundColors] count] > 0,
+           "there is a non-empty backgroundColors array by default");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSCollectionView defaults")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSCollectionView/defaults.m
+++ b/Tests/gui/NSCollectionView/defaults.m
@@ -37,13 +37,13 @@ main(int argc, char **argv)
       cv = AUTORELEASE([[NSCollectionView alloc]
         initWithFrame: NSMakeRect(0, 0, 400, 300)]);
 
-      pass([cv allowsEmptySelection] == YES,
+      PASS([cv allowsEmptySelection] == YES,
            "empty selection is allowed by default");
-      pass([cv selectionIndexPaths] != nil,
+      PASS([cv selectionIndexPaths] != nil,
            "the default selection index paths set is not nil");
-      pass([[cv selectionIndexPaths] count] == 0,
+      PASS([[cv selectionIndexPaths] count] == 0,
            "the default selection index paths set is empty");
-      pass([cv backgroundColors] != nil
+      PASS([cv backgroundColors] != nil
            && [[cv backgroundColors] count] > 0,
            "there is a non-empty backgroundColors array by default");
     }


### PR DESCRIPTION
A newly created NSCollectionView diverged from AppKit on three initial values: allowsEmptySelection was NO where AppKit reports YES, selectionIndexPaths was nil where AppKit returns an empty set, and backgroundColors was nil where AppKit provides a one-colour array. -_initDefaults now sets these, and dealloc releases the selection index paths set.

Added Tests/gui/NSCollectionView/defaults.m, checked against AppKit on a macOS runner; backend-guarded.