### PR TITLE
Fix: NSImageView implements animates and defaults it to YES

### DIFF
--- a/Headers/AppKit/NSImageView.h
+++ b/Headers/AppKit/NSImageView.h
@@ -68,9 +68,10 @@ APPKIT_EXPORT_CLASS
   id _target;
   SEL _action;
   struct GSImageViewFlagsType {
-    // total 32 bits.  30 bits left.
+    // total 32 bits.  29 bits left.
     unsigned allowsCutCopyPaste: 1;
     unsigned initiatesDrag: 1;
+    unsigned animates: 1;
   } _ivflags;
 }
 

--- a/Source/NSImageView.m
+++ b/Source/NSImageView.m
@@ -94,6 +94,7 @@ static Class imageCellClass;
   [self setImageScaling: NSScaleProportionally];
   [self setEditable: NO];
   [self setAllowsCutCopyPaste: YES];
+  [self setAnimates: YES];
 
   return self;
 }
@@ -162,13 +163,12 @@ static Class imageCellClass;
 
 - (BOOL) animates
 {
-  // FIXME: Should be passed on to cell.
-  return NO;
+  return _ivflags.animates;
 }
 
 - (void) setAnimates: (BOOL) flag
 {
-  // FIXME: Should be passed on to cell.
+  _ivflags.animates = flag;
 }
 
 - (BOOL) allowsCutCopyPaste
@@ -419,6 +419,7 @@ static Class imageCellClass;
     return self;
 
   [self setAllowsCutCopyPaste: YES];
+  [self setAnimates: YES];
   if ([aDecoder allowsKeyedCoding])
     {
       //NSArray *dragType = [aDecoder decodeObjectForKey: @"NSDragTypes"];

--- a/Tests/gui/NSImageView/animates.m
+++ b/Tests/gui/NSImageView/animates.m
@@ -1,0 +1,60 @@
+/* An NSImageView animates its image by default (matching AppKit), and
+   -setAnimates: round-trips.  The accessors used to be stubs: -animates always
+   returned NO and -setAnimates: did nothing.  Checked against AppKit on a
+   macOS runner.  The view uses the theme and font backend, so the set is
+   skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSImageView.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSImageView *iv;
+
+  START_SET("NSImageView animates")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      iv = AUTORELEASE([[NSImageView alloc]
+        initWithFrame: NSMakeRect(0, 0, 80, 80)]);
+
+      pass([iv animates] == YES, "an image view animates by default");
+
+      [iv setAnimates: NO];
+      pass([iv animates] == NO, "setAnimates: NO round trips");
+      [iv setAnimates: YES];
+      pass([iv animates] == YES, "setAnimates: YES round trips");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSImageView animates")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSImageView/animates.m
+++ b/Tests/gui/NSImageView/animates.m
@@ -36,12 +36,12 @@ main(int argc, char **argv)
       iv = AUTORELEASE([[NSImageView alloc]
         initWithFrame: NSMakeRect(0, 0, 80, 80)]);
 
-      pass([iv animates] == YES, "an image view animates by default");
+      PASS([iv animates] == YES, "an image view animates by default");
 
       [iv setAnimates: NO];
-      pass([iv animates] == NO, "setAnimates: NO round trips");
+      PASS([iv animates] == NO, "setAnimates: NO round trips");
       [iv setAnimates: YES];
-      pass([iv animates] == YES, "setAnimates: YES round trips");
+      PASS([iv animates] == YES, "setAnimates: YES round trips");
     }
   NS_HANDLER
     {


### PR DESCRIPTION
-animates and -setAnimates: were stubs: -animates always returned NO and -setAnimates: did nothing, so the property never round-tripped. They now store the flag in the view's flags word (there was room in the existing 32 bit field), and it defaults to YES as on AppKit.

Added Tests/gui/NSImageView/animates.m, checked against AppKit on a macOS runner; backend-guarded.