### PR TITLE
Fix: let themes round the background of a highlighted menu item

### DIFF
--- a/Headers/Additions/GNUstepGUI/GSTheme.h
+++ b/Headers/Additions/GNUstepGUI/GSTheme.h
@@ -1204,6 +1204,13 @@ APPKIT_EXPORT_CLASS
 - (CGFloat) menuItemHeight;
 - (CGFloat) menuSeparatorHeight;
 
+/**
+ * Corner radius used when filling the background of a highlighted menu item.
+ * The default is zero, which fills the whole item rectangle; a larger value
+ * rounds the corners of the highlight.
+ */
+- (CGFloat) menuItemBackgroundRadius;
+
 // NSColorWell drawing method
 - (NSRect) drawColorWellBorder: (NSColorWell*)well
                     withBounds: (NSRect)bounds

--- a/Source/GSThemeDrawing.m
+++ b/Source/GSThemeDrawing.m
@@ -1238,21 +1238,39 @@
   if (tiles == nil)
     {
       NSColor	*backgroundColor = [cell backgroundColor];
+      CGFloat radius = 0.0;
+
+      /* Only a highlighted item shows a coloured background, so round just
+         that one; rounding the plain items would notch every row. */
+      if (state == GSThemeHighlightedState || state == GSThemeSelectedState)
+        {
+          radius = [self menuItemBackgroundRadius];
+        }
 
       if (isHorizontal)
 	{
 	  cellFrame = [cell drawingRectForBounds: cellFrame];
-	  [backgroundColor set];
-	  NSRectFill(cellFrame);
+	}
+
+      [backgroundColor set];
+      if (radius > 0.0)
+        {
+          [[NSBezierPath bezierPathWithRoundedRect: cellFrame
+                                           xRadius: radius
+                                           yRadius: radius] fill];
+        }
+      else
+        {
+          NSRectFill(cellFrame);
+        }
+
+      if (isHorizontal)
+	{
 	  return;
 	}
 
-      // Set cell's background color
-      [backgroundColor set];
-      NSRectFill(cellFrame);
-
-      if (![self drawsBorderForMenuItemCell: cell 
-                                      state: state 
+      if (![self drawsBorderForMenuItemCell: cell
+                                      state: state
                                isHorizontal: isHorizontal])
         {
           return;
@@ -1435,6 +1453,11 @@
       return 20;
     }
   return height;
+}
+
+- (CGFloat) menuItemBackgroundRadius
+{
+  return 0.0;
 }
 
 // NSColorWell drawing method

--- a/Tests/gui/NSMenuItemCell/backgroundRadius.m
+++ b/Tests/gui/NSMenuItemCell/backgroundRadius.m
@@ -1,0 +1,140 @@
+/* The background of a highlighted menu item can be rounded by the theme through
+   -[GSTheme menuItemBackgroundRadius] (gnustep/libs-gui#221).  The default is
+   zero, which fills the whole item rectangle; a larger radius rounds the
+   corners of the highlight, leaving the menu background showing through them.
+   This draws a highlighted item on a white background and reads back a corner
+   pixel, so it needs the backend and the body is guarded. */
+#import "Testing.h"
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSBitmapImageRep.h>
+#import <AppKit/NSColor.h>
+#import <AppKit/NSGraphics.h>
+#import <AppKit/NSMenuItemCell.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSWindow.h>
+#import <GNUstepGUI/GSTheme.h>
+
+/* Both themes paint the selected item red so the fill is visible; they differ
+   only in the corner radius. */
+@interface FlatRedTheme : GSTheme
+@end
+@implementation FlatRedTheme
+- (NSString *) name
+{
+  return @"FlatRedTheme";
+}
+- (NSColor *) colorNamed: (NSString *)aName state: (GSThemeControlState)state
+{
+  if ([aName isEqualToString: @"NSMenuItem"])
+    return [NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0];
+  return [super colorNamed: aName state: state];
+}
+- (CGFloat) menuItemBackgroundRadius
+{
+  return 0.0;
+}
+@end
+
+@interface RoundRedTheme : FlatRedTheme
+@end
+@implementation RoundRedTheme
+- (NSString *) name
+{
+  return @"RoundRedTheme";
+}
+- (CGFloat) menuItemBackgroundRadius
+{
+  return 12.0;
+}
+@end
+
+/* Draw a highlighted menu item filling the view and return the colour at (x, y)
+   in calibrated RGB. */
+static NSColor *
+drawnPixel(int side, int x, int y)
+{
+  NSWindow *w = AUTORELEASE([[NSWindow alloc]
+    initWithContentRect: NSMakeRect(0, 0, side, side)
+              styleMask: NSWindowStyleMaskBorderless
+                backing: NSBackingStoreBuffered
+                  defer: NO]);
+  NSView *v = AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(0, 0, side, side)]);
+  NSMenuItemCell *cell = AUTORELEASE([[NSMenuItemCell alloc] init]);
+  NSBitmapImageRep *rep;
+  NSColor *c;
+
+  [w setContentView: v];
+  [v lockFocus];
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, side, side));
+
+  [cell setBordered: NO];
+  [cell setHighlightsBy: NSPushInCellMask];
+  [cell setHighlighted: YES];
+  [[GSTheme theme] drawBorderAndBackgroundForMenuItemCell: cell
+    withFrame: NSMakeRect(0, 0, side, side)
+    inView: v
+    state: GSThemeSelectedState
+    isHorizontal: NO];
+
+  rep = AUTORELEASE([[NSBitmapImageRep alloc]
+    initWithFocusedViewRect: NSMakeRect(0, 0, side, side)]);
+  [v unlockFocus];
+  c = [rep colorAtX: x y: y];
+  return [c colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+}
+
+static BOOL
+isRed(NSColor *c)
+{
+  return [c redComponent] > 0.7 && [c greenComponent] < 0.3
+    && [c blueComponent] < 0.3;
+}
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSMenuItemCell background radius")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  /* The default theme does not round the highlight. */
+  PASS([[GSTheme theme] menuItemBackgroundRadius] == 0.0,
+       "the default menu item background radius is zero");
+
+  GSTheme *saved = RETAIN([GSTheme theme]);
+
+  /* A zero radius fills the whole rectangle, so a corner is painted. */
+  [GSTheme setTheme: AUTORELEASE([[FlatRedTheme alloc] initWithBundle: nil])];
+  NSColor *flatCenter = drawnPixel(40, 20, 20);
+  NSColor *flatCorner = drawnPixel(40, 1, 1);
+
+  /* A non-zero radius rounds the corners, so the corner keeps the white
+     background while the centre is still painted. */
+  [GSTheme setTheme: AUTORELEASE([[RoundRedTheme alloc] initWithBundle: nil])];
+  NSColor *roundCenter = drawnPixel(40, 20, 20);
+  NSColor *roundCorner = drawnPixel(40, 1, 1);
+
+  [GSTheme setTheme: saved];
+  RELEASE(saved);
+
+  PASS(isRed(flatCenter), "a highlighted item is painted at its centre");
+  PASS(isRed(flatCorner),
+       "with a zero radius the highlight reaches the corner");
+  PASS(isRed(roundCenter),
+       "a rounded highlight is still painted at its centre");
+  PASS(!isRed(roundCorner),
+       "with a non-zero radius the highlight does not reach the corner");
+
+  END_SET("NSMenuItemCell background radius")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A highlighted ("overed") menu item's background is filled as a plain rectangle in `-[GSTheme drawBorderAndBackgroundForMenuItemCell:...]`, with no way for a theme to round its corners. This is issue #221 (the reporter wants the selected item — blue background, white text in the screenshot — to have a rounded background).

This adds `-[GSTheme menuItemBackgroundRadius]`. The default is zero, so the whole item rectangle is filled as before; a larger value fills the highlight through `+[NSBezierPath bezierPathWithRoundedRect:xRadius:yRadius:]` instead. Only the highlighted or selected item is rounded — the plain items paint their whole row, so rounding them would notch every row.

`Tests/gui/NSMenuItemCell/backgroundRadius.m` draws a highlighted item on a white background and reads back the pixels: the default radius is zero, a zero-radius highlight reaches the corner, and a non-zero radius keeps the corner as background while still painting the centre.

This is the last of the three menu-theming requests (#219 push-in offset, #220 item area insets, #221 corner radius); together they let a theme give menus a modern inset, rounded selection.

Fixes #221
