### PR TITLE
tests: add NSSlider tests

### DIFF
--- a/Tests/gui/NSSlider/rendering.m
+++ b/Tests/gui/NSSlider/rendering.m
@@ -1,0 +1,59 @@
+/* A slider draws through its cell into a bitmap of its own size.  This is a
+   render regression lock (GNUstep against itself), not a pixel comparison
+   against AppKit.  The slider uses the theme and font backend, so the set is
+   skipped when the backend is unavailable.
+*/
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSSlider.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSlider rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 120, 24)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSSlider *s = AUTORELEASE([[NSSlider alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 24)]);
+      [s setMinValue: 0.0];
+      [s setMaxValue: 10.0];
+      [s setDoubleValue: 5.0];
+      [w setContentView: s];
+
+      [s lockFocus];
+      [s drawRect: [s bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 120, 24)]);
+      [s unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 120 && [rep pixelsHigh] == 24,
+        "a slider renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSSlider rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSSlider/slider.m
+++ b/Tests/gui/NSSlider/slider.m
@@ -1,0 +1,95 @@
+/* Coverage for NSSlider value and tick-mark state: the defaults that match
+   AppKit (a 0..1 range, no ticks, tick-only off), the setter round-trips and
+   the clamping of the double value to the range.  Checked against AppKit on a
+   macOS runner (the tick-mark position is compared by its enumerated name).
+   The slider uses the theme and font backend, so the set is skipped when the
+   backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSlider.h>
+#include <AppKit/NSSliderCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSSlider *s;
+
+  START_SET("NSSlider slider")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      s = AUTORELEASE([[NSSlider alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 24)]);
+
+      /* Defaults. */
+      pass([s minValue] == 0.0, "the default minimum is zero");
+      pass([s maxValue] == 1.0, "the default maximum is one");
+      pass([s doubleValue] == 0.0, "the default value is zero");
+      pass([s numberOfTickMarks] == 0, "there are no tick marks by default");
+      pass([s tickMarkPosition] == NSTickMarkBelow,
+           "the default tick-mark position is below");
+      pass([s allowsTickMarkValuesOnly] == NO,
+           "the slider is not restricted to tick values by default");
+
+      /* Round-trips. */
+      [s setMinValue: 2.0];
+      pass([s minValue] == 2.0, "setMinValue: round trips");
+      [s setMaxValue: 10.0];
+      pass([s maxValue] == 10.0, "setMaxValue: round trips");
+      [s setDoubleValue: 5.0];
+      pass([s doubleValue] == 5.0, "setDoubleValue: round trips");
+      [s setNumberOfTickMarks: 6];
+      pass([s numberOfTickMarks] == 6, "setNumberOfTickMarks: round trips");
+      [s setTickMarkPosition: NSTickMarkAbove];
+      pass([s tickMarkPosition] == NSTickMarkAbove,
+           "setTickMarkPosition: round trips");
+      [s setAllowsTickMarkValuesOnly: YES];
+      pass([s allowsTickMarkValuesOnly] == YES,
+           "setAllowsTickMarkValuesOnly: round trips");
+      [s setAltIncrementValue: 0.5];
+      pass([s altIncrementValue] == 0.5, "setAltIncrementValue: round trips");
+
+      /* Clamping to the range. */
+      NSSlider *s2 = AUTORELEASE([[NSSlider alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 24)]);
+      [s2 setMinValue: 0.0];
+      [s2 setMaxValue: 10.0];
+      [s2 setDoubleValue: 100.0];
+      pass([s2 doubleValue] == 10.0,
+           "a value above the maximum clamps to the maximum");
+      [s2 setDoubleValue: -5.0];
+      pass([s2 doubleValue] == 0.0,
+           "a value below the minimum clamps to the minimum");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSSlider slider")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSSlider/slider.m
+++ b/Tests/gui/NSSlider/slider.m
@@ -39,32 +39,32 @@ main(int argc, char **argv)
         initWithFrame: NSMakeRect(0, 0, 120, 24)]);
 
       /* Defaults. */
-      pass([s minValue] == 0.0, "the default minimum is zero");
-      pass([s maxValue] == 1.0, "the default maximum is one");
-      pass([s doubleValue] == 0.0, "the default value is zero");
-      pass([s numberOfTickMarks] == 0, "there are no tick marks by default");
-      pass([s tickMarkPosition] == NSTickMarkBelow,
+      PASS([s minValue] == 0.0, "the default minimum is zero");
+      PASS([s maxValue] == 1.0, "the default maximum is one");
+      PASS([s doubleValue] == 0.0, "the default value is zero");
+      PASS([s numberOfTickMarks] == 0, "there are no tick marks by default");
+      PASS([s tickMarkPosition] == NSTickMarkBelow,
            "the default tick-mark position is below");
-      pass([s allowsTickMarkValuesOnly] == NO,
+      PASS([s allowsTickMarkValuesOnly] == NO,
            "the slider is not restricted to tick values by default");
 
       /* Round-trips. */
       [s setMinValue: 2.0];
-      pass([s minValue] == 2.0, "setMinValue: round trips");
+      PASS([s minValue] == 2.0, "setMinValue: round trips");
       [s setMaxValue: 10.0];
-      pass([s maxValue] == 10.0, "setMaxValue: round trips");
+      PASS([s maxValue] == 10.0, "setMaxValue: round trips");
       [s setDoubleValue: 5.0];
-      pass([s doubleValue] == 5.0, "setDoubleValue: round trips");
+      PASS([s doubleValue] == 5.0, "setDoubleValue: round trips");
       [s setNumberOfTickMarks: 6];
-      pass([s numberOfTickMarks] == 6, "setNumberOfTickMarks: round trips");
+      PASS([s numberOfTickMarks] == 6, "setNumberOfTickMarks: round trips");
       [s setTickMarkPosition: NSTickMarkAbove];
-      pass([s tickMarkPosition] == NSTickMarkAbove,
+      PASS([s tickMarkPosition] == NSTickMarkAbove,
            "setTickMarkPosition: round trips");
       [s setAllowsTickMarkValuesOnly: YES];
-      pass([s allowsTickMarkValuesOnly] == YES,
+      PASS([s allowsTickMarkValuesOnly] == YES,
            "setAllowsTickMarkValuesOnly: round trips");
       [s setAltIncrementValue: 0.5];
-      pass([s altIncrementValue] == 0.5, "setAltIncrementValue: round trips");
+      PASS([s altIncrementValue] == 0.5, "setAltIncrementValue: round trips");
 
       /* Clamping to the range. */
       NSSlider *s2 = AUTORELEASE([[NSSlider alloc]
@@ -72,10 +72,10 @@ main(int argc, char **argv)
       [s2 setMinValue: 0.0];
       [s2 setMaxValue: 10.0];
       [s2 setDoubleValue: 100.0];
-      pass([s2 doubleValue] == 10.0,
+      PASS([s2 doubleValue] == 10.0,
            "a value above the maximum clamps to the maximum");
       [s2 setDoubleValue: -5.0];
-      pass([s2 doubleValue] == 0.0,
+      PASS([s2 doubleValue] == 0.0,
            "a value below the minimum clamps to the minimum");
     }
   NS_HANDLER


### PR DESCRIPTION
Adds coverage for NSSlider value and tick-mark state: the defaults, the setter round-trips, and the clamping of the double value to the range. The tick-mark position is compared by its enumerated name. Values were checked against AppKit on a macOS runner. The sets are backend-guarded and skip when no backend is available.