### PR TITLE
tests: add NSSwitch tests

### DIFF
--- a/Tests/gui/NSSwitch/rendering.m
+++ b/Tests/gui/NSSwitch/rendering.m
@@ -1,0 +1,58 @@
+/* A switch draws into a bitmap of its own size.  This is a render regression
+   lock (GNUstep against itself), not a pixel comparison against AppKit.  The
+   switch uses the theme and font backend, so the set is skipped when the
+   backend is unavailable.
+*/
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSSwitch.h>
+#import <AppKit/NSCell.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSwitch rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 40, 24)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSSwitch *sw = AUTORELEASE([[NSSwitch alloc]
+        initWithFrame: NSMakeRect(0, 0, 40, 24)]);
+      [sw setState: NSControlStateValueOn];
+      [w setContentView: sw];
+
+      [sw lockFocus];
+      [sw drawRect: [sw bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 40, 24)]);
+      [sw unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 40 && [rep pixelsHigh] == 24,
+        "a switch renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSSwitch rendering")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSSwitch/switch.m
+++ b/Tests/gui/NSSwitch/switch.m
@@ -36,17 +36,17 @@ main(int argc, char **argv)
       sw = AUTORELEASE([[NSSwitch alloc]
         initWithFrame: NSMakeRect(0, 0, 40, 24)]);
 
-      pass([sw state] == NSControlStateValueOff, "a switch is off by default");
+      PASS([sw state] == NSControlStateValueOff, "a switch is off by default");
 
       [sw setState: NSControlStateValueOn];
-      pass([sw state] == NSControlStateValueOn, "setState: on round trips");
-      pass([sw doubleValue] == 1.0, "an on switch has a double value of one");
-      pass([sw intValue] == 1, "an on switch has an integer value of one");
+      PASS([sw state] == NSControlStateValueOn, "setState: on round trips");
+      PASS([sw doubleValue] == 1.0, "an on switch has a double value of one");
+      PASS([sw intValue] == 1, "an on switch has an integer value of one");
 
       [sw setState: NSControlStateValueOff];
-      pass([sw state] == NSControlStateValueOff, "setState: off round trips");
-      pass([sw doubleValue] == 0.0, "an off switch has a double value of zero");
-      pass([sw intValue] == 0, "an off switch has an integer value of zero");
+      PASS([sw state] == NSControlStateValueOff, "setState: off round trips");
+      PASS([sw doubleValue] == 0.0, "an off switch has a double value of zero");
+      PASS([sw intValue] == 0, "an off switch has an integer value of zero");
     }
   NS_HANDLER
     {

--- a/Tests/gui/NSSwitch/switch.m
+++ b/Tests/gui/NSSwitch/switch.m
@@ -1,0 +1,65 @@
+/* Coverage for NSSwitch: it is off by default, setState: round-trips, and the
+   state maps to the double and integer values (on is one, off is zero).
+   Checked against AppKit on a macOS runner.  The switch uses the theme and
+   font backend, so the set is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSwitch.h>
+#include <AppKit/NSCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSSwitch *sw;
+
+  START_SET("NSSwitch switch")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      sw = AUTORELEASE([[NSSwitch alloc]
+        initWithFrame: NSMakeRect(0, 0, 40, 24)]);
+
+      pass([sw state] == NSControlStateValueOff, "a switch is off by default");
+
+      [sw setState: NSControlStateValueOn];
+      pass([sw state] == NSControlStateValueOn, "setState: on round trips");
+      pass([sw doubleValue] == 1.0, "an on switch has a double value of one");
+      pass([sw intValue] == 1, "an on switch has an integer value of one");
+
+      [sw setState: NSControlStateValueOff];
+      pass([sw state] == NSControlStateValueOff, "setState: off round trips");
+      pass([sw doubleValue] == 0.0, "an off switch has a double value of zero");
+      pass([sw intValue] == 0, "an off switch has an integer value of zero");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSSwitch switch")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds coverage for NSSwitch: it is off by default, setState: round-trips, and the state maps to the double and integer values (on is one, off is zero). Values were checked against AppKit on a macOS runner. The sets are backend-guarded and skip when no backend is available.