### PR TITLE
Fix: NSViewController lifecycle - viewDidLoad and appearance methods (#149)

### DIFF
--- a/Headers/AppKit/NSViewController.h
+++ b/Headers/AppKit/NSViewController.h
@@ -68,7 +68,8 @@ APPKIT_EXPORT_CLASS
   struct ___vcFlags
     {
       unsigned int nib_is_loaded:1;
-      unsigned int RESERVED:31;
+      unsigned int view_did_load:1;
+      unsigned int RESERVED:30;
     } _vcFlags;
   id                   _reserved;
 }
@@ -84,6 +85,7 @@ APPKIT_EXPORT_CLASS
 
 - (void)setView:(NSView *)aView;
 - (NSView *)view;
+- (BOOL)isViewLoaded;
 - (void)loadView;
 
 - (NSString *)nibName;

--- a/Headers/AppKit/NSViewController.h
+++ b/Headers/AppKit/NSViewController.h
@@ -69,7 +69,8 @@ APPKIT_EXPORT_CLASS
     {
       unsigned int nib_is_loaded:1;
       unsigned int view_did_load:1;
-      unsigned int RESERVED:30;
+      unsigned int view_is_visible:1;
+      unsigned int RESERVED:29;
     } _vcFlags;
   id                   _reserved;
 }

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -56,6 +56,7 @@
 #import "AppKit/NSBezierPath.h"
 #import "AppKit/NSBitmapImageRep.h"
 #import "AppKit/NSCursor.h"
+#import "AppKit/NSViewController.h"
 #import "AppKit/NSDocumentController.h"
 #import "AppKit/NSDocument.h"
 #import "AppKit/NSClipView.h"
@@ -109,6 +110,14 @@ NSView *viewIsPrinting = nil;
 
 const CGFloat NSViewNoInstrinsicMetric = -1;
 const CGFloat NSViewNoIntrinsicMetric = -1;
+
+/* Private NSViewController hooks used to drive a controller's appearance
+   transitions when its view moves between windows. */
+@interface NSViewController (GSViewAppearance)
++ (NSViewController *) _viewControllerForView: (NSView *)aView;
+- (void) _viewWillMoveToWindow: (NSWindow *)newWindow;
+- (void) _viewDidMoveToWindow;
+@end
 
 /**
   <p>NSView is an abstract class which provides facilities for drawing
@@ -369,7 +378,13 @@ GSSetDragTypes(NSView* obj, NSArray *types)
 
 - (void) _viewDidMoveToWindow
 {
+  NSViewController *vc = [NSViewController _viewControllerForView: self];
+
   [self viewDidMoveToWindow];
+  if (vc != nil)
+    {
+      [vc _viewDidMoveToWindow];
+    }
   if (_rFlags.has_subviews)
     {
       NSUInteger count = [_sub_views count];
@@ -407,7 +422,16 @@ GSSetDragTypes(NSView* obj, NSArray *types)
       return;
     }
 
-  // This call also reset _allocate_gstate, so we have 
+  {
+    NSViewController *vc = [NSViewController _viewControllerForView: self];
+
+    if (vc != nil)
+      {
+	[vc _viewWillMoveToWindow: newWindow];
+      }
+  }
+
+  // This call also reset _allocate_gstate, so we have
   // to store this value and set it again.
   // This way we keep the logic in one place.
   old_allocate_gstate = _allocate_gstate;

--- a/Source/NSViewController.m
+++ b/Source/NSViewController.m
@@ -25,6 +25,8 @@
  Boston, MA 02110-1301, USA.
  */
 
+#import <objc/runtime.h>
+
 #import <Foundation/NSArray.h>
 #import <Foundation/NSBundle.h>
 #import <Foundation/NSKeyedArchiver.h>
@@ -41,6 +43,18 @@
 #import "AppKit/NSWindowController.h"
 
 @implementation NSViewController
+
+/* Weak association from a view back to its controller, so the view can drive
+   the controller's appearance transitions as it moves between windows.  A
+   responder-chain link cannot be used for this because -[NSView addSubview:]
+   resets a view's next responder to its superview. */
+static void *viewControllerAssociationKey = &viewControllerAssociationKey;
+
++ (NSViewController *) _viewControllerForView: (NSView *)aView
+{
+  return (NSViewController *)objc_getAssociatedObject(aView,
+    viewControllerAssociationKey);
+}
 
 - (id)initWithNibName:(NSString *)nibNameOrNil
 	       bundle:(NSBundle *)nibBundleOrNil
@@ -173,7 +187,55 @@
 {
   if (view != aView)
     {
+      if (view != nil)
+	{
+	  objc_setAssociatedObject(view, viewControllerAssociationKey,
+	    nil, OBJC_ASSOCIATION_ASSIGN);
+	}
       ASSIGN(view, aView);
+      if (aView != nil)
+	{
+	  objc_setAssociatedObject(aView, viewControllerAssociationKey,
+	    self, OBJC_ASSOCIATION_ASSIGN);
+	}
+    }
+}
+
+/* Sent by -[NSView _viewWillMoveToWindow:] on the controller's own view, while
+   the view still reports its current window.  Predict the appearance change so
+   the -viewWillAppear:/-viewWillDisappear: notifications precede the move. */
+- (void) _viewWillMoveToWindow: (NSWindow *)newWindow
+{
+  if (newWindow != nil && !_vcFlags.view_is_visible)
+    {
+      [self viewWillAppear: NO];
+    }
+  else if (newWindow == nil && _vcFlags.view_is_visible)
+    {
+      [self viewWillDisappear: NO];
+    }
+}
+
+/* Sent by -[NSView _viewDidMoveToWindow] once the move has happened.  This is
+   where the visible state actually flips, so it drives the -viewDidAppear: and
+   -viewDidDisappear: notifications and guards against sending them twice. */
+- (void) _viewDidMoveToWindow
+{
+  if ([view window] != nil)
+    {
+      if (!_vcFlags.view_is_visible)
+	{
+	  _vcFlags.view_is_visible = YES;
+	  [self viewDidAppear: NO];
+	}
+    }
+  else
+    {
+      if (_vcFlags.view_is_visible)
+	{
+	  _vcFlags.view_is_visible = NO;
+	  [self viewDidDisappear: NO];
+	}
     }
 }
 
@@ -187,7 +249,6 @@
     }
 
   [self viewWillLoad];
-  [self viewWillAppear: NO];
   nib = [[NSNib alloc] initWithNibNamed: [self nibName]
 				 bundle: [self nibBundle]];
   if ((nib != nil) && [nib instantiateNibWithOwner: self
@@ -197,7 +258,6 @@
       // FIXME: Need to resolve possible retain cycles here
       _vcFlags.view_did_load = YES;
       [self viewDidLoad];
-      [self viewDidAppear: NO];
     }
   else
     {

--- a/Source/NSViewController.m
+++ b/Source/NSViewController.m
@@ -152,7 +152,21 @@
     {
       [self loadView];
     }
+
+  /* Send -viewDidLoad once the view exists, whether it was loaded from a nib,
+     created in a -loadView override, or set directly. */
+  if (view != nil && !_vcFlags.view_did_load)
+    {
+      _vcFlags.view_did_load = YES;
+      [self viewDidLoad];
+    }
+
   return view;
+}
+
+- (BOOL)isViewLoaded
+{
+  return view != nil;
 }
 
 - (void)setView:(NSView *)aView
@@ -181,6 +195,7 @@
     {
       _vcFlags.nib_is_loaded = YES;
       // FIXME: Need to resolve possible retain cycles here
+      _vcFlags.view_did_load = YES;
       [self viewDidLoad];
       [self viewDidAppear: NO];
     }

--- a/Tests/gui/NSViewController/appearance.m
+++ b/Tests/gui/NSViewController/appearance.m
@@ -1,0 +1,85 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSViewController.h>
+#import <AppKit/NSWindow.h>
+
+/* -[NSViewController viewWillAppear:]/-viewDidAppear: were sent from -loadView,
+   so they fired when the view loaded rather than when it entered a window, and
+   the disappear pair was never sent (gnustep/libs-gui issue #149).  They should
+   now follow the view's window membership. */
+
+@interface AppearanceVC : NSViewController
+{
+@public
+  int didLoad;
+  int willAppear;
+  int didAppear;
+  int willDisappear;
+  int didDisappear;
+}
+@end
+
+@implementation AppearanceVC
+- (void) loadView
+{
+  [self setView: AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(0, 0, 50, 50)])];
+}
+- (void) viewDidLoad { didLoad++; }
+- (void) viewWillAppear: (BOOL)a { [super viewWillAppear: a]; willAppear++; }
+- (void) viewDidAppear: (BOOL)a { [super viewDidAppear: a]; didAppear++; }
+- (void) viewWillDisappear: (BOOL)a { [super viewWillDisappear: a]; willDisappear++; }
+- (void) viewDidDisappear: (BOOL)a { [super viewDidDisappear: a]; didDisappear++; }
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSViewController appearance")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  AppearanceVC *vc = AUTORELEASE([[AppearanceVC alloc]
+    initWithNibName: nil bundle: nil]);
+  NSView *view = [vc view];
+
+  PASS(view != nil, "the controller loads its view");
+  PASS(vc->didLoad == 1, "viewDidLoad is sent once when the view loads");
+  PASS(vc->willAppear == 0 && vc->didAppear == 0,
+    "the appearance methods are not sent while merely loading the view");
+
+  NS_DURING
+    {
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 200, 200)
+                  styleMask: NSTitledWindowMask
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+
+      [[w contentView] addSubview: view];
+      PASS(vc->willAppear == 1 && vc->didAppear == 1,
+        "the appearance methods are sent when the view enters a window");
+
+      [view removeFromSuperview];
+      PASS(vc->willDisappear == 1 && vc->didDisappear == 1,
+        "the disappearance methods are sent when the view leaves a window");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSViewController appearance")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSViewController/viewDidLoad.m
+++ b/Tests/gui/NSViewController/viewDidLoad.m
@@ -1,0 +1,85 @@
+/* NSViewController sends -viewDidLoad once its view has been loaded, including
+   when the view is created in a -loadView override rather than from a nib.  It
+   used to be sent only on the nib path.  -isViewLoaded reports whether the view
+   has been loaded.  A plain view is created, so the theme and font backend is
+   used; the set is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSView.h>
+#include <AppKit/NSViewController.h>
+
+@interface CodeViewController : NSViewController
+{
+@public
+  int viewDidLoadCount;
+}
+@end
+
+@implementation CodeViewController
+- (void) loadView
+{
+  [self setView: AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(0, 0, 20, 20)])];
+}
+- (void) viewDidLoad
+{
+  [super viewDidLoad];
+  viewDidLoadCount++;
+}
+@end
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSViewController viewDidLoad")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      CodeViewController *vc = AUTORELEASE([[CodeViewController alloc]
+        initWithNibName: nil bundle: nil]);
+
+      pass([vc isViewLoaded] == NO, "the view is not loaded before it is used");
+      pass(vc->viewDidLoadCount == 0, "viewDidLoad has not been sent yet");
+
+      NSView *v = [vc view];
+      pass(v != nil, "accessing the view loads it from -loadView");
+      pass([vc isViewLoaded] == YES, "the view reports as loaded");
+      pass(vc->viewDidLoadCount == 1, "viewDidLoad is sent once the view loads");
+
+      /* Accessing the view again must not send viewDidLoad a second time. */
+      [vc view];
+      pass(vc->viewDidLoadCount == 1, "viewDidLoad is sent only once");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSViewController viewDidLoad")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSViewController/viewDidLoad.m
+++ b/Tests/gui/NSViewController/viewDidLoad.m
@@ -56,17 +56,17 @@ main(int argc, char **argv)
       CodeViewController *vc = AUTORELEASE([[CodeViewController alloc]
         initWithNibName: nil bundle: nil]);
 
-      pass([vc isViewLoaded] == NO, "the view is not loaded before it is used");
-      pass(vc->viewDidLoadCount == 0, "viewDidLoad has not been sent yet");
+      PASS([vc isViewLoaded] == NO, "the view is not loaded before it is used");
+      PASS(vc->viewDidLoadCount == 0, "viewDidLoad has not been sent yet");
 
       NSView *v = [vc view];
-      pass(v != nil, "accessing the view loads it from -loadView");
-      pass([vc isViewLoaded] == YES, "the view reports as loaded");
-      pass(vc->viewDidLoadCount == 1, "viewDidLoad is sent once the view loads");
+      PASS(v != nil, "accessing the view loads it from -loadView");
+      PASS([vc isViewLoaded] == YES, "the view reports as loaded");
+      PASS(vc->viewDidLoadCount == 1, "viewDidLoad is sent once the view loads");
 
       /* Accessing the view again must not send viewDidLoad a second time. */
       [vc view];
-      pass(vc->viewDidLoadCount == 1, "viewDidLoad is sent only once");
+      PASS(vc->viewDidLoadCount == 1, "viewDidLoad is sent only once");
     }
   NS_HANDLER
     {


### PR DESCRIPTION
Works towards #149. Two commits.

## viewDidLoad on programmatic load

viewDidLoad was only sent on the nib path, so a controller that creates its
view in a -loadView override (or has it set directly) never received it.
-view now sends viewDidLoad once when the view first exists, guarded by a
flag so the nib path does not send it twice. Adds -isViewLoaded.

## Appearance methods on window transitions

viewWillAppear: and viewDidAppear: were sent from -loadView, so they fired
when the view loaded rather than when it entered a window, and the disappear
pair was never sent.

They now follow the view's window membership. -setView: associates the view
with its controller (a weak association, because -[NSView addSubview:] resets
a view's next responder, so a responder-chain link would not survive being
added to a hierarchy). -[NSView _viewWillMoveToWindow:] and
-_viewDidMoveToWindow notify the controller, which sends
viewWillAppear:/viewDidAppear: as the view enters a window and
viewWillDisappear:/viewDidDisappear: as it leaves. A visible flag prevents a
transition being sent twice.

## Testing

- `Tests/gui/NSViewController/viewDidLoad.m`: a programmatic controller gets
  viewDidLoad exactly once.
- `Tests/gui/NSViewController/appearance.m`: the appearance methods are not
  sent while merely loading the view, are sent when the view enters a window,
  and the disappearance methods are sent when it leaves. Backend-guarded so it
  skips where no display is available.

Without the change the appearance test fails (no transition on window entry or
exit); with it the NSView, NSWindow and NSViewController test directories pass.

## Not covered here

updateViewConstraints, viewWillLayout and viewDidLayout from the issue's
acceptance list are the layout-pass hooks and are left for a follow-up.
