### PR TITLE
tests: add NSColorWell tests

### DIFF
--- a/Tests/gui/NSColorWell/colorwell.m
+++ b/Tests/gui/NSColorWell/colorwell.m
@@ -1,0 +1,72 @@
+/* Coverage for NSColorWell state: the defaults that match AppKit (not active,
+   bordered, a non-nil colour), the bordered round-trip and the colour
+   round-trip.  activate: is not exercised, as it drives the shared colour
+   panel.  Checked against AppKit on a macOS runner.  The well uses the theme
+   and font backend, so the set is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSColorWell.h>
+#include <AppKit/NSColor.h>
+#include <AppKit/NSGraphics.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSColorWell *cw;
+
+  START_SET("NSColorWell state")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      cw = AUTORELEASE([[NSColorWell alloc]
+        initWithFrame: NSMakeRect(0, 0, 40, 40)]);
+
+      /* Defaults. */
+      pass([cw isActive] == NO, "a color well is not active by default");
+      pass([cw isBordered] == YES, "a color well is bordered by default");
+      pass([cw color] != nil, "a color well has a colour by default");
+
+      /* Round-trips. */
+      [cw setBordered: NO];
+      pass([cw isBordered] == NO, "setBordered: round trips");
+
+      [cw setColor: [NSColor redColor]];
+      NSColor *c = [[cw color] colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+      pass(c != nil
+           && [c redComponent] > 0.9
+           && [c greenComponent] < 0.1
+           && [c blueComponent] < 0.1,
+           "setColor: keeps the red colour");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSColorWell state")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSColorWell/colorwell.m
+++ b/Tests/gui/NSColorWell/colorwell.m
@@ -39,17 +39,17 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 40, 40)]);
 
       /* Defaults. */
-      pass([cw isActive] == NO, "a color well is not active by default");
-      pass([cw isBordered] == YES, "a color well is bordered by default");
-      pass([cw color] != nil, "a color well has a colour by default");
+      PASS([cw isActive] == NO, "a color well is not active by default");
+      PASS([cw isBordered] == YES, "a color well is bordered by default");
+      PASS([cw color] != nil, "a color well has a colour by default");
 
       /* Round-trips. */
       [cw setBordered: NO];
-      pass([cw isBordered] == NO, "setBordered: round trips");
+      PASS([cw isBordered] == NO, "setBordered: round trips");
 
       [cw setColor: [NSColor redColor]];
       NSColor *c = [[cw color] colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
-      pass(c != nil
+      PASS(c != nil
            && [c redComponent] > 0.9
            && [c greenComponent] < 0.1
            && [c blueComponent] < 0.1,

--- a/Tests/gui/NSColorWell/rendering.m
+++ b/Tests/gui/NSColorWell/rendering.m
@@ -1,0 +1,68 @@
+/* A borderless color well fills its interior with its colour.  This is a
+   render regression lock (GNUstep against itself), not a pixel comparison
+   against AppKit.  The well uses the theme and font backend, so the set is
+   skipped when the backend is unavailable.
+*/
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSColorWell.h>
+#import <AppKit/NSColor.h>
+#import <AppKit/NSBitmapImageRep.h>
+#import <AppKit/NSGraphics.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSColorWell rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 40, 40)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSColorWell *cw = AUTORELEASE([[NSColorWell alloc]
+        initWithFrame: NSMakeRect(0, 0, 40, 40)]);
+      [cw setBordered: NO];
+      [cw setColor: [NSColor redColor]];
+      [w setContentView: cw];
+
+      [cw lockFocus];
+      [cw drawRect: [cw bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 40, 40)]);
+      [cw unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 40 && [rep pixelsHigh] == 40,
+        "a color well renders into a bitmap of its bounds");
+
+      NSColor *centre = [[rep colorAtX: 20 y: 20]
+        colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+      PASS(centre != nil
+           && [centre redComponent] > 0.9
+           && [centre greenComponent] < 0.1
+           && [centre blueComponent] < 0.1,
+        "the interior is filled with the red colour");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSColorWell rendering")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds coverage for NSColorWell: the defaults, the bordered round-trip, the colour round-trip and a render regression lock that checks the well fills its interior with its colour. activate: is not exercised, as it drives the shared colour panel. Values were checked against AppKit on a macOS runner. The sets are backend-guarded and skip when no backend is available.