### PR TITLE
tests: add NSComboBox tests

### DIFF
--- a/Tests/gui/NSComboBox/config.m
+++ b/Tests/gui/NSComboBox/config.m
@@ -1,0 +1,73 @@
+/* Coverage for the NSComboBox configuration: the defaults that match AppKit
+   (internal list mode, a vertical scroller, no completion, a bordered button,
+   no items and no selection) and the setter round-trips.  Checked against
+   AppKit on a macOS runner.  The combo box uses the theme and font backend,
+   so the set is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSComboBox.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSComboBox *cb;
+
+  START_SET("NSComboBox config")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      cb = AUTORELEASE([[NSComboBox alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 22)]);
+
+      /* Defaults. */
+      pass([cb usesDataSource] == NO,
+           "a combo box uses its internal list by default");
+      pass([cb hasVerticalScroller] == YES,
+           "a combo box has a vertical scroller by default");
+      pass([cb completes] == NO, "completion is off by default");
+      pass([cb isButtonBordered] == YES, "the button is bordered by default");
+      pass([cb numberOfItems] == 0, "a new combo box has no items");
+      pass([cb indexOfSelectedItem] == -1, "nothing is selected by default");
+
+      /* Setter round-trips. */
+      [cb setHasVerticalScroller: NO];
+      pass([cb hasVerticalScroller] == NO, "setHasVerticalScroller: round trips");
+      [cb setCompletes: YES];
+      pass([cb completes] == YES, "setCompletes: round trips");
+      [cb setButtonBordered: NO];
+      pass([cb isButtonBordered] == NO, "setButtonBordered: round trips");
+      [cb setItemHeight: 20.0];
+      pass([cb itemHeight] == 20.0, "setItemHeight: round trips");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSComboBox config")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSComboBox/config.m
+++ b/Tests/gui/NSComboBox/config.m
@@ -37,24 +37,24 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 120, 22)]);
 
       /* Defaults. */
-      pass([cb usesDataSource] == NO,
+      PASS([cb usesDataSource] == NO,
            "a combo box uses its internal list by default");
-      pass([cb hasVerticalScroller] == YES,
+      PASS([cb hasVerticalScroller] == YES,
            "a combo box has a vertical scroller by default");
-      pass([cb completes] == NO, "completion is off by default");
-      pass([cb isButtonBordered] == YES, "the button is bordered by default");
-      pass([cb numberOfItems] == 0, "a new combo box has no items");
-      pass([cb indexOfSelectedItem] == -1, "nothing is selected by default");
+      PASS([cb completes] == NO, "completion is off by default");
+      PASS([cb isButtonBordered] == YES, "the button is bordered by default");
+      PASS([cb numberOfItems] == 0, "a new combo box has no items");
+      PASS([cb indexOfSelectedItem] == -1, "nothing is selected by default");
 
       /* Setter round-trips. */
       [cb setHasVerticalScroller: NO];
-      pass([cb hasVerticalScroller] == NO, "setHasVerticalScroller: round trips");
+      PASS([cb hasVerticalScroller] == NO, "setHasVerticalScroller: round trips");
       [cb setCompletes: YES];
-      pass([cb completes] == YES, "setCompletes: round trips");
+      PASS([cb completes] == YES, "setCompletes: round trips");
       [cb setButtonBordered: NO];
-      pass([cb isButtonBordered] == NO, "setButtonBordered: round trips");
+      PASS([cb isButtonBordered] == NO, "setButtonBordered: round trips");
       [cb setItemHeight: 20.0];
-      pass([cb itemHeight] == 20.0, "setItemHeight: round trips");
+      PASS([cb itemHeight] == 20.0, "setItemHeight: round trips");
     }
   NS_HANDLER
     {

--- a/Tests/gui/NSComboBox/items.m
+++ b/Tests/gui/NSComboBox/items.m
@@ -39,26 +39,26 @@ main(int argc, char **argv)
       [cb addItemWithObjectValue: @"alpha"];
       [cb addItemWithObjectValue: @"beta"];
       [cb addItemWithObjectValue: @"gamma"];
-      pass([cb numberOfItems] == 3, "three items were added");
-      pass([[cb itemObjectValueAtIndex: 1] isEqualToString: @"beta"],
+      PASS([cb numberOfItems] == 3, "three items were added");
+      PASS([[cb itemObjectValueAtIndex: 1] isEqualToString: @"beta"],
            "the item at index one is the second added");
 
       [cb selectItemAtIndex: 2];
-      pass([cb indexOfSelectedItem] == 2, "selecting an item reports its index");
-      pass([[cb objectValueOfSelectedItem] isEqualToString: @"gamma"],
+      PASS([cb indexOfSelectedItem] == 2, "selecting an item reports its index");
+      PASS([[cb objectValueOfSelectedItem] isEqualToString: @"gamma"],
            "the selected item's object value is reported");
 
       [cb insertItemWithObjectValue: @"delta" atIndex: 0];
-      pass([cb numberOfItems] == 4, "inserting adds an item");
-      pass([[cb itemObjectValueAtIndex: 0] isEqualToString: @"delta"],
+      PASS([cb numberOfItems] == 4, "inserting adds an item");
+      PASS([[cb itemObjectValueAtIndex: 0] isEqualToString: @"delta"],
            "the inserted item is at the given index");
-      pass([cb indexOfItemWithObjectValue: @"beta"] == 2,
+      PASS([cb indexOfItemWithObjectValue: @"beta"] == 2,
            "an item is found by its object value");
 
       [cb removeItemAtIndex: 0];
-      pass([cb numberOfItems] == 3, "removing an item drops the count");
+      PASS([cb numberOfItems] == 3, "removing an item drops the count");
       [cb removeAllItems];
-      pass([cb numberOfItems] == 0, "removeAllItems empties the list");
+      PASS([cb numberOfItems] == 0, "removeAllItems empties the list");
     }
   NS_HANDLER
     {

--- a/Tests/gui/NSComboBox/items.m
+++ b/Tests/gui/NSComboBox/items.m
@@ -1,0 +1,77 @@
+/* Coverage for NSComboBox internal-list management (usesDataSource NO): adding,
+   indexing, selecting, inserting, searching and removing object values.
+   Checked against AppKit on a macOS runner.  The combo box uses the theme and
+   font backend, so the set is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSComboBox.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSComboBox *cb;
+
+  START_SET("NSComboBox items")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      cb = AUTORELEASE([[NSComboBox alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 22)]);
+
+      [cb addItemWithObjectValue: @"alpha"];
+      [cb addItemWithObjectValue: @"beta"];
+      [cb addItemWithObjectValue: @"gamma"];
+      pass([cb numberOfItems] == 3, "three items were added");
+      pass([[cb itemObjectValueAtIndex: 1] isEqualToString: @"beta"],
+           "the item at index one is the second added");
+
+      [cb selectItemAtIndex: 2];
+      pass([cb indexOfSelectedItem] == 2, "selecting an item reports its index");
+      pass([[cb objectValueOfSelectedItem] isEqualToString: @"gamma"],
+           "the selected item's object value is reported");
+
+      [cb insertItemWithObjectValue: @"delta" atIndex: 0];
+      pass([cb numberOfItems] == 4, "inserting adds an item");
+      pass([[cb itemObjectValueAtIndex: 0] isEqualToString: @"delta"],
+           "the inserted item is at the given index");
+      pass([cb indexOfItemWithObjectValue: @"beta"] == 2,
+           "an item is found by its object value");
+
+      [cb removeItemAtIndex: 0];
+      pass([cb numberOfItems] == 3, "removing an item drops the count");
+      [cb removeAllItems];
+      pass([cb numberOfItems] == 0, "removeAllItems empties the list");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSComboBox items")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds coverage for NSComboBox: the configuration defaults that match AppKit and the setter round-trips, and internal-list management (usesDataSource NO) — adding, indexing, selecting, inserting, searching and removing object values. Values were checked against AppKit on a macOS runner. The sets are backend-guarded and skip when no backend is available.