### PR TITLE
tests: add NSSegmentedControl tests

### DIFF
--- a/Tests/gui/NSSegmentedControl/rendering.m
+++ b/Tests/gui/NSSegmentedControl/rendering.m
@@ -1,0 +1,59 @@
+/* A segmented control with segments draws through its cell into a bitmap of
+   its own size.  This is a render regression lock (GNUstep against itself),
+   not a pixel comparison against AppKit.  The control uses the theme and font
+   backend, so the set is skipped when the backend is unavailable.
+*/
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSSegmentedControl.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSegmentedControl rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 120, 24)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSSegmentedControl *sc = AUTORELEASE([[NSSegmentedControl alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 24)]);
+      [sc setSegmentCount: 2];
+      [sc setLabel: @"one" forSegment: 0];
+      [sc setLabel: @"two" forSegment: 1];
+      [w setContentView: sc];
+
+      [sc lockFocus];
+      [sc drawRect: [sc bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 120, 24)]);
+      [sc unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 120 && [rep pixelsHigh] == 24,
+        "a segmented control renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSSegmentedControl rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSSegmentedControl/segments.m
+++ b/Tests/gui/NSSegmentedControl/segments.m
@@ -40,48 +40,48 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 200, 24)]);
 
       /* Defaults. */
-      pass([sc segmentCount] == 0, "a new control has no segments");
-      pass([sc selectedSegment] == -1, "nothing is selected by default");
-      pass([sc segmentStyle] == NSSegmentStyleAutomatic,
+      PASS([sc segmentCount] == 0, "a new control has no segments");
+      PASS([sc selectedSegment] == -1, "nothing is selected by default");
+      PASS([sc segmentStyle] == NSSegmentStyleAutomatic,
            "the default style is automatic");
 
       /* Segment management. */
       [sc setSegmentCount: 3];
-      pass([sc segmentCount] == 3, "setSegmentCount: sets the number of segments");
+      PASS([sc segmentCount] == 3, "setSegmentCount: sets the number of segments");
       [sc setLabel: @"A" forSegment: 0];
       [sc setLabel: @"B" forSegment: 1];
       [sc setLabel: @"C" forSegment: 2];
-      pass([[sc labelForSegment: 1] isEqualToString: @"B"],
+      PASS([[sc labelForSegment: 1] isEqualToString: @"B"],
            "a segment keeps its label");
-      pass([sc isEnabledForSegment: 0] == YES,
+      PASS([sc isEnabledForSegment: 0] == YES,
            "a segment is enabled by default");
       [sc setWidth: 40.0 forSegment: 0];
-      pass([sc widthForSegment: 0] == 40.0, "a segment keeps its width");
-      pass([sc widthForSegment: 1] == 0.0,
+      PASS([sc widthForSegment: 0] == 40.0, "a segment keeps its width");
+      PASS([sc widthForSegment: 1] == 0.0,
            "an unset width is zero (auto sized)");
 
       /* setSelectedSegment: selects one segment. */
       [sc setSelectedSegment: 2];
-      pass([sc selectedSegment] == 2, "setSelectedSegment: selects the segment");
-      pass([sc isSelectedForSegment: 2] == YES, "the selected segment reports selected");
-      pass([sc isSelectedForSegment: 0] == NO, "another segment is not selected");
+      PASS([sc selectedSegment] == 2, "setSelectedSegment: selects the segment");
+      PASS([sc isSelectedForSegment: 2] == YES, "the selected segment reports selected");
+      PASS([sc isSelectedForSegment: 0] == NO, "another segment is not selected");
 
       /* setSelected:forSegment: keeps a single selection (select-one tracking). */
       [sc setSelected: YES forSegment: 1];
-      pass([sc selectedSegment] == 1, "selecting a segment updates selectedSegment");
-      pass([sc isSelectedForSegment: 1] == YES, "the newly selected segment is selected");
-      pass([sc isSelectedForSegment: 2] == NO,
+      PASS([sc selectedSegment] == 1, "selecting a segment updates selectedSegment");
+      PASS([sc isSelectedForSegment: 1] == YES, "the newly selected segment is selected");
+      PASS([sc isSelectedForSegment: 2] == NO,
            "the previously selected segment is deselected");
 
       /* Per-segment enabled state. */
       [sc setEnabled: NO forSegment: 1];
-      pass([sc isEnabledForSegment: 1] == NO, "a segment can be disabled");
-      pass([sc isEnabledForSegment: 0] == YES,
+      PASS([sc isEnabledForSegment: 1] == NO, "a segment can be disabled");
+      PASS([sc isEnabledForSegment: 0] == YES,
            "disabling one segment leaves the others enabled");
 
       /* Segment style round-trip. */
       [sc setSegmentStyle: NSSegmentStyleCapsule];
-      pass([sc segmentStyle] == NSSegmentStyleCapsule,
+      PASS([sc segmentStyle] == NSSegmentStyleCapsule,
            "setSegmentStyle: round trips");
     }
   NS_HANDLER

--- a/Tests/gui/NSSegmentedControl/segments.m
+++ b/Tests/gui/NSSegmentedControl/segments.m
@@ -1,0 +1,101 @@
+/* Coverage for NSSegmentedControl: the defaults (no segments, no selection,
+   the automatic style), segment management (count, per-segment labels and
+   widths), select-one tracking (setSelectedSegment: and setSelected:forSegment:
+   both leave a single segment selected), per-segment enabled state and the
+   segment-style round-trip.  Checked against AppKit on a macOS runner.  The
+   control uses the theme and font backend, so the set is skipped when the
+   backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSegmentedControl.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSSegmentedControl *sc;
+
+  START_SET("NSSegmentedControl segments")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      sc = AUTORELEASE([[NSSegmentedControl alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 24)]);
+
+      /* Defaults. */
+      pass([sc segmentCount] == 0, "a new control has no segments");
+      pass([sc selectedSegment] == -1, "nothing is selected by default");
+      pass([sc segmentStyle] == NSSegmentStyleAutomatic,
+           "the default style is automatic");
+
+      /* Segment management. */
+      [sc setSegmentCount: 3];
+      pass([sc segmentCount] == 3, "setSegmentCount: sets the number of segments");
+      [sc setLabel: @"A" forSegment: 0];
+      [sc setLabel: @"B" forSegment: 1];
+      [sc setLabel: @"C" forSegment: 2];
+      pass([[sc labelForSegment: 1] isEqualToString: @"B"],
+           "a segment keeps its label");
+      pass([sc isEnabledForSegment: 0] == YES,
+           "a segment is enabled by default");
+      [sc setWidth: 40.0 forSegment: 0];
+      pass([sc widthForSegment: 0] == 40.0, "a segment keeps its width");
+      pass([sc widthForSegment: 1] == 0.0,
+           "an unset width is zero (auto sized)");
+
+      /* setSelectedSegment: selects one segment. */
+      [sc setSelectedSegment: 2];
+      pass([sc selectedSegment] == 2, "setSelectedSegment: selects the segment");
+      pass([sc isSelectedForSegment: 2] == YES, "the selected segment reports selected");
+      pass([sc isSelectedForSegment: 0] == NO, "another segment is not selected");
+
+      /* setSelected:forSegment: keeps a single selection (select-one tracking). */
+      [sc setSelected: YES forSegment: 1];
+      pass([sc selectedSegment] == 1, "selecting a segment updates selectedSegment");
+      pass([sc isSelectedForSegment: 1] == YES, "the newly selected segment is selected");
+      pass([sc isSelectedForSegment: 2] == NO,
+           "the previously selected segment is deselected");
+
+      /* Per-segment enabled state. */
+      [sc setEnabled: NO forSegment: 1];
+      pass([sc isEnabledForSegment: 1] == NO, "a segment can be disabled");
+      pass([sc isEnabledForSegment: 0] == YES,
+           "disabling one segment leaves the others enabled");
+
+      /* Segment style round-trip. */
+      [sc setSegmentStyle: NSSegmentStyleCapsule];
+      pass([sc segmentStyle] == NSSegmentStyleCapsule,
+           "setSegmentStyle: round trips");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSSegmentedControl segments")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds coverage for NSSegmentedControl: the defaults, segment management (count, per-segment labels and widths), select-one tracking (setSelectedSegment: and setSelected:forSegment: both leave a single segment selected), per-segment enabled state, the segment-style round-trip, and a render regression lock. Values were checked against AppKit on a macOS runner. The sets are backend-guarded and skip when no backend is available.