### PR TITLE
Fix: let themes control the push-in displacement of a button's contents

### DIFF
--- a/Headers/Additions/GNUstepGUI/GSTheme.h
+++ b/Headers/Additions/GNUstepGUI/GSTheme.h
@@ -828,6 +828,13 @@ APPKIT_EXPORT_CLASS
 				  style: (int)style 
 				  state: (GSThemeControlState)state;
 
+/**
+ * Amount by which a pushed-in button's contents are displaced to give it a
+ * pressed look.  The default is one pixel to the bottom right; return
+ * NSZeroSize to keep the contents fixed while the button is pressed.
+ */
+- (NSSize) buttonPushInOffsetForCell: (NSCell*)cell;
+
 /** 
  * Draws the indicator (normally a dotted rectangle) to show that
  * the view currently has keyboard focus.

--- a/Source/GSThemeDrawing.m
+++ b/Source/GSThemeDrawing.m
@@ -316,6 +316,11 @@
     }
 }
 
+- (NSSize) buttonPushInOffsetForCell: (NSCell*)cell
+{
+  return NSMakeSize(1.0, 1.0);
+}
+
 - (void) drawFocusFrame: (NSRect) frame view: (NSView*) view
 {
   GSDrawTiles *tiles = [self tilesNamed: @"NSFocusRing" state: GSThemeNormalState];

--- a/Source/NSButtonCell.m
+++ b/Source/NSButtonCell.m
@@ -1494,11 +1494,14 @@
 				 border.top : border.bottom);
       interiorFrame.size.height -= border.bottom + border.top;
 
-      /* Pushed in buttons contents are displaced to the bottom right 1px.  */
+      /* Pushed in buttons contents are displaced towards the bottom right, by
+         an amount the theme can change (or suppress).  */
       if (mask & NSPushInCellMask)
         {
-          interiorFrame = NSOffsetRect(interiorFrame, 1.0,
-	    [_control_view isFlipped] ? 1.0 : -1.0);
+          NSSize offset = [[GSTheme theme] buttonPushInOffsetForCell: self];
+
+          interiorFrame = NSOffsetRect(interiorFrame, offset.width,
+	    [_control_view isFlipped] ? offset.height : -offset.height);
         }
       return interiorFrame;
     }

--- a/Tests/gui/NSButtonCell/pushInOffset.m
+++ b/Tests/gui/NSButtonCell/pushInOffset.m
@@ -1,0 +1,54 @@
+/* The displacement of a pushed-in button's contents is controlled by the theme
+   through -[GSTheme buttonPushInOffsetForCell:], so a theme can change or
+   suppress it (gnustep/libs-gui#219).  The default is one pixel to the bottom
+   right, and -[NSButtonCell drawingRectForBounds:] offsets the interior by that
+   amount while the button is highlighted.  Laying out the cell needs the theme,
+   so the body is guarded. */
+#import "Testing.h"
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSButtonCell.h>
+#import <GNUstepGUI/GSTheme.h>
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSButtonCell push-in offset")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  /* The default theme displaces the contents by one pixel. */
+  NSSize offset = [[GSTheme theme] buttonPushInOffsetForCell: nil];
+  PASS(offset.width == 1.0 && offset.height == 1.0,
+       "the default push-in offset is one pixel to the bottom right");
+
+  NSButtonCell *cell = AUTORELEASE([[NSButtonCell alloc] init]);
+  [cell setButtonType: NSMomentaryPushInButton];
+  [cell setBordered: YES];
+  NSRect bounds = NSMakeRect(0, 0, 120, 32);
+
+  [cell setHighlighted: NO];
+  NSRect normal = [cell drawingRectForBounds: bounds];
+
+  [cell setHighlighted: YES];
+  NSRect pushed = [cell drawingRectForBounds: bounds];
+
+  /* The contents move by exactly the theme's offset; the view is not flipped,
+     so the y axis points up and the downward move is a negative offset. */
+  PASS(pushed.origin.x - normal.origin.x == offset.width,
+       "a pushed-in cell shifts its contents right by the theme offset");
+  PASS(normal.origin.y - pushed.origin.y == offset.height,
+       "a pushed-in cell shifts its contents down by the theme offset");
+  PASS(NSEqualSizes(pushed.size, normal.size),
+       "the push-in offset moves the contents without resizing them");
+
+  END_SET("NSButtonCell push-in offset")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A pushed-in button displaces its contents one pixel to the bottom right so that it looks pressed. The amount was hard-coded in `-[NSButtonCell drawingRectForBounds:]`, so a theme had no way to change or disable it, as reported in #219 (the reporter wants a theme that keeps the text fixed while a button is clicked).

This reads the displacement from a new theme hook, `-[GSTheme buttonPushInOffsetForCell:]`. The default returns the previous one-pixel offset, so existing themes are unchanged; a theme can return `NSZeroSize` to keep the contents fixed while the button is pressed, or any other size to alter the effect.

`Tests/gui/NSButtonCell/pushInOffset.m` checks the default offset and that `drawingRectForBounds:` moves a highlighted push-in cell's interior by exactly that offset (without resizing it). The existing NSButtonCell tests still pass.

Fixes #219
