### PR TITLE
tests: add NSButton tests

### DIFF
--- a/Tests/gui/NSButton/rendering.m
+++ b/Tests/gui/NSButton/rendering.m
@@ -1,0 +1,57 @@
+/* A bordered button draws through its cell into a bitmap of its own size.
+   This is a render regression lock (GNUstep against itself), not a pixel
+   comparison against AppKit.  The button uses the theme and font backend, so
+   the set is skipped when the backend is unavailable.
+*/
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSButton.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSButton rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 100, 24)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSButton *b = AUTORELEASE([[NSButton alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 24)]);
+      [b setTitle: @"Press"];
+      [w setContentView: b];
+
+      [b lockFocus];
+      [b drawRect: [b bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 100, 24)]);
+      [b unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 100 && [rep pixelsHigh] == 24,
+        "a button renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSButton rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSButton/state.m
+++ b/Tests/gui/NSButton/state.m
@@ -40,41 +40,41 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 100, 24)]);
 
       /* Defaults. */
-      pass([b state] == NSOffState, "a button is off by default");
-      pass([[b title] isEqualToString: @"Button"],
+      PASS([b state] == NSOffState, "a button is off by default");
+      PASS([[b title] isEqualToString: @"Button"],
            "the default title is Button");
-      pass([b isBordered] == YES, "a button is bordered by default");
-      pass([b isTransparent] == NO, "a button is not transparent by default");
-      pass([b allowsMixedState] == NO, "mixed state is off by default");
-      pass([b imagePosition] == NSNoImage, "there is no image by default");
-      pass([[b keyEquivalent] isEqualToString: @""],
+      PASS([b isBordered] == YES, "a button is bordered by default");
+      PASS([b isTransparent] == NO, "a button is not transparent by default");
+      PASS([b allowsMixedState] == NO, "mixed state is off by default");
+      PASS([b imagePosition] == NSNoImage, "there is no image by default");
+      PASS([[b keyEquivalent] isEqualToString: @""],
            "there is no key equivalent by default");
 
       /* Round-trips. */
       [b setState: NSOnState];
-      pass([b state] == NSOnState, "setState: round trips");
+      PASS([b state] == NSOnState, "setState: round trips");
       [b setTitle: @"OK"];
-      pass([[b title] isEqualToString: @"OK"], "setTitle: round trips");
+      PASS([[b title] isEqualToString: @"OK"], "setTitle: round trips");
       [b setBordered: NO];
-      pass([b isBordered] == NO, "setBordered: round trips");
+      PASS([b isBordered] == NO, "setBordered: round trips");
       [b setTransparent: YES];
-      pass([b isTransparent] == YES, "setTransparent: round trips");
+      PASS([b isTransparent] == YES, "setTransparent: round trips");
       [b setImagePosition: NSImageLeft];
-      pass([b imagePosition] == NSImageLeft, "setImagePosition: round trips");
+      PASS([b imagePosition] == NSImageLeft, "setImagePosition: round trips");
       [b setKeyEquivalent: @"x"];
-      pass([[b keyEquivalent] isEqualToString: @"x"],
+      PASS([[b keyEquivalent] isEqualToString: @"x"],
            "setKeyEquivalent: round trips");
       [b setAllowsMixedState: YES];
-      pass([b allowsMixedState] == YES, "setAllowsMixedState: round trips");
+      PASS([b allowsMixedState] == YES, "setAllowsMixedState: round trips");
 
       /* setNextState cycles off and on. */
       NSButton *b2 = AUTORELEASE([[NSButton alloc]
         initWithFrame: NSMakeRect(0, 0, 100, 24)]);
       [b2 setState: NSOffState];
       [b2 setNextState];
-      pass([b2 state] == NSOnState, "setNextState turns an off button on");
+      PASS([b2 state] == NSOnState, "setNextState turns an off button on");
       [b2 setNextState];
-      pass([b2 state] == NSOffState, "setNextState turns an on button off");
+      PASS([b2 state] == NSOffState, "setNextState turns an on button off");
     }
   NS_HANDLER
     {

--- a/Tests/gui/NSButton/state.m
+++ b/Tests/gui/NSButton/state.m
@@ -1,0 +1,93 @@
+/* Coverage for NSButton state and configuration: the defaults (off state, the
+   "Button" title, bordered, not transparent, no mixed state, no image, no key
+   equivalent), the setter round-trips and the off/on cycling of setNextState.
+   Checked against AppKit on a macOS runner (image position is compared by its
+   enumerated name).  The button uses the theme and font backend, so the set is
+   skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSButton.h>
+#include <AppKit/NSCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSButton *b;
+
+  START_SET("NSButton state")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      b = AUTORELEASE([[NSButton alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 24)]);
+
+      /* Defaults. */
+      pass([b state] == NSOffState, "a button is off by default");
+      pass([[b title] isEqualToString: @"Button"],
+           "the default title is Button");
+      pass([b isBordered] == YES, "a button is bordered by default");
+      pass([b isTransparent] == NO, "a button is not transparent by default");
+      pass([b allowsMixedState] == NO, "mixed state is off by default");
+      pass([b imagePosition] == NSNoImage, "there is no image by default");
+      pass([[b keyEquivalent] isEqualToString: @""],
+           "there is no key equivalent by default");
+
+      /* Round-trips. */
+      [b setState: NSOnState];
+      pass([b state] == NSOnState, "setState: round trips");
+      [b setTitle: @"OK"];
+      pass([[b title] isEqualToString: @"OK"], "setTitle: round trips");
+      [b setBordered: NO];
+      pass([b isBordered] == NO, "setBordered: round trips");
+      [b setTransparent: YES];
+      pass([b isTransparent] == YES, "setTransparent: round trips");
+      [b setImagePosition: NSImageLeft];
+      pass([b imagePosition] == NSImageLeft, "setImagePosition: round trips");
+      [b setKeyEquivalent: @"x"];
+      pass([[b keyEquivalent] isEqualToString: @"x"],
+           "setKeyEquivalent: round trips");
+      [b setAllowsMixedState: YES];
+      pass([b allowsMixedState] == YES, "setAllowsMixedState: round trips");
+
+      /* setNextState cycles off and on. */
+      NSButton *b2 = AUTORELEASE([[NSButton alloc]
+        initWithFrame: NSMakeRect(0, 0, 100, 24)]);
+      [b2 setState: NSOffState];
+      [b2 setNextState];
+      pass([b2 state] == NSOnState, "setNextState turns an off button on");
+      [b2 setNextState];
+      pass([b2 state] == NSOffState, "setNextState turns an on button off");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSButton state")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds coverage for NSButton state and configuration: the defaults, the setter round-trips, the off/on cycling of setNextState, and a render regression lock. Image position is compared by its enumerated name. Values were checked against AppKit on a macOS runner. The sets are backend-guarded and skip when no backend is available.