### PR TITLE
Fix: NSComboBox shows five items by default and stores any positive visible count

### DIFF
--- a/Source/NSComboBoxCell.m
+++ b/Source/NSComboBoxCell.m
@@ -654,7 +654,7 @@ static GSComboWindow *gsWindow = nil;
   //_completes = NO;
   _popUpList = [[NSMutableArray alloc] init];
   _hasVerticalScroller = YES;
-  _visibleItems = 10;
+  _visibleItems = 5;
   _intercellSpacing = NSMakeSize(3.0, 2.0);
   _itemHeight = 16;
   _selectedItem = -1;
@@ -762,7 +762,7 @@ static GSComboWindow *gsWindow = nil;
  */
 - (void) setNumberOfVisibleItems: (NSInteger)visibleItems
 {
-  if (visibleItems > 10)
+  if (visibleItems > 0)
     _visibleItems = visibleItems;
 }
 

--- a/Tests/gui/NSComboBox/visibleItems.m
+++ b/Tests/gui/NSComboBox/visibleItems.m
@@ -36,15 +36,15 @@ main(int argc, char **argv)
       cb = AUTORELEASE([[NSComboBox alloc]
         initWithFrame: NSMakeRect(0, 0, 120, 22)]);
 
-      pass([cb numberOfVisibleItems] == 5,
+      PASS([cb numberOfVisibleItems] == 5,
            "the default number of visible items is five");
 
       [cb setNumberOfVisibleItems: 8];
-      pass([cb numberOfVisibleItems] == 8,
+      PASS([cb numberOfVisibleItems] == 8,
            "a count of eight is stored");
 
       [cb setNumberOfVisibleItems: 12];
-      pass([cb numberOfVisibleItems] == 12,
+      PASS([cb numberOfVisibleItems] == 12,
            "a count above ten is stored");
     }
   NS_HANDLER

--- a/Tests/gui/NSComboBox/visibleItems.m
+++ b/Tests/gui/NSComboBox/visibleItems.m
@@ -1,0 +1,64 @@
+/* A combo box shows five items by default (matching AppKit), and
+   -setNumberOfVisibleItems: stores any positive count.  The setter used to
+   ignore counts of ten or fewer.  Checked against AppKit on a macOS runner.
+   The combo box uses the theme and font backend, so the set is skipped when
+   the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSComboBox.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSComboBox *cb;
+
+  START_SET("NSComboBox visible items")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      cb = AUTORELEASE([[NSComboBox alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 22)]);
+
+      pass([cb numberOfVisibleItems] == 5,
+           "the default number of visible items is five");
+
+      [cb setNumberOfVisibleItems: 8];
+      pass([cb numberOfVisibleItems] == 8,
+           "a count of eight is stored");
+
+      [cb setNumberOfVisibleItems: 12];
+      pass([cb numberOfVisibleItems] == 12,
+           "a count above ten is stored");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSComboBox visible items")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Two issues with the visible-item count, both in NSComboBoxCell:

- The default was ten where AppKit shows five.
- -setNumberOfVisibleItems: only stored the value when it was greater than ten, so a count of ten or fewer was silently ignored. It now stores any positive count.

Added Tests/gui/NSComboBox/visibleItems.m, checked against AppKit on a macOS runner; backend-guarded.