### PR TITLE
tests: add NSProgressIndicator tests

### DIFF
--- a/Tests/gui/NSProgressIndicator/progress.m
+++ b/Tests/gui/NSProgressIndicator/progress.m
@@ -1,0 +1,105 @@
+/* Coverage for NSProgressIndicator value and configuration: the defaults that
+   match AppKit (a 0..100 range, indeterminate, bezeled, shown when stopped,
+   regular size, bar style), the setter round-trips, incrementBy: and the
+   clamping of the double value to the range.  Animation is not exercised.
+   Checked against AppKit on a macOS runner (control size and style are
+   compared by their enumerated names).  The indicator uses the theme and font
+   backend, so the set is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSProgressIndicator.h>
+#include <AppKit/NSCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSProgressIndicator *pi;
+
+  START_SET("NSProgressIndicator progress")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      pi = AUTORELEASE([[NSProgressIndicator alloc]
+        initWithFrame: NSMakeRect(0, 0, 160, 20)]);
+
+      /* Defaults. */
+      pass([pi minValue] == 0.0, "the default minimum is zero");
+      pass([pi maxValue] == 100.0, "the default maximum is one hundred");
+      pass([pi doubleValue] == 0.0, "the default value is zero");
+      pass([pi isIndeterminate] == YES, "an indicator is indeterminate by default");
+      pass([pi isBezeled] == YES, "an indicator is bezeled by default");
+      pass([pi isDisplayedWhenStopped] == YES,
+           "an indicator is shown when stopped by default");
+      pass([pi controlSize] == NSControlSizeRegular,
+           "the default control size is regular");
+      pass([pi style] == NSProgressIndicatorBarStyle,
+           "the default style is the bar style");
+
+      /* Setter round-trips. */
+      [pi setIndeterminate: NO];
+      pass([pi isIndeterminate] == NO, "setIndeterminate: round trips");
+      [pi setMinValue: 10.0];
+      pass([pi minValue] == 10.0, "setMinValue: round trips");
+      [pi setMaxValue: 200.0];
+      pass([pi maxValue] == 200.0, "setMaxValue: round trips");
+      [pi setDoubleValue: 50.0];
+      pass([pi doubleValue] == 50.0, "setDoubleValue: round trips");
+      [pi setControlSize: NSControlSizeSmall];
+      pass([pi controlSize] == NSControlSizeSmall, "setControlSize: round trips");
+      [pi setStyle: NSProgressIndicatorStyleSpinning];
+      pass([pi style] == NSProgressIndicatorStyleSpinning, "setStyle: round trips");
+      [pi setDisplayedWhenStopped: NO];
+      pass([pi isDisplayedWhenStopped] == NO,
+           "setDisplayedWhenStopped: round trips");
+      [pi setUsesThreadedAnimation: YES];
+      pass([pi usesThreadedAnimation] == YES,
+           "setUsesThreadedAnimation: round trips");
+
+      /* incrementBy: and clamping to the range. */
+      NSProgressIndicator *p2 = AUTORELEASE([[NSProgressIndicator alloc]
+        initWithFrame: NSMakeRect(0, 0, 160, 20)]);
+      [p2 setIndeterminate: NO];
+      [p2 setMinValue: 0.0];
+      [p2 setMaxValue: 100.0];
+      [p2 setDoubleValue: 20.0];
+      [p2 incrementBy: 5.0];
+      pass([p2 doubleValue] == 25.0, "incrementBy: advances the value");
+      [p2 setDoubleValue: 500.0];
+      pass([p2 doubleValue] == 100.0,
+           "a value above the maximum clamps to the maximum");
+      [p2 setDoubleValue: -10.0];
+      pass([p2 doubleValue] == 0.0,
+           "a value below the minimum clamps to the minimum");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSProgressIndicator progress")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSProgressIndicator/progress.m
+++ b/Tests/gui/NSProgressIndicator/progress.m
@@ -40,36 +40,36 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 160, 20)]);
 
       /* Defaults. */
-      pass([pi minValue] == 0.0, "the default minimum is zero");
-      pass([pi maxValue] == 100.0, "the default maximum is one hundred");
-      pass([pi doubleValue] == 0.0, "the default value is zero");
-      pass([pi isIndeterminate] == YES, "an indicator is indeterminate by default");
-      pass([pi isBezeled] == YES, "an indicator is bezeled by default");
-      pass([pi isDisplayedWhenStopped] == YES,
+      PASS([pi minValue] == 0.0, "the default minimum is zero");
+      PASS([pi maxValue] == 100.0, "the default maximum is one hundred");
+      PASS([pi doubleValue] == 0.0, "the default value is zero");
+      PASS([pi isIndeterminate] == YES, "an indicator is indeterminate by default");
+      PASS([pi isBezeled] == YES, "an indicator is bezeled by default");
+      PASS([pi isDisplayedWhenStopped] == YES,
            "an indicator is shown when stopped by default");
-      pass([pi controlSize] == NSControlSizeRegular,
+      PASS([pi controlSize] == NSControlSizeRegular,
            "the default control size is regular");
-      pass([pi style] == NSProgressIndicatorBarStyle,
+      PASS([pi style] == NSProgressIndicatorBarStyle,
            "the default style is the bar style");
 
       /* Setter round-trips. */
       [pi setIndeterminate: NO];
-      pass([pi isIndeterminate] == NO, "setIndeterminate: round trips");
+      PASS([pi isIndeterminate] == NO, "setIndeterminate: round trips");
       [pi setMinValue: 10.0];
-      pass([pi minValue] == 10.0, "setMinValue: round trips");
+      PASS([pi minValue] == 10.0, "setMinValue: round trips");
       [pi setMaxValue: 200.0];
-      pass([pi maxValue] == 200.0, "setMaxValue: round trips");
+      PASS([pi maxValue] == 200.0, "setMaxValue: round trips");
       [pi setDoubleValue: 50.0];
-      pass([pi doubleValue] == 50.0, "setDoubleValue: round trips");
+      PASS([pi doubleValue] == 50.0, "setDoubleValue: round trips");
       [pi setControlSize: NSControlSizeSmall];
-      pass([pi controlSize] == NSControlSizeSmall, "setControlSize: round trips");
+      PASS([pi controlSize] == NSControlSizeSmall, "setControlSize: round trips");
       [pi setStyle: NSProgressIndicatorStyleSpinning];
-      pass([pi style] == NSProgressIndicatorStyleSpinning, "setStyle: round trips");
+      PASS([pi style] == NSProgressIndicatorStyleSpinning, "setStyle: round trips");
       [pi setDisplayedWhenStopped: NO];
-      pass([pi isDisplayedWhenStopped] == NO,
+      PASS([pi isDisplayedWhenStopped] == NO,
            "setDisplayedWhenStopped: round trips");
       [pi setUsesThreadedAnimation: YES];
-      pass([pi usesThreadedAnimation] == YES,
+      PASS([pi usesThreadedAnimation] == YES,
            "setUsesThreadedAnimation: round trips");
 
       /* incrementBy: and clamping to the range. */
@@ -80,12 +80,12 @@ main(int argc, char **argv)
       [p2 setMaxValue: 100.0];
       [p2 setDoubleValue: 20.0];
       [p2 incrementBy: 5.0];
-      pass([p2 doubleValue] == 25.0, "incrementBy: advances the value");
+      PASS([p2 doubleValue] == 25.0, "incrementBy: advances the value");
       [p2 setDoubleValue: 500.0];
-      pass([p2 doubleValue] == 100.0,
+      PASS([p2 doubleValue] == 100.0,
            "a value above the maximum clamps to the maximum");
       [p2 setDoubleValue: -10.0];
-      pass([p2 doubleValue] == 0.0,
+      PASS([p2 doubleValue] == 0.0,
            "a value below the minimum clamps to the minimum");
     }
   NS_HANDLER

--- a/Tests/gui/NSProgressIndicator/rendering.m
+++ b/Tests/gui/NSProgressIndicator/rendering.m
@@ -1,0 +1,60 @@
+/* A determinate progress indicator draws into a bitmap of its own size.  This
+   is a render regression lock (GNUstep against itself), not a pixel comparison
+   against AppKit.  The indicator uses the theme and font backend, so the set
+   is skipped when the backend is unavailable.
+*/
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSProgressIndicator.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSProgressIndicator rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 160, 20)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSProgressIndicator *pi = AUTORELEASE([[NSProgressIndicator alloc]
+        initWithFrame: NSMakeRect(0, 0, 160, 20)]);
+      [pi setIndeterminate: NO];
+      [pi setMinValue: 0.0];
+      [pi setMaxValue: 100.0];
+      [pi setDoubleValue: 60.0];
+      [w setContentView: pi];
+
+      [pi lockFocus];
+      [pi drawRect: [pi bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 160, 20)]);
+      [pi unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 160 && [rep pixelsHigh] == 20,
+        "a progress indicator renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSProgressIndicator rendering")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds coverage for NSProgressIndicator value and configuration: the defaults, the setter round-trips, incrementBy:, and the clamping of the double value to the min/max range. Animation is not exercised. Control size and style are compared by their enumerated names. Values were checked against AppKit on a macOS runner. The sets are backend-guarded and skip when no backend is available.