### PR TITLE
Fix: NSMenuItem -setSubmenu: overwrites the submenu's title

### DIFF
--- a/Source/NSMenuItem.m
+++ b/Source/NSMenuItem.m
@@ -238,7 +238,6 @@ static Class imageClass;
   if (submenu != nil)
     {
       [submenu setSupermenu: _menu];
-      [submenu setTitle: _title];
     }
   [self setTarget: _menu];
   [self setAction: @selector(submenuAction:)];

--- a/Source/NSMenuView.m
+++ b/Source/NSMenuView.m
@@ -831,7 +831,7 @@ static float menuBarHeight = 0.0;
               NSMenuItemCell *msr;
 
               msr = [r menuItemCellForItemAtIndex:
-                [m indexOfItemWithTitle: [_attachedMenu title]]];
+                [m indexOfItemWithSubmenu: _attachedMenu]];
               neededImageAndTitleWidth
                 = [msr titleWidth] + GSCellTextImageXDist;
             }

--- a/Tests/gui/NSMenu/submenuTitle.m
+++ b/Tests/gui/NSMenu/submenuTitle.m
@@ -1,0 +1,63 @@
+/* Attaching a menu to a menu item must not change the menu's own title, as
+   reported in gnustep/libs-gui#218 ("NSMenu ignores initWithTitle").  A menu's
+   title and the title of the item it is attached to are independent.  Every
+   assertion was checked against Apple AppKit (macOS 26) and matches.  Creating
+   a menu pulls in its windows, which needs the backend, so the body is
+   guarded. */
+#import "Testing.h"
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSMenu.h>
+#import <AppKit/NSMenuItem.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSMenu submenu title")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  /* initWithTitle: keeps the title. */
+  NSMenu *menu = AUTORELEASE([[NSMenu alloc] initWithTitle: @"File"]);
+  PASS([[menu title] isEqualToString: @"File"],
+       "-initWithTitle: keeps the title");
+
+  /* The reporter's case: attaching the menu to a fresh item must not wipe the
+     menu's title. */
+  NSMenuItem *item = AUTORELEASE([NSMenuItem new]);
+  [item setSubmenu: menu];
+  PASS([[menu title] isEqualToString: @"File"],
+       "-setSubmenu: does not change the submenu's title");
+
+  /* A titled item does not rename its submenu either, and the item keeps its
+     own title. */
+  NSMenu *other = AUTORELEASE([[NSMenu alloc] initWithTitle: @"Colours"]);
+  NSMenuItem *format = AUTORELEASE([[NSMenuItem alloc] initWithTitle: @"Format"
+                                                              action: NULL
+                                                       keyEquivalent: @""]);
+  [format setSubmenu: other];
+  PASS([[other title] isEqualToString: @"Colours"],
+       "-setSubmenu: leaves a titled submenu's title alone");
+  PASS([[format title] isEqualToString: @"Format"],
+       "-setSubmenu: leaves the item's own title alone");
+
+  /* The NSMenu convenience -setSubmenu:forItem: behaves the same way. */
+  NSMenu *main = AUTORELEASE([[NSMenu alloc] initWithTitle: @"Main"]);
+  NSMenuItem *entry = [main addItemWithTitle: @"Edit"
+                                      action: NULL
+                               keyEquivalent: @""];
+  NSMenu *edit = AUTORELEASE([[NSMenu alloc] initWithTitle: @"Edit menu"]);
+  [main setSubmenu: edit forItem: entry];
+  PASS([[edit title] isEqualToString: @"Edit menu"],
+       "-setSubmenu:forItem: does not change the submenu's title");
+
+  END_SET("NSMenu submenu title")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`[[NSMenu alloc] initWithTitle:@"File"]` keeps its title until the menu is attached to a menu item, at which point `-[NSMenuItem setSubmenu:]` copied the item's title onto the submenu and the menu's own title was lost. This is issue #218.

A menu's title and the title of the item it is attached to are independent. Verified against Apple AppKit (macOS 26): after `[item setSubmenu: menu]` the menu keeps its `-initWithTitle:` title and the item keeps its own title, for both empty and non-empty item titles, and `-setSubmenu:forItem:` behaves the same way.

The only place that relied on the submenu's title matching the owning item's title was `-[NSMenuView sizeToFit]`, which located the item in a horizontal supermenu with `indexOfItemWithTitle:`. That now uses `indexOfItemWithSubmenu:` (already used elsewhere in NSMenu for the same purpose), so the lookup no longer depends on the titles being equal.

`Tests/gui/NSMenu/submenuTitle.m` covers the behaviour; its three title-preservation assertions fail before this change and pass after, with no regression in the existing NSMenu/NSMenuItemCell/NSMenuToolbarItem tests.

Fixes #218
