### PR TITLE
Fix: NSTokenField -initWithFrame: reads its cell defaults from the cell class

### DIFF
--- a/Source/NSTokenField.m
+++ b/Source/NSTokenField.m
@@ -73,12 +73,12 @@ static Class tokenFieldCellClass;
     {
       return nil;
     }
-  
+
   // initialize...
   [_cell setTokenStyle: NSDefaultTokenStyle];
-  [_cell setCompletionDelay: [_cell defaultCompletionDelay]];
-  [_cell setTokenizingCharacterSet: [_cell defaultTokenizingCharacterSet]];
-  
+  [_cell setCompletionDelay: [[_cell class] defaultCompletionDelay]];
+  [_cell setTokenizingCharacterSet: [[_cell class] defaultTokenizingCharacterSet]];
+
   return self;
 }
 

--- a/Tests/gui/NSTokenField/defaults.m
+++ b/Tests/gui/NSTokenField/defaults.m
@@ -1,0 +1,78 @@
+/* A frame-initialised NSTokenField constructs without hanging and carries its
+   token defaults: the default token style, a zero completion delay and a
+   tokenizing character set of a single comma.  The setters round-trip.
+   Checked against AppKit on a macOS runner (the token style is compared by
+   its enumerated name, whose raw value differs between GNUstep and macOS).
+   The field uses the theme and font backend, so the set is skipped when the
+   backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSCharacterSet.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTokenField.h>
+#include <AppKit/NSTokenFieldCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTokenField *tf;
+
+  START_SET("NSTokenField defaults")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tf = AUTORELEASE([[NSTokenField alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 22)]);
+
+      /* Defaults. */
+      pass([tf tokenStyle] == NSDefaultTokenStyle,
+           "the default token style is the default style");
+      pass([tf completionDelay] == 0.0, "the default completion delay is zero");
+      pass([[tf tokenizingCharacterSet] characterIsMember: ','],
+           "the default tokenizing set contains a comma");
+      pass([[tf tokenizingCharacterSet] characterIsMember: ' '] == NO,
+           "the default tokenizing set does not contain a space");
+
+      /* Setter round-trips. */
+      [tf setTokenStyle: NSRoundedTokenStyle];
+      pass([tf tokenStyle] == NSRoundedTokenStyle, "setTokenStyle: round trips");
+      [tf setCompletionDelay: 0.5];
+      pass([tf completionDelay] == 0.5, "setCompletionDelay: round trips");
+      [tf setTokenizingCharacterSet:
+        [NSCharacterSet characterSetWithCharactersInString: @";"]];
+      pass([[tf tokenizingCharacterSet] characterIsMember: ';'],
+           "setTokenizingCharacterSet: keeps the new separator");
+      pass([[tf tokenizingCharacterSet] characterIsMember: ','] == NO,
+           "setTokenizingCharacterSet: replaces the old separator");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSTokenField defaults")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTokenField/defaults.m
+++ b/Tests/gui/NSTokenField/defaults.m
@@ -41,24 +41,24 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 200, 22)]);
 
       /* Defaults. */
-      pass([tf tokenStyle] == NSDefaultTokenStyle,
+      PASS([tf tokenStyle] == NSDefaultTokenStyle,
            "the default token style is the default style");
-      pass([tf completionDelay] == 0.0, "the default completion delay is zero");
-      pass([[tf tokenizingCharacterSet] characterIsMember: ','],
+      PASS([tf completionDelay] == 0.0, "the default completion delay is zero");
+      PASS([[tf tokenizingCharacterSet] characterIsMember: ','],
            "the default tokenizing set contains a comma");
-      pass([[tf tokenizingCharacterSet] characterIsMember: ' '] == NO,
+      PASS([[tf tokenizingCharacterSet] characterIsMember: ' '] == NO,
            "the default tokenizing set does not contain a space");
 
       /* Setter round-trips. */
       [tf setTokenStyle: NSRoundedTokenStyle];
-      pass([tf tokenStyle] == NSRoundedTokenStyle, "setTokenStyle: round trips");
+      PASS([tf tokenStyle] == NSRoundedTokenStyle, "setTokenStyle: round trips");
       [tf setCompletionDelay: 0.5];
-      pass([tf completionDelay] == 0.5, "setCompletionDelay: round trips");
+      PASS([tf completionDelay] == 0.5, "setCompletionDelay: round trips");
       [tf setTokenizingCharacterSet:
         [NSCharacterSet characterSetWithCharactersInString: @";"]];
-      pass([[tf tokenizingCharacterSet] characterIsMember: ';'],
+      PASS([[tf tokenizingCharacterSet] characterIsMember: ';'],
            "setTokenizingCharacterSet: keeps the new separator");
-      pass([[tf tokenizingCharacterSet] characterIsMember: ','] == NO,
+      PASS([[tf tokenizingCharacterSet] characterIsMember: ','] == NO,
            "setTokenizingCharacterSet: replaces the old separator");
     }
   NS_HANDLER


### PR DESCRIPTION
Creating an NSTokenField hung. -initWithFrame: seeded the cell's completion delay and tokenizing character set with [_cell defaultCompletionDelay] and [_cell defaultTokenizingCharacterSet], but those are class methods; sending them to the cell instance did not return and the initializer never completed. They are now sent to the cell's class, as the cell's own initializer already does.

Added Tests/gui/NSTokenField/defaults.m, which constructs a field (previously hanging) and checks the token style, completion delay and tokenizing character-set defaults and round-trips, verified against AppKit on a macOS runner; backend-guarded.