### PR TITLE
Feature: NSTextField label and text-field convenience constructors

### DIFF
--- a/Headers/AppKit/NSTextField.h
+++ b/Headers/AppKit/NSTextField.h
@@ -52,8 +52,18 @@ APPKIT_EXPORT_CLASS
   NSText *_text_object;
 }
 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_12, GS_API_LATEST)
 //
-// Setting User Access to Text 
+// Creating Text Fields
+//
++ (instancetype) labelWithString: (NSString *)stringValue;
++ (instancetype) labelWithAttributedString: (NSAttributedString *)attributedStringValue;
++ (instancetype) textFieldWithString: (NSString *)stringValue;
++ (instancetype) wrappingLabelWithString: (NSString *)stringValue;
+#endif
+
+//
+// Setting User Access to Text
 //
 - (BOOL)isEditable;
 - (BOOL)isSelectable;

--- a/Source/NSTextField.m
+++ b/Source/NSTextField.m
@@ -105,6 +105,74 @@ static Class textFieldCellClass;
   return self;
 }
 
++ (instancetype) labelWithString: (NSString *)stringValue
+{
+  NSTextField *field = AUTORELEASE([[self alloc] initWithFrame: NSZeroRect]);
+
+  [field setEditable: NO];
+  [field setSelectable: NO];
+  [field setBezeled: NO];
+  [field setBordered: NO];
+  [field setDrawsBackground: NO];
+  [field setAlignment: NSTextAlignmentNatural];
+  [[field cell] setLineBreakMode: NSLineBreakByClipping];
+  [field setStringValue: stringValue];
+  [field sizeToFit];
+
+  return field;
+}
+
++ (instancetype) labelWithAttributedString: (NSAttributedString *)attributedStringValue
+{
+  NSTextField *field = AUTORELEASE([[self alloc] initWithFrame: NSZeroRect]);
+
+  [field setEditable: NO];
+  [field setSelectable: NO];
+  [field setBezeled: NO];
+  [field setBordered: NO];
+  [field setDrawsBackground: NO];
+  [field setAlignment: NSTextAlignmentNatural];
+  [[field cell] setLineBreakMode: NSLineBreakByWordWrapping];
+  [field setAttributedStringValue: attributedStringValue];
+  [field sizeToFit];
+
+  return field;
+}
+
++ (instancetype) textFieldWithString: (NSString *)stringValue
+{
+  NSTextField *field = AUTORELEASE([[self alloc] initWithFrame: NSZeroRect]);
+
+  [field setEditable: YES];
+  [field setSelectable: YES];
+  [field setBezeled: YES];
+  [field setBordered: NO];
+  [field setDrawsBackground: YES];
+  [field setAlignment: NSTextAlignmentNatural];
+  [[field cell] setLineBreakMode: NSLineBreakByClipping];
+  [field setStringValue: stringValue];
+  [field sizeToFit];
+
+  return field;
+}
+
++ (instancetype) wrappingLabelWithString: (NSString *)stringValue
+{
+  NSTextField *field = AUTORELEASE([[self alloc] initWithFrame: NSZeroRect]);
+
+  [field setEditable: NO];
+  [field setSelectable: YES];
+  [field setBezeled: NO];
+  [field setBordered: NO];
+  [field setDrawsBackground: NO];
+  [field setAlignment: NSTextAlignmentNatural];
+  [[field cell] setLineBreakMode: NSLineBreakByWordWrapping];
+  [field setStringValue: stringValue];
+  [field sizeToFit];
+
+  return field;
+}
+
 - (void) dealloc
 {
   if (_delegate != nil)

--- a/Tests/gui/NSTextField/constructors.m
+++ b/Tests/gui/NSTextField/constructors.m
@@ -1,0 +1,104 @@
+/* Coverage for the NSTextField convenience constructors: +labelWithString:,
+   +labelWithAttributedString:, +textFieldWithString: and
+   +wrappingLabelWithString:.  Each configures the field the way AppKit does
+   (checked against AppKit on a macOS runner): a label is not editable, not
+   bezeled, not bordered and draws no background; a text field is editable and
+   bezeled and draws its background; a wrapping label is selectable and word
+   wraps.  Line-break modes and alignment are compared by their enumerated
+   names, whose raw values differ between GNUstep and macOS.  The field uses
+   the theme and font backend, so the set is skipped when the backend is
+   unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSAttributedString.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTextField.h>
+#include <AppKit/NSText.h>
+#include <AppKit/NSParagraphStyle.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTextField *label, *field, *wrap, *attr;
+
+  START_SET("NSTextField constructors")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      /* +labelWithString: a static, non-interactive label. */
+      label = [NSTextField labelWithString: @"Label"];
+      pass([[label stringValue] isEqualToString: @"Label"],
+           "the label keeps its string");
+      pass([label isEditable] == NO, "a label is not editable");
+      pass([label isSelectable] == NO, "a label is not selectable");
+      pass([label isBezeled] == NO, "a label is not bezeled");
+      pass([label isBordered] == NO, "a label is not bordered");
+      pass([label drawsBackground] == NO, "a label draws no background");
+      pass([[label cell] lineBreakMode] == NSLineBreakByClipping,
+           "a label clips its line");
+      pass([label alignment] == NSTextAlignmentNatural,
+           "a label uses natural alignment");
+
+      /* +textFieldWithString: a standard editable field. */
+      field = [NSTextField textFieldWithString: @"Field"];
+      pass([[field stringValue] isEqualToString: @"Field"],
+           "the text field keeps its string");
+      pass([field isEditable] == YES, "a text field is editable");
+      pass([field isSelectable] == YES, "a text field is selectable");
+      pass([field isBezeled] == YES, "a text field is bezeled");
+      pass([field isBordered] == NO, "a text field is not bordered");
+      pass([field drawsBackground] == YES, "a text field draws its background");
+
+      /* +wrappingLabelWithString: a selectable, wrapping label. */
+      wrap = [NSTextField wrappingLabelWithString: @"Wrap"];
+      pass([[wrap stringValue] isEqualToString: @"Wrap"],
+           "the wrapping label keeps its string");
+      pass([wrap isEditable] == NO, "a wrapping label is not editable");
+      pass([wrap isSelectable] == YES, "a wrapping label is selectable");
+      pass([wrap isBezeled] == NO, "a wrapping label is not bezeled");
+      pass([wrap drawsBackground] == NO, "a wrapping label draws no background");
+      pass([[wrap cell] lineBreakMode] == NSLineBreakByWordWrapping,
+           "a wrapping label wraps at word boundaries");
+
+      /* +labelWithAttributedString: a rich-text label. */
+      attr = [NSTextField labelWithAttributedString:
+        AUTORELEASE([[NSAttributedString alloc] initWithString: @"Attr"])];
+      pass([[attr stringValue] isEqualToString: @"Attr"],
+           "the attributed label exposes its plain string");
+      pass([attr isEditable] == NO, "an attributed label is not editable");
+      pass([attr isSelectable] == NO, "an attributed label is not selectable");
+      pass([attr isBezeled] == NO, "an attributed label is not bezeled");
+      pass([[attr cell] lineBreakMode] == NSLineBreakByWordWrapping,
+           "an attributed label wraps at word boundaries");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSTextField constructors")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTextField/constructors.m
+++ b/Tests/gui/NSTextField/constructors.m
@@ -43,48 +43,48 @@ main(int argc, char **argv)
     {
       /* +labelWithString: a static, non-interactive label. */
       label = [NSTextField labelWithString: @"Label"];
-      pass([[label stringValue] isEqualToString: @"Label"],
+      PASS([[label stringValue] isEqualToString: @"Label"],
            "the label keeps its string");
-      pass([label isEditable] == NO, "a label is not editable");
-      pass([label isSelectable] == NO, "a label is not selectable");
-      pass([label isBezeled] == NO, "a label is not bezeled");
-      pass([label isBordered] == NO, "a label is not bordered");
-      pass([label drawsBackground] == NO, "a label draws no background");
-      pass([[label cell] lineBreakMode] == NSLineBreakByClipping,
+      PASS([label isEditable] == NO, "a label is not editable");
+      PASS([label isSelectable] == NO, "a label is not selectable");
+      PASS([label isBezeled] == NO, "a label is not bezeled");
+      PASS([label isBordered] == NO, "a label is not bordered");
+      PASS([label drawsBackground] == NO, "a label draws no background");
+      PASS([[label cell] lineBreakMode] == NSLineBreakByClipping,
            "a label clips its line");
-      pass([label alignment] == NSTextAlignmentNatural,
+      PASS([label alignment] == NSTextAlignmentNatural,
            "a label uses natural alignment");
 
       /* +textFieldWithString: a standard editable field. */
       field = [NSTextField textFieldWithString: @"Field"];
-      pass([[field stringValue] isEqualToString: @"Field"],
+      PASS([[field stringValue] isEqualToString: @"Field"],
            "the text field keeps its string");
-      pass([field isEditable] == YES, "a text field is editable");
-      pass([field isSelectable] == YES, "a text field is selectable");
-      pass([field isBezeled] == YES, "a text field is bezeled");
-      pass([field isBordered] == NO, "a text field is not bordered");
-      pass([field drawsBackground] == YES, "a text field draws its background");
+      PASS([field isEditable] == YES, "a text field is editable");
+      PASS([field isSelectable] == YES, "a text field is selectable");
+      PASS([field isBezeled] == YES, "a text field is bezeled");
+      PASS([field isBordered] == NO, "a text field is not bordered");
+      PASS([field drawsBackground] == YES, "a text field draws its background");
 
       /* +wrappingLabelWithString: a selectable, wrapping label. */
       wrap = [NSTextField wrappingLabelWithString: @"Wrap"];
-      pass([[wrap stringValue] isEqualToString: @"Wrap"],
+      PASS([[wrap stringValue] isEqualToString: @"Wrap"],
            "the wrapping label keeps its string");
-      pass([wrap isEditable] == NO, "a wrapping label is not editable");
-      pass([wrap isSelectable] == YES, "a wrapping label is selectable");
-      pass([wrap isBezeled] == NO, "a wrapping label is not bezeled");
-      pass([wrap drawsBackground] == NO, "a wrapping label draws no background");
-      pass([[wrap cell] lineBreakMode] == NSLineBreakByWordWrapping,
+      PASS([wrap isEditable] == NO, "a wrapping label is not editable");
+      PASS([wrap isSelectable] == YES, "a wrapping label is selectable");
+      PASS([wrap isBezeled] == NO, "a wrapping label is not bezeled");
+      PASS([wrap drawsBackground] == NO, "a wrapping label draws no background");
+      PASS([[wrap cell] lineBreakMode] == NSLineBreakByWordWrapping,
            "a wrapping label wraps at word boundaries");
 
       /* +labelWithAttributedString: a rich-text label. */
       attr = [NSTextField labelWithAttributedString:
         AUTORELEASE([[NSAttributedString alloc] initWithString: @"Attr"])];
-      pass([[attr stringValue] isEqualToString: @"Attr"],
+      PASS([[attr stringValue] isEqualToString: @"Attr"],
            "the attributed label exposes its plain string");
-      pass([attr isEditable] == NO, "an attributed label is not editable");
-      pass([attr isSelectable] == NO, "an attributed label is not selectable");
-      pass([attr isBezeled] == NO, "an attributed label is not bezeled");
-      pass([[attr cell] lineBreakMode] == NSLineBreakByWordWrapping,
+      PASS([attr isEditable] == NO, "an attributed label is not editable");
+      PASS([attr isSelectable] == NO, "an attributed label is not selectable");
+      PASS([attr isBezeled] == NO, "an attributed label is not bezeled");
+      PASS([[attr cell] lineBreakMode] == NSLineBreakByWordWrapping,
            "an attributed label wraps at word boundaries");
     }
   NS_HANDLER


### PR DESCRIPTION
Implements the NSTextField factory methods from 10.12: +labelWithString:, +labelWithAttributedString:, +textFieldWithString: and +wrappingLabelWithString:.

Each configures the field as AppKit does (verified against AppKit on a macOS runner): a label is not editable, not selectable, not bezeled, not bordered and draws no background; a text field is editable, selectable and bezeled and draws its background; a wrapping label is a selectable label that word wraps; the attributed label takes an attributed string. Each is sized to fit its content.

Added Tests/gui/NSTextField/constructors.m. Line-break modes and alignment are compared by their enumerated names, whose raw values differ between GNUstep and macOS. The set is backend-guarded.