### PR TITLE
tests: add NSImageView tests

### DIFF
--- a/Tests/gui/NSImageView/rendering.m
+++ b/Tests/gui/NSImageView/rendering.m
@@ -1,0 +1,58 @@
+/* An image view with a frame style draws into a bitmap of its own size.  This
+   is a render regression lock (GNUstep against itself), not a pixel comparison
+   against AppKit.  The view uses the theme and font backend, so the set is
+   skipped when the backend is unavailable.
+*/
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSImageView.h>
+#import <AppKit/NSImageCell.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSImageView rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 60, 60)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSImageView *iv = AUTORELEASE([[NSImageView alloc]
+        initWithFrame: NSMakeRect(0, 0, 60, 60)]);
+      [iv setImageFrameStyle: NSImageFrameGrayBezel];
+      [w setContentView: iv];
+
+      [iv lockFocus];
+      [iv drawRect: [iv bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 60, 60)]);
+      [iv unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 60 && [rep pixelsHigh] == 60,
+        "an image view renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSImageView rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSImageView/state.m
+++ b/Tests/gui/NSImageView/state.m
@@ -41,37 +41,37 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 80, 80)]);
 
       /* Defaults. */
-      pass([iv image] == nil, "a new image view has no image");
-      pass([iv imageAlignment] == NSImageAlignCenter,
+      PASS([iv image] == nil, "a new image view has no image");
+      PASS([iv imageAlignment] == NSImageAlignCenter,
            "the default alignment is centre");
-      pass([iv imageFrameStyle] == NSImageFrameNone,
+      PASS([iv imageFrameStyle] == NSImageFrameNone,
            "the default frame style is none");
-      pass([iv isEditable] == NO, "an image view is not editable by default");
-      pass([iv allowsCutCopyPaste] == YES,
+      PASS([iv isEditable] == NO, "an image view is not editable by default");
+      PASS([iv allowsCutCopyPaste] == YES,
            "cut, copy and paste are allowed by default");
 
       /* Round-trips. */
       [iv setImageAlignment: NSImageAlignTop];
-      pass([iv imageAlignment] == NSImageAlignTop, "setImageAlignment: round trips");
+      PASS([iv imageAlignment] == NSImageAlignTop, "setImageAlignment: round trips");
       [iv setImageScaling: NSImageScaleNone];
-      pass([iv imageScaling] == NSImageScaleNone, "setImageScaling: round trips");
+      PASS([iv imageScaling] == NSImageScaleNone, "setImageScaling: round trips");
       [iv setImageFrameStyle: NSImageFramePhoto];
-      pass([iv imageFrameStyle] == NSImageFramePhoto,
+      PASS([iv imageFrameStyle] == NSImageFramePhoto,
            "setImageFrameStyle: round trips");
       [iv setEditable: YES];
-      pass([iv isEditable] == YES, "setEditable: round trips");
+      PASS([iv isEditable] == YES, "setEditable: round trips");
 
       /* Image round-trip. */
       NSImage *img = AUTORELEASE([[NSImage alloc] initWithSize: NSMakeSize(16, 16)]);
       [iv setImage: img];
-      pass([iv image] == img, "setImage: keeps the image");
+      PASS([iv image] == img, "setImage: keeps the image");
 
       /* +imageViewWithImage: builds a non-editable view holding the image. */
       NSImageView *iv2 = [NSImageView imageViewWithImage: img];
-      pass([iv2 image] == img, "+imageViewWithImage: sets the image");
-      pass([iv2 isEditable] == NO,
+      PASS([iv2 image] == img, "+imageViewWithImage: sets the image");
+      PASS([iv2 isEditable] == NO,
            "+imageViewWithImage: makes a non-editable view");
-      pass([iv2 imageFrameStyle] == NSImageFrameNone,
+      PASS([iv2 imageFrameStyle] == NSImageFrameNone,
            "+imageViewWithImage: uses no frame");
     }
   NS_HANDLER

--- a/Tests/gui/NSImageView/state.m
+++ b/Tests/gui/NSImageView/state.m
@@ -1,0 +1,91 @@
+/* Coverage for NSImageView configuration: the defaults (no image, centre
+   alignment, no frame, not editable, cut/copy/paste allowed), the alignment,
+   scaling and frame-style round-trips, the image round-trip and the
+   +imageViewWithImage: constructor.  Checked against AppKit on a macOS runner
+   (alignment, scaling and frame style are compared by their enumerated names).
+   The view uses the theme and font backend, so the set is skipped when the
+   backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSImageView.h>
+#include <AppKit/NSImageCell.h>
+#include <AppKit/NSImage.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSImageView *iv;
+
+  START_SET("NSImageView state")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      iv = AUTORELEASE([[NSImageView alloc]
+        initWithFrame: NSMakeRect(0, 0, 80, 80)]);
+
+      /* Defaults. */
+      pass([iv image] == nil, "a new image view has no image");
+      pass([iv imageAlignment] == NSImageAlignCenter,
+           "the default alignment is centre");
+      pass([iv imageFrameStyle] == NSImageFrameNone,
+           "the default frame style is none");
+      pass([iv isEditable] == NO, "an image view is not editable by default");
+      pass([iv allowsCutCopyPaste] == YES,
+           "cut, copy and paste are allowed by default");
+
+      /* Round-trips. */
+      [iv setImageAlignment: NSImageAlignTop];
+      pass([iv imageAlignment] == NSImageAlignTop, "setImageAlignment: round trips");
+      [iv setImageScaling: NSImageScaleNone];
+      pass([iv imageScaling] == NSImageScaleNone, "setImageScaling: round trips");
+      [iv setImageFrameStyle: NSImageFramePhoto];
+      pass([iv imageFrameStyle] == NSImageFramePhoto,
+           "setImageFrameStyle: round trips");
+      [iv setEditable: YES];
+      pass([iv isEditable] == YES, "setEditable: round trips");
+
+      /* Image round-trip. */
+      NSImage *img = AUTORELEASE([[NSImage alloc] initWithSize: NSMakeSize(16, 16)]);
+      [iv setImage: img];
+      pass([iv image] == img, "setImage: keeps the image");
+
+      /* +imageViewWithImage: builds a non-editable view holding the image. */
+      NSImageView *iv2 = [NSImageView imageViewWithImage: img];
+      pass([iv2 image] == img, "+imageViewWithImage: sets the image");
+      pass([iv2 isEditable] == NO,
+           "+imageViewWithImage: makes a non-editable view");
+      pass([iv2 imageFrameStyle] == NSImageFrameNone,
+           "+imageViewWithImage: uses no frame");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSImageView state")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds coverage for NSImageView configuration: the defaults, the alignment, scaling and frame-style round-trips, the image round-trip, the +imageViewWithImage: constructor and a render regression lock. Alignment, scaling and frame style are compared by their enumerated names. Values were checked against AppKit on a macOS runner. The sets are backend-guarded and skip when no backend is available.