### PR TITLE
tests: add NSTextField tests

### DIFF
--- a/Tests/gui/NSTextField/rendering.m
+++ b/Tests/gui/NSTextField/rendering.m
@@ -1,0 +1,70 @@
+/* A text field that draws its background fills its interior with the
+   background colour.  This is a render regression lock (GNUstep against
+   itself), not a pixel comparison against AppKit.  The field uses the theme
+   and font backend, so the set is skipped when the backend is unavailable.
+*/
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSTextField.h>
+#import <AppKit/NSColor.h>
+#import <AppKit/NSBitmapImageRep.h>
+#import <AppKit/NSGraphics.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSTextField rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 60, 24)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSTextField *tf = AUTORELEASE([[NSTextField alloc]
+        initWithFrame: NSMakeRect(0, 0, 60, 24)]);
+      [tf setBezeled: NO];
+      [tf setBordered: NO];
+      [tf setDrawsBackground: YES];
+      [tf setBackgroundColor: [NSColor redColor]];
+      [w setContentView: tf];
+
+      [tf lockFocus];
+      [tf drawRect: [tf bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 60, 24)]);
+      [tf unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 60 && [rep pixelsHigh] == 24,
+        "a text field renders into a bitmap of its bounds");
+
+      NSColor *centre = [[rep colorAtX: 30 y: 12]
+        colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+      PASS(centre != nil
+           && [centre redComponent] > 0.9
+           && [centre greenComponent] < 0.1
+           && [centre blueComponent] < 0.1,
+        "the interior is filled with the red background colour");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSTextField rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTextField/state.m
+++ b/Tests/gui/NSTextField/state.m
@@ -1,0 +1,104 @@
+/* Coverage for NSTextField state: the defaults of a plain frame-initialised
+   field (editable, selectable, bezeled, not bordered, draws its background,
+   left alignment, square bezel, no attribute editing, colours present, empty
+   value, no placeholder), the setter round-trips and the rule that making a
+   field editable also makes it selectable.  Checked against AppKit on a macOS
+   runner (alignment and bezel style are compared by their enumerated names,
+   whose raw values differ between GNUstep and macOS).  The field uses the
+   theme and font backend, so the set is skipped when the backend is
+   unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTextField.h>
+#include <AppKit/NSText.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTextField *tf;
+
+  START_SET("NSTextField state")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tf = AUTORELEASE([[NSTextField alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 22)]);
+
+      /* Defaults. */
+      pass([tf isEditable] == YES, "a text field is editable by default");
+      pass([tf isSelectable] == YES, "a text field is selectable by default");
+      pass([tf isBezeled] == YES, "a text field is bezeled by default");
+      pass([tf isBordered] == NO, "a text field is not bordered by default");
+      pass([tf drawsBackground] == YES,
+           "a text field draws its background by default");
+      pass([tf alignment] == NSTextAlignmentLeft,
+           "the default alignment is left");
+      pass([tf allowsEditingTextAttributes] == NO,
+           "attribute editing is off by default");
+      pass([tf textColor] != nil, "there is a text colour by default");
+      pass([tf backgroundColor] != nil, "there is a background colour by default");
+      pass([[tf stringValue] isEqualToString: @""],
+           "the default string value is empty");
+      pass([tf placeholderString] == nil, "there is no placeholder by default");
+
+      /* Setter round-trips. */
+      [tf setEditable: NO];
+      pass([tf isEditable] == NO, "setEditable: round trips");
+      [tf setSelectable: NO];
+      pass([tf isSelectable] == NO, "setSelectable: round trips");
+      [tf setBezeled: NO];
+      pass([tf isBezeled] == NO, "setBezeled: round trips");
+      [tf setBordered: YES];
+      pass([tf isBordered] == YES, "setBordered: round trips");
+      [tf setDrawsBackground: NO];
+      pass([tf drawsBackground] == NO, "setDrawsBackground: round trips");
+      [tf setAlignment: NSTextAlignmentRight];
+      pass([tf alignment] == NSTextAlignmentRight, "setAlignment: round trips");
+      [tf setStringValue: @"hello"];
+      pass([[tf stringValue] isEqualToString: @"hello"],
+           "setStringValue: round trips");
+      [tf setPlaceholderString: @"type here"];
+      pass([[tf placeholderString] isEqualToString: @"type here"],
+           "setPlaceholderString: round trips");
+
+      /* Making a field editable makes it selectable too. */
+      NSTextField *tf2 = AUTORELEASE([[NSTextField alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 22)]);
+      [tf2 setSelectable: NO];
+      [tf2 setEditable: YES];
+      pass([tf2 isSelectable] == YES,
+           "making a field editable makes it selectable");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSTextField state")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTextField/state.m
+++ b/Tests/gui/NSTextField/state.m
@@ -43,40 +43,40 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 120, 22)]);
 
       /* Defaults. */
-      pass([tf isEditable] == YES, "a text field is editable by default");
-      pass([tf isSelectable] == YES, "a text field is selectable by default");
-      pass([tf isBezeled] == YES, "a text field is bezeled by default");
-      pass([tf isBordered] == NO, "a text field is not bordered by default");
-      pass([tf drawsBackground] == YES,
+      PASS([tf isEditable] == YES, "a text field is editable by default");
+      PASS([tf isSelectable] == YES, "a text field is selectable by default");
+      PASS([tf isBezeled] == YES, "a text field is bezeled by default");
+      PASS([tf isBordered] == NO, "a text field is not bordered by default");
+      PASS([tf drawsBackground] == YES,
            "a text field draws its background by default");
-      pass([tf alignment] == NSTextAlignmentLeft,
+      PASS([tf alignment] == NSTextAlignmentLeft,
            "the default alignment is left");
-      pass([tf allowsEditingTextAttributes] == NO,
+      PASS([tf allowsEditingTextAttributes] == NO,
            "attribute editing is off by default");
-      pass([tf textColor] != nil, "there is a text colour by default");
-      pass([tf backgroundColor] != nil, "there is a background colour by default");
-      pass([[tf stringValue] isEqualToString: @""],
+      PASS([tf textColor] != nil, "there is a text colour by default");
+      PASS([tf backgroundColor] != nil, "there is a background colour by default");
+      PASS([[tf stringValue] isEqualToString: @""],
            "the default string value is empty");
-      pass([tf placeholderString] == nil, "there is no placeholder by default");
+      PASS([tf placeholderString] == nil, "there is no placeholder by default");
 
       /* Setter round-trips. */
       [tf setEditable: NO];
-      pass([tf isEditable] == NO, "setEditable: round trips");
+      PASS([tf isEditable] == NO, "setEditable: round trips");
       [tf setSelectable: NO];
-      pass([tf isSelectable] == NO, "setSelectable: round trips");
+      PASS([tf isSelectable] == NO, "setSelectable: round trips");
       [tf setBezeled: NO];
-      pass([tf isBezeled] == NO, "setBezeled: round trips");
+      PASS([tf isBezeled] == NO, "setBezeled: round trips");
       [tf setBordered: YES];
-      pass([tf isBordered] == YES, "setBordered: round trips");
+      PASS([tf isBordered] == YES, "setBordered: round trips");
       [tf setDrawsBackground: NO];
-      pass([tf drawsBackground] == NO, "setDrawsBackground: round trips");
+      PASS([tf drawsBackground] == NO, "setDrawsBackground: round trips");
       [tf setAlignment: NSTextAlignmentRight];
-      pass([tf alignment] == NSTextAlignmentRight, "setAlignment: round trips");
+      PASS([tf alignment] == NSTextAlignmentRight, "setAlignment: round trips");
       [tf setStringValue: @"hello"];
-      pass([[tf stringValue] isEqualToString: @"hello"],
+      PASS([[tf stringValue] isEqualToString: @"hello"],
            "setStringValue: round trips");
       [tf setPlaceholderString: @"type here"];
-      pass([[tf placeholderString] isEqualToString: @"type here"],
+      PASS([[tf placeholderString] isEqualToString: @"type here"],
            "setPlaceholderString: round trips");
 
       /* Making a field editable makes it selectable too. */
@@ -84,7 +84,7 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 120, 22)]);
       [tf2 setSelectable: NO];
       [tf2 setEditable: YES];
-      pass([tf2 isSelectable] == YES,
+      PASS([tf2 isSelectable] == YES,
            "making a field editable makes it selectable");
     }
   NS_HANDLER


### PR DESCRIPTION
Adds coverage for NSTextField: the state defaults of a plain frame-initialised field, the setter round-trips, the rule that making a field editable also makes it selectable, and a render regression lock for the background fill. Alignment and bezel style are compared by their enumerated names, whose raw values differ between GNUstep and macOS. Values were checked against AppKit on a macOS runner. The sets are backend-guarded and skip when no backend is available.