### PR TITLE
Fix: import NSProcessInfo in the NSApplication test

### DIFF
--- a/Tests/gui/NSApplication/basic.m
+++ b/Tests/gui/NSApplication/basic.m
@@ -10,6 +10,7 @@
 #import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSString.h>
 #import <Foundation/NSNotification.h>
+#import <Foundation/NSProcessInfo.h>
 #import <Foundation/NSUserDefaults.h>
 #import <AppKit/NSApplication.h>
 #import <AppKit/NSEvent.h>


### PR DESCRIPTION
`Tests/gui/NSApplication/basic.m` uses `+[NSProcessInfo processInfo]` (line 240) but never imports `<Foundation/NSProcessInfo.h>`. It compiles only where another included header happens to pull that declaration in; where it does not, the test fails to build:

```
basic.m:240:22: error: use of undeclared identifier 'NSProcessInfo'
```

Add the missing import.
