### PR TITLE
Fix: NSGridView defaults its cell placement and spacing to match AppKit

### DIFF
--- a/Source/NSGridView.m
+++ b/Source/NSGridView.m
@@ -236,6 +236,10 @@
       _rows = [[NSMutableArray alloc] init];
       _columns = [[NSMutableArray alloc] init];
       _cells = [[NSMutableArray alloc] init];
+      _xPlacement = NSGridCellPlacementLeading;
+      _yPlacement = NSGridCellPlacementTop;
+      _columnSpacing = 6.0;
+      _rowSpacing = 6.0;
     }
 
   return self;

--- a/Tests/gui/NSGridView/defaults.m
+++ b/Tests/gui/NSGridView/defaults.m
@@ -1,0 +1,58 @@
+/* A new NSGridView carries AppKit's placement and spacing defaults: leading x
+   placement, top y placement and a six-point column and row spacing (they were
+   zero).  Checked against AppKit on a macOS runner.  The grid uses the theme
+   and font backend, so the set is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSGridView.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSGridView *g;
+
+  START_SET("NSGridView defaults")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      g = [NSGridView gridViewWithNumberOfColumns: 2 rows: 2];
+
+      pass([g xPlacement] == NSGridCellPlacementLeading,
+           "the default x placement is leading");
+      pass([g yPlacement] == NSGridCellPlacementTop,
+           "the default y placement is top");
+      pass([g columnSpacing] == 6.0, "the default column spacing is six");
+      pass([g rowSpacing] == 6.0, "the default row spacing is six");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSGridView defaults")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A new NSGridView reported a zero x and y placement and zero column and row spacing, where AppKit uses leading and top placement and a six-point spacing. -initWithFrame: now sets these.

Added Tests/gui/NSGridView/defaults.m, checked against AppKit on a macOS runner; backend-guarded.