### PR TITLE
Fix: let themes inset a menu's item cells from its edges

### DIFF
--- a/Headers/Additions/GNUstepGUI/GSTheme.h
+++ b/Headers/Additions/GNUstepGUI/GSTheme.h
@@ -1204,6 +1204,13 @@ APPKIT_EXPORT_CLASS
 - (CGFloat) menuItemHeight;
 - (CGFloat) menuSeparatorHeight;
 
+/**
+ * Padding between the edges of a vertical menu and its item cells.  The
+ * default is zero on every side; a theme can return larger insets to inset the
+ * list of items within the menu.
+ */
+- (NSEdgeInsets) menuItemAreaInsets;
+
 // NSColorWell drawing method
 - (NSRect) drawColorWellBorder: (NSColorWell*)well
                     withBounds: (NSRect)bounds

--- a/Source/GSThemeDrawing.m
+++ b/Source/GSThemeDrawing.m
@@ -1437,6 +1437,11 @@
   return height;
 }
 
+- (NSEdgeInsets) menuItemAreaInsets
+{
+  return NSEdgeInsetsMake(0.0, 0.0, 0.0, 0.0);
+}
+
 // NSColorWell drawing method
 - (NSRect) drawColorWellBorder: (NSColorWell*)well
                     withBounds: (NSRect)bounds

--- a/Source/NSMenuView.m
+++ b/Source/NSMenuView.m
@@ -969,10 +969,15 @@ static float menuBarHeight = 0.0;
           _keyEqOffset = _cellSize.width - _keyEqWidth - popupImageWidth;
         }
 
-      [self setFrameSize: NSMakeSize(_cellSize.width + _leftBorderOffset, 
-                                     [self totalHeight] 
+      NSEdgeInsets insets = [[GSTheme theme] menuItemAreaInsets];
+
+      [self setFrameSize: NSMakeSize(_cellSize.width + _leftBorderOffset
+                                     + insets.left + insets.right,
+                                     [self totalHeight]
+                                     + insets.top + insets.bottom
                                      + menuBarHeight)];
-      [_titleView setFrame: NSMakeRect (0, [self totalHeight],
+      [_titleView setFrame: NSMakeRect (0, [self totalHeight]
+                                        + insets.top + insets.bottom,
                                         NSWidth (_bounds), menuBarHeight)];
     }
   _needsSizing = NO;
@@ -1069,9 +1074,10 @@ static float menuBarHeight = 0.0;
   else
     {
       NSRect theRect;
+      NSEdgeInsets insets = [[GSTheme theme] menuItemAreaInsets];
 
-      theRect.origin.y	= [self yOriginForItem: index];
-      theRect.origin.x = _leftBorderOffset;
+      theRect.origin.y	= [self yOriginForItem: index] + insets.bottom;
+      theRect.origin.x = _leftBorderOffset + insets.left;
       theRect.size = _cellSize;
       theRect.size.height = [self heightForItem: index];
 

--- a/Tests/gui/NSMenuView/menuItemAreaInsets.m
+++ b/Tests/gui/NSMenuView/menuItemAreaInsets.m
@@ -1,0 +1,85 @@
+/* A theme can inset the item cells of a vertical menu within the menu's edges
+   through -[GSTheme menuItemAreaInsets] (gnustep/libs-gui#220).  The default is
+   zero on every side; with non-zero insets -[NSMenuView sizeToFit] grows the
+   frame and -[NSMenuView rectOfItemAtIndex:] moves the cells by the same
+   amount, and hit testing follows.  Laying out a menu needs the backend, so the
+   body is guarded. */
+#import "Testing.h"
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSMenu.h>
+#import <AppKit/NSMenuView.h>
+#import <GNUstepGUI/GSTheme.h>
+
+@interface PadTheme : GSTheme
+@end
+
+@implementation PadTheme
+- (NSString *) name
+{
+  return @"PadTheme";
+}
+- (NSEdgeInsets) menuItemAreaInsets
+{
+  return NSEdgeInsetsMake(7.0, 11.0, 3.0, 13.0);
+}
+@end
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSMenuView item area insets")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  /* The default theme insets nothing. */
+  NSEdgeInsets d = [[GSTheme theme] menuItemAreaInsets];
+  PASS(d.top == 0.0 && d.left == 0.0 && d.bottom == 0.0 && d.right == 0.0,
+       "the default menu item area insets are zero");
+
+  NSMenu *menu = AUTORELEASE([[NSMenu alloc] initWithTitle: @"M"]);
+  [menu addItemWithTitle: @"One" action: NULL keyEquivalent: @""];
+  [menu addItemWithTitle: @"Two" action: NULL keyEquivalent: @""];
+  [menu addItemWithTitle: @"Three" action: NULL keyEquivalent: @""];
+  NSMenuView *mv = [menu menuRepresentation];
+
+  [mv setNeedsSizing: YES];
+  [mv sizeToFit];
+  NSRect plainFrame = [mv frame];
+  NSRect plainItem = [mv rectOfItemAtIndex: 1];
+
+  /* Install a theme that insets the item area and measure again. */
+  GSTheme *saved = RETAIN([GSTheme theme]);
+  [GSTheme setTheme: AUTORELEASE([[PadTheme alloc] initWithBundle: nil])];
+  [mv setNeedsSizing: YES];
+  [mv sizeToFit];
+  NSRect padFrame = [mv frame];
+  NSRect padItem = [mv rectOfItemAtIndex: 1];
+  NSInteger hit = [mv indexOfItemAtPoint:
+    NSMakePoint(NSMidX(padItem), NSMidY(padItem))];
+  [GSTheme setTheme: saved];
+  RELEASE(saved);
+
+  PASS(padFrame.size.width - plainFrame.size.width == 11.0 + 13.0,
+       "insets widen the menu by the left and right insets");
+  PASS(padFrame.size.height - plainFrame.size.height == 7.0 + 3.0,
+       "insets heighten the menu by the top and bottom insets");
+  PASS(padItem.origin.x - plainItem.origin.x == 11.0,
+       "an item moves right by the left inset");
+  PASS(padItem.origin.y - plainItem.origin.y == 3.0,
+       "an item moves up by the bottom inset");
+  PASS(NSEqualSizes(padItem.size, plainItem.size),
+       "insetting the item area does not resize the cells");
+  PASS(hit == 1,
+       "hit testing still finds the item under its inset rect");
+
+  END_SET("NSMenuView item area insets")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The size and layout of a vertical menu are computed in `-[NSMenuView sizeToFit]` before drawing, with no way for a theme to add space between the menu's edges and its item cells. This is issue #220 (@fredkiefer you confirmed it and asked whether influencing `_leftBorderOffset` would be enough or whether a per-border offset was needed; the OP asked for per-side values / `NSEdgeInsets`).

This adds a `-[GSTheme menuItemAreaInsets]` returning `NSEdgeInsets`. The default is zero on every side, so existing themes are unchanged. When a theme returns non-zero insets:

- `-[NSMenuView sizeToFit]` grows the menu frame by the left/right insets (width) and top/bottom insets (height), and positions the title view above the inset item area;
- `-[NSMenuView rectOfItemAtIndex:]` offsets each item cell by the left and bottom insets.

Because drawing (`drawMenuRect:`) and hit testing (`indexOfItemAtPoint:`) both go through `rectOfItemAtIndex:`, they follow the inset layout automatically; the item cells keep their size and the padding around them is filled by the menu background.

`Tests/gui/NSMenuView/menuItemAreaInsets.m` installs a theme returning `NSEdgeInsetsMake(7, 11, 3, 13)` and checks the frame grows by 24×10, an item moves right 11 / up 3 without resizing, and a point at the moved item's centre still hit-tests to that item. The default insets are zero and the existing menu tests still pass.

I went with `NSEdgeInsets` (per the OP's suggestion, covering your "all borders" option) rather than only `_leftBorderOffset`; happy to narrow it if you prefer the smaller change.

Fixes #220
