### PR TITLE
Fix: GSHorizontalTypesetter applies paragraph spacing after a paragraph

### DIFF
--- a/Source/GSHorizontalTypesetter.m
+++ b/Source/GSHorizontalTypesetter.m
@@ -1316,7 +1316,12 @@ static inline BOOL wantNewLineHeight(CGFloat height, CGFloat *lineHeight, CGFloa
   currentPoint = NSMakePoint(0, NSMaxY(lineFragments->rect));
 
   if (newParagraph)
-    return 3;
+    {
+      /* This line ended a paragraph; add its trailing spacing before the
+         next paragraph begins. */
+      currentPoint.y += [currentParagraphStyle paragraphSpacing];
+      return 3;
+    }
   else
     return 0;
 }

--- a/Tests/gui/GSHorizontalTypesetter/paragraphSpacing.m
+++ b/Tests/gui/GSHorizontalTypesetter/paragraphSpacing.m
@@ -1,0 +1,93 @@
+/* GSHorizontalTypesetter applies a paragraph's paragraphSpacing as vertical
+   space after the paragraph: the line fragment that begins the following
+   paragraph is pushed down by that amount.  This is checked by laying out two
+   paragraphs and comparing the second paragraph's y origin with and without
+   the spacing.  It used to be ignored.  The typesetter uses the font backend,
+   so the set is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSValue.h>
+#include <Foundation/NSDictionary.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSAttributedString.h>
+#include <AppKit/NSFont.h>
+#include <AppKit/NSTextStorage.h>
+#include <AppKit/NSLayoutManager.h>
+#include <AppKit/NSTextContainer.h>
+#include <AppKit/NSParagraphStyle.h>
+#include <AppKit/NSStringDrawing.h>
+
+/* Lays out two paragraphs with the given paragraph spacing and returns the
+   y origin of the line fragment that starts the second paragraph. */
+static CGFloat
+secondParagraphY(CGFloat spacing)
+{
+  NSFont *font = [NSFont userFontOfSize: 12.0];
+  NSMutableParagraphStyle *ps = AUTORELEASE([[NSMutableParagraphStyle alloc] init]);
+  [ps setParagraphSpacing: spacing];
+  NSDictionary *attrs = [NSDictionary dictionaryWithObjectsAndKeys:
+    font, NSFontAttributeName, ps, NSParagraphStyleAttributeName, nil];
+
+  NSTextStorage *ts = AUTORELEASE([[NSTextStorage alloc]
+    initWithString: @"aaa\nbbb" attributes: attrs]);
+  NSLayoutManager *lm = AUTORELEASE([[NSLayoutManager alloc] init]);
+  [ts addLayoutManager: lm];
+  NSTextContainer *tc = AUTORELEASE([[NSTextContainer alloc]
+    initWithContainerSize: NSMakeSize(200, 1000)]);
+  [tc setLineFragmentPadding: 0.0];
+  [lm addTextContainer: tc];
+  [lm glyphRangeForTextContainer: tc];
+
+  /* Glyph 5 is in the second paragraph ("bbb" after the newline at index 3). */
+  NSRange r;
+  NSRect frag = [lm lineFragmentRectForGlyphAtIndex: 5 effectiveRange: &r];
+  return frag.origin.y;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("GSHorizontalTypesetter paragraphSpacing")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      CGFloat none = secondParagraphY(0.0);
+      CGFloat spaced = secondParagraphY(20.0);
+
+      pass(none > 0.0,
+           "the second paragraph is below the first without extra spacing");
+      pass(spaced - none == 20.0,
+           "paragraphSpacing pushes the next paragraph down by that amount");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("GSHorizontalTypesetter paragraphSpacing")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Fixes #416 

A paragraph's `paragraphSpacing` was ignored: the line fragment that begins the following paragraph was not pushed down by it, so paragraphs ran together with only the normal line advance between them.

When a line ends a paragraph, its trailing `paragraphSpacing` is now added to the current point before the next paragraph is laid out. `lineSpacing` was already handled; this adds the paragraph-level spacing.

Added Tests/gui/GSHorizontalTypesetter/paragraphSpacing.m, which lays out two paragraphs through an NSLayoutManager and checks that the second paragraph's line fragment moves down by exactly the paragraph spacing (it does not move without this change). This is also the first layout-driven test for the typesetter; the same setup (text storage, layout manager, container, then reading line fragment rects) can drive tests for other layout behaviour. The set is backend-guarded and skips when no backend is available.
