### PR TITLE
Fix: NSCollectionView -setSelectionIndexes: tolerates indexes past the loaded items

### DIFF
--- a/Source/NSCollectionView.m
+++ b/Source/NSCollectionView.m
@@ -665,7 +665,7 @@ static NSString *_placeholderItem = nil;
     {
       if (index >= [_items count])
 	{
-	  continue;
+	  break;
 	}
 
       id item = [_items objectAtIndex: index];

--- a/Source/NSCollectionView.m
+++ b/Source/NSCollectionView.m
@@ -663,6 +663,11 @@ static NSString *_placeholderItem = nil;
   while ((index = [_selectionIndexes indexGreaterThanIndex: index]) !=
 	 NSNotFound)
     {
+      if (index >= [_items count])
+	{
+	  continue;
+	}
+
       id item = [_items objectAtIndex: index];
       if ([item respondsToSelector: @selector(setSelected:)])
 	{

--- a/Tests/gui/NSCollectionView/selection.m
+++ b/Tests/gui/NSCollectionView/selection.m
@@ -1,0 +1,67 @@
+/* -[NSCollectionView setSelectionIndexes:] stores the given indexes even when
+   they lie beyond the loaded items (AppKit keeps the selection index set
+   regardless of how many items exist).  Setting an index past the item count
+   used to raise NSRangeException.  Checked against AppKit on a macOS runner.
+   The view uses the theme and font backend, so the set is skipped when the
+   backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSIndexSet.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSCollectionView.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSCollectionView *cv;
+
+  START_SET("NSCollectionView selection")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      cv = AUTORELEASE([[NSCollectionView alloc]
+        initWithFrame: NSMakeRect(0, 0, 400, 300)]);
+      [cv setSelectable: YES];
+
+      /* No items are loaded, so index 1 is past the end. */
+      [cv setSelectionIndexes: [NSIndexSet indexSetWithIndex: 1]];
+      pass([[cv selectionIndexes] count] == 1,
+           "an out-of-range selection index is still stored");
+      pass([[cv selectionIndexes] containsIndex: 1],
+           "the stored selection keeps the given index");
+
+      [cv setSelectionIndexes: [NSIndexSet indexSet]];
+      pass([[cv selectionIndexes] count] == 0,
+           "the selection can be cleared");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSCollectionView selection")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSCollectionView/selection.m
+++ b/Tests/gui/NSCollectionView/selection.m
@@ -41,13 +41,13 @@ main(int argc, char **argv)
 
       /* No items are loaded, so index 1 is past the end. */
       [cv setSelectionIndexes: [NSIndexSet indexSetWithIndex: 1]];
-      pass([[cv selectionIndexes] count] == 1,
+      PASS([[cv selectionIndexes] count] == 1,
            "an out-of-range selection index is still stored");
-      pass([[cv selectionIndexes] containsIndex: 1],
+      PASS([[cv selectionIndexes] containsIndex: 1],
            "the stored selection keeps the given index");
 
       [cv setSelectionIndexes: [NSIndexSet indexSet]];
-      pass([[cv selectionIndexes] count] == 0,
+      PASS([[cv selectionIndexes] count] == 0,
            "the selection can be cleared");
     }
   NS_HANDLER


### PR DESCRIPTION
Setting a selection index beyond the number of loaded items raised NSRangeException: the loop that marks items selected read -[NSArray objectAtIndex:] for every selected index without checking it against the item count. AppKit keeps the selection index set regardless of how many items exist.

The loop now skips indexes past the loaded items; the selection index set is still stored.

Added Tests/gui/NSCollectionView/selection.m, checked against AppKit on a macOS runner; backend-guarded.