### PR TITLE
Fix: let themes set the text colour of a highlighted menu item

### DIFF
--- a/Source/NSMenuItemCell.m
+++ b/Source/NSMenuItemCell.m
@@ -129,20 +129,9 @@ static NSString *commandKeyString = @"#";
   return _cell.is_highlighted;
 }
 
-- (NSColor *)textColor
-{
-  if (_cell.is_highlighted && [self isEnabled])
-    {
-      return [NSColor selectedMenuItemTextColor];
-    }
-
-  return [super textColor];
-}
-
-- (NSColor *) backgroundColor
+- (GSThemeControlState) _themeControlState
 {
   unsigned	mask;
-  NSColor	*color;
   GSThemeControlState state = GSThemeNormalState;
 
   if (_cell.is_highlighted)
@@ -157,7 +146,6 @@ static NSString *commandKeyString = @"#";
   else
     mask = NSNoCellMask;
 
-  // Determine the background color
   if (mask & (NSChangeGrayCellMask | NSChangeBackgroundCellMask))
     {
       state = GSThemeHighlightedState;
@@ -167,6 +155,32 @@ static NSString *commandKeyString = @"#";
     {
       state = GSThemeSelectedState;
     }
+
+  return state;
+}
+
+- (NSColor *)textColor
+{
+  if (_cell.is_highlighted && [self isEnabled])
+    {
+      NSColor *color = [[GSTheme theme] colorNamed: @"NSMenuItemText"
+                                             state: [self _themeControlState]];
+
+      if (color != nil)
+        {
+          return color;
+        }
+
+      return [NSColor selectedMenuItemTextColor];
+    }
+
+  return [super textColor];
+}
+
+- (NSColor *) backgroundColor
+{
+  NSColor	*color;
+  GSThemeControlState state = [self _themeControlState];
 
   // TODO: Make the color lookup simpler.
   color = [[GSTheme theme] colorNamed: @"NSMenuItem" state: state];

--- a/Tests/gui/NSMenuItemCell/textColor.m
+++ b/Tests/gui/NSMenuItemCell/textColor.m
@@ -1,0 +1,80 @@
+/* The text colour of a highlighted ("overed") menu item can be set by the
+   theme through the "NSMenuItemText" named colour, the same way the highlight
+   background is set through "NSMenuItem" (gnustep/libs-gui#222).  When the
+   theme provides no such colour the default stays [NSColor
+   selectedMenuItemTextColor], and the hook only applies while the item is
+   highlighted and enabled. */
+#import "Testing.h"
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSColor.h>
+#import <AppKit/NSGraphics.h>
+#import <AppKit/NSMenuItemCell.h>
+#import <GNUstepGUI/GSTheme.h>
+
+/* A theme that paints the highlighted item's text red. */
+@interface RedTextTheme : GSTheme
+@end
+@implementation RedTextTheme
+- (NSString *) name
+{
+  return @"RedTextTheme";
+}
+- (NSColor *) colorNamed: (NSString *)aName state: (GSThemeControlState)state
+{
+  if ([aName isEqualToString: @"NSMenuItemText"])
+    return [NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0];
+  return [super colorNamed: aName state: state];
+}
+@end
+
+static BOOL
+isRed(NSColor *c)
+{
+  c = [c colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+  return [c redComponent] > 0.7 && [c greenComponent] < 0.3
+    && [c blueComponent] < 0.3;
+}
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSMenuItemCell text colour")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NSMenuItemCell *cell = AUTORELEASE([[NSMenuItemCell alloc] init]);
+  [cell setEnabled: YES];
+  [cell setHighlightsBy: NSPushInCellMask];
+
+  /* With no override the highlighted text colour is the default one. */
+  [cell setHighlighted: YES];
+  PASS([[cell textColor] isEqual: [NSColor selectedMenuItemTextColor]],
+       "a highlighted item uses selectedMenuItemTextColor by default");
+
+  GSTheme *saved = RETAIN([GSTheme theme]);
+  [GSTheme setTheme: AUTORELEASE([[RedTextTheme alloc] initWithBundle: nil])];
+
+  /* The theme's NSMenuItemText colour now drives the highlighted text. */
+  [cell setHighlighted: YES];
+  PASS(isRed([cell textColor]),
+       "a highlighted item takes its text colour from the theme");
+
+  /* The hook only applies while highlighted; a normal item is unaffected. */
+  [cell setHighlighted: NO];
+  PASS(!isRed([cell textColor]),
+       "a non-highlighted item ignores the NSMenuItemText colour");
+
+  [GSTheme setTheme: saved];
+  RELEASE(saved);
+
+  END_SET("NSMenuItemCell text colour")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Fixes #222.

A theme can already set the background of a highlighted ("overed") menu item
through the "NSMenuItem" colour, but the text drawn over it was fixed:
`-[NSMenuItemCell textColor]` returned `selectedMenuItemTextColor` for any
highlighted item regardless of the theme, so the white title in the report
could not be changed.

`textColor` now resolves the highlighted text from the theme's
"NSMenuItemText" colour, mirroring how `backgroundColor` resolves
"NSMenuItem", and falls back to `selectedMenuItemTextColor` when the theme
provides none. The default look is therefore unchanged. The mask to
theme-state mapping shared by the two methods is factored into
`_themeControlState`.

Tests in `Tests/gui/NSMenuItemCell/textColor.m`: the default highlighted
colour is `selectedMenuItemTextColor`; a theme returning a colour for
"NSMenuItemText" drives the highlighted text; a non-highlighted item ignores
it. The theme-driven case fails against the current code and passes with this
change.
