### PR TITLE
Fix: NSApplication keeps a drawable application icon image

### DIFF
--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -2424,6 +2424,26 @@ image.</p><p>See Also: -applicationIconImage</p>
   // Use a copy as we change the name and size
   ASSIGNCOPY(_app_icon, anImage);
 
+  /* -[NSImage copyWithZone:] does not copy cached representations, so an image
+     that was only drawn into (e.g. with -lockFocus, whose sole representation
+     is a cached one) copies to an image with no representations and would draw
+     nothing. Take an independent bitmap snapshot of the original in that case
+     so the icon still draws. */
+  if ([[_app_icon representations] count] == 0)
+    {
+      NSData *tiff = [anImage TIFFRepresentation];
+
+      if (tiff != nil)
+        {
+          NSImageRep *bitmap = [NSBitmapImageRep imageRepWithData: tiff];
+
+          if (bitmap != nil)
+            {
+              [_app_icon addRepresentation: bitmap];
+            }
+        }
+    }
+
   server = GSCurrentServer();
   miniWindowSize = server != 0 ? [server iconSize] : NSZeroSize;
   if (miniWindowSize.width <= 0 || miniWindowSize.height <= 0) 

--- a/Tests/gui/NSApplication/applicationIconImage.m
+++ b/Tests/gui/NSApplication/applicationIconImage.m
@@ -1,0 +1,87 @@
+/* -[NSApplication setApplicationIconImage:] keeps a drawable image even when
+   the image was produced by drawing into it (whose only representation is a
+   cached one, which -[NSImage copyWithZone:] drops).  A red image is set as
+   the application icon and read back; it must still contain the red drawing.
+   Drawing needs the theme and font backend, so the set is skipped when the
+   backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSImage.h>
+#include <AppKit/NSBitmapImageRep.h>
+#include <AppKit/NSColor.h>
+#include <AppKit/NSGraphics.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSApplication applicationIconImage")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSImage *img = AUTORELEASE([[NSImage alloc]
+        initWithSize: NSMakeSize(48, 48)]);
+      [img lockFocus];
+      [[NSColor redColor] set];
+      NSRectFill(NSMakeRect(0, 0, 48, 48));
+      [img unlockFocus];
+
+      [NSApp setApplicationIconImage: img];
+      NSImage *icon = [NSApp applicationIconImage];
+
+      pass(icon != nil && [[icon representations] count] > 0,
+           "the application icon keeps a representation");
+
+      NSBitmapImageRep *bitmap = nil;
+      NSEnumerator *e = [[icon representations] objectEnumerator];
+      NSImageRep *rep;
+      while ((rep = [e nextObject]) != nil)
+        {
+          if ([rep isKindOfClass: [NSBitmapImageRep class]])
+            bitmap = (NSBitmapImageRep *)rep;
+        }
+      pass(bitmap != nil, "the application icon has a bitmap representation");
+
+      if (bitmap != nil)
+        {
+          NSColor *c = [[bitmap colorAtX: 24 y: 24]
+            colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+          pass(c != nil
+               && [c redComponent] > 0.9
+               && [c greenComponent] < 0.1
+               && [c blueComponent] < 0.1,
+               "the application icon keeps the red drawing");
+        }
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSApplication applicationIconImage")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-[NSApplication setApplicationIconImage:]` copies the image, since it changes its name and size, and `-[NSImage copyWithZone:]` does not copy cached representations. An image built by drawing into it, for example with `-lockFocus`, has only a cached representation, so the copy ends up with no representations and the icon draws nothing. This is the case reported in #101.

When the copy has no representations, the setter now takes an independent bitmap snapshot of the original image, via its TIFF representation, and adds it, so the icon still draws. Images loaded from a file already have a bitmap representation and are unaffected.

Added Tests/gui/NSApplication/applicationIconImage.m: a red image is drawn, set as the application icon, read back, and its centre pixel is checked to still be red. The test fails without this change, since the icon ends up with no representations.

Fixes #101.
