### PR TITLE
tests: add NSForm tests

### DIFF
--- a/Tests/gui/NSForm/form.m
+++ b/Tests/gui/NSForm/form.m
@@ -37,23 +37,23 @@ main(int argc, char **argv)
       f = AUTORELEASE([[NSForm alloc]
         initWithFrame: NSMakeRect(0, 0, 200, 100)]);
 
-      pass([f numberOfRows] == 0, "a new form has no entries");
+      PASS([f numberOfRows] == 0, "a new form has no entries");
 
       NSFormCell *e0 = [f addEntry: @"Name"];
       NSFormCell *e1 = [f addEntry: @"Email"];
       [e1 setTag: 42];
 
-      pass([e0 isKindOfClass: [NSFormCell class]],
+      PASS([e0 isKindOfClass: [NSFormCell class]],
            "addEntry: returns a form cell");
-      pass([f numberOfRows] == 2, "adding two entries makes two rows");
-      pass([f cellAtIndex: 0] == e0, "the cell at index zero is the first entry");
-      pass([[[f cellAtIndex: 1] title] isEqualToString: @"Email"],
+      PASS([f numberOfRows] == 2, "adding two entries makes two rows");
+      PASS([f cellAtIndex: 0] == e0, "the cell at index zero is the first entry");
+      PASS([[[f cellAtIndex: 1] title] isEqualToString: @"Email"],
            "the second entry keeps its title");
-      pass([f indexOfCellWithTag: 42] == 1, "an entry is found by its tag");
+      PASS([f indexOfCellWithTag: 42] == 1, "an entry is found by its tag");
 
       [f removeEntryAtIndex: 0];
-      pass([f numberOfRows] == 1, "removing an entry drops a row");
-      pass([[[f cellAtIndex: 0] title] isEqualToString: @"Email"],
+      PASS([f numberOfRows] == 1, "removing an entry drops a row");
+      PASS([[[f cellAtIndex: 0] title] isEqualToString: @"Email"],
            "the remaining entry shifts into index zero");
     }
   NS_HANDLER

--- a/Tests/gui/NSForm/form.m
+++ b/Tests/gui/NSForm/form.m
@@ -1,0 +1,73 @@
+/* Coverage for NSForm entry management: adding entries as form cells, the
+   entry count, the cell at an index, finding a cell by tag and removing an
+   entry.  Checked against AppKit on a macOS runner.  The form uses the theme
+   and font backend, so the set is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSForm.h>
+#include <AppKit/NSFormCell.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSForm *f;
+
+  START_SET("NSForm form")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      f = AUTORELEASE([[NSForm alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 100)]);
+
+      pass([f numberOfRows] == 0, "a new form has no entries");
+
+      NSFormCell *e0 = [f addEntry: @"Name"];
+      NSFormCell *e1 = [f addEntry: @"Email"];
+      [e1 setTag: 42];
+
+      pass([e0 isKindOfClass: [NSFormCell class]],
+           "addEntry: returns a form cell");
+      pass([f numberOfRows] == 2, "adding two entries makes two rows");
+      pass([f cellAtIndex: 0] == e0, "the cell at index zero is the first entry");
+      pass([[[f cellAtIndex: 1] title] isEqualToString: @"Email"],
+           "the second entry keeps its title");
+      pass([f indexOfCellWithTag: 42] == 1, "an entry is found by its tag");
+
+      [f removeEntryAtIndex: 0];
+      pass([f numberOfRows] == 1, "removing an entry drops a row");
+      pass([[[f cellAtIndex: 0] title] isEqualToString: @"Email"],
+           "the remaining entry shifts into index zero");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSForm form")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSForm/rendering.m
+++ b/Tests/gui/NSForm/rendering.m
@@ -1,0 +1,58 @@
+/* A form with entries draws into a bitmap of its own size.  This is a render
+   regression lock (GNUstep against itself), not a pixel comparison against
+   AppKit.  The form uses the theme and font backend, so the set is skipped
+   when the backend is unavailable.
+*/
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSForm.h>
+#import <AppKit/NSBitmapImageRep.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSForm rendering")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 200, 60)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSForm *f = AUTORELEASE([[NSForm alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 60)]);
+      [f addEntry: @"Name"];
+      [f addEntry: @"Email"];
+      [w setContentView: f];
+
+      [f lockFocus];
+      [f drawRect: [f bounds]];
+      NSBitmapImageRep *rep = AUTORELEASE([[NSBitmapImageRep alloc]
+        initWithFocusedViewRect: NSMakeRect(0, 0, 200, 60)]);
+      [f unlockFocus];
+
+      PASS(rep != nil && [rep pixelsWide] == 200 && [rep pixelsHigh] == 60,
+        "a form renders into a bitmap of its bounds");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSForm rendering")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds coverage for NSForm entry management: adding entries as form cells, the entry count, the cell at an index, finding a cell by tag, removing an entry, and a render regression lock. Values were checked against AppKit on a macOS runner. The sets are backend-guarded and skip when no backend is available.