### PR TITLE
Fix: prevent unbounded recursion when autohidesScrollers is set

### DIFF
--- a/Source/NSScrollView.m
+++ b/Source/NSScrollView.m
@@ -106,6 +106,7 @@ typedef struct _scrollViewFlags
 /* GNUstep private methods */
 - (void) _synchronizeHeaderAndCornerView;
 - (void) _themeDidActivate: (NSNotification*)notification;
+- (void) _autohideScrollers;
 @end
 
 @implementation NSScrollView
@@ -826,6 +827,64 @@ static CGFloat scrollerWidth;
   [self _doScroll: scroller];
 }
 
+/* Show or hide the scrollers for -autohidesScrollers.  The two axes are
+ * coupled: a vertical scroller takes away width, which can make a horizontal
+ * scroller necessary, and a horizontal scroller takes away height, which can
+ * make a vertical scroller necessary.  They must therefore be decided
+ * together rather than one axis at a time.  Reconstruct the area the clip
+ * view would have with no scrollers (its current bounds plus the footprint of
+ * whatever scrollers are currently shown) and evaluate each axis against it,
+ * allowing for the space the other scroller takes.  The evaluation only ever
+ * turns scrollers on, so it settles on a single configuration.  Because the
+ * reconstructed area does not depend on which scrollers are currently shown,
+ * -setHas...Scroller: below re-tiles and re-enters this method with the same
+ * result, where it changes nothing further.
+ */
+- (void) _autohideScrollers
+{
+  NSView *documentView = [_contentView documentView];
+  NSSize documentSize;
+  NSSize clipSize;
+  CGFloat innerBorderWidth;
+  CGFloat footprint;
+  CGFloat availWidth;
+  CGFloat availHeight;
+  BOOL needsVert;
+  BOOL needsHoriz;
+
+  if (documentView == nil)
+    {
+      return;
+    }
+
+  documentSize = [documentView frame].size;
+  clipSize = [_contentView bounds].size;
+  innerBorderWidth = [[NSUserDefaults standardUserDefaults]
+                       boolForKey: @"GSScrollViewNoInnerBorder"] ? 0.0 : 1.0;
+  footprint = scrollerWidth + innerBorderWidth;
+
+  availWidth = clipSize.width + (_hasVertScroller ? footprint : 0.0);
+  availHeight = clipSize.height + (_hasHorizScroller ? footprint : 0.0);
+
+  needsVert = documentSize.height > availHeight;
+  needsHoriz = documentSize.width > availWidth;
+  if (needsVert)
+    {
+      needsHoriz = documentSize.width > (availWidth - footprint);
+    }
+  if (needsHoriz)
+    {
+      needsVert = documentSize.height > (availHeight - footprint);
+    }
+  if (needsVert)
+    {
+      needsHoriz = documentSize.width > (availWidth - footprint);
+    }
+
+  [self setHasVerticalScroller: needsVert];
+  [self setHasHorizontalScroller: needsHoriz];
+}
+
 - (void) reflectScrolledClipView: (NSClipView *)aClipView
 {
   NSRect documentFrame = NSZeroRect;
@@ -841,6 +900,11 @@ static CGFloat scrollerWidth;
 
   NSDebugLLog (@"NSScrollView", @"reflectScrolledClipView:");
 
+  if (_autohidesScrollers)
+    {
+      [self _autohideScrollers];
+    }
+
   if (_contentView)
     {
       clipViewBounds = [_contentView bounds];
@@ -850,25 +914,11 @@ static CGFloat scrollerWidth;
       documentFrame = [documentView frame];
     }
 
-  // FIXME: Should we just hide the scroll bar or remove it?
-  if ((_autohidesScrollers)
-    && (documentFrame.size.height > clipViewBounds.size.height))
-    {
-      [self setHasVerticalScroller: YES];        
-    } 
- 
   if (_hasVertScroller)
     {
       if (documentFrame.size.height <= clipViewBounds.size.height)
         {
-          if (_autohidesScrollers)
-            {
-              [self setHasVerticalScroller: NO];
-            }
-          else
-            {
-              [_vertScroller setEnabled: NO];
-            }
+          [_vertScroller setEnabled: NO];
         }
       else
         {
@@ -884,29 +934,16 @@ static CGFloat scrollerWidth;
             {
               floatValue = 1 - floatValue;
             }
-          [_vertScroller setFloatValue: floatValue 
+          [_vertScroller setFloatValue: floatValue
                          knobProportion: knobProportion];
         }
     }
 
-  if ((_autohidesScrollers)
-    && (documentFrame.size.width > clipViewBounds.size.width))
-    {
-      [self setHasHorizontalScroller: YES];        
-    } 
- 
   if (_hasHorizScroller)
     {
       if (documentFrame.size.width <= clipViewBounds.size.width)
         {
-          if (_autohidesScrollers)
-            {
-              [self setHasHorizontalScroller: NO];
-            }
-          else
-            {
-              [_horizScroller setEnabled: NO];
-            }
+          [_horizScroller setEnabled: NO];
         }
       else
         {

--- a/Tests/gui/NSScrollView/autohidesScrollers.m
+++ b/Tests/gui/NSScrollView/autohidesScrollers.m
@@ -1,0 +1,88 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSClipView.h>
+#import <AppKit/NSScrollView.h>
+#import <AppKit/NSView.h>
+
+/* Lay out an autohiding scroll view whose document is a given size and
+   return whether each scroller ended up visible.  With the pre-#234 code a
+   document sized so that showing one scroller forces the other on (and vice
+   versa) makes -reflectScrolledClipView: and -tile recurse without bound and
+   the process crashes, so simply returning from here is the regression check. */
+static void
+layoutScrollView(NSSize frame, NSSize document, BOOL *hasVert, BOOL *hasHoriz)
+{
+  NSScrollView *sv = AUTORELEASE([[NSScrollView alloc]
+    initWithFrame: NSMakeRect(0, 0, frame.width, frame.height)]);
+  NSView *doc = AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(0, 0, document.width, document.height)]);
+
+  [sv setBorderType: NSNoBorder];
+  [sv setDocumentView: doc];
+  [sv setHasVerticalScroller: YES];
+  [sv setHasHorizontalScroller: NO];
+  [sv setAutohidesScrollers: YES];
+
+  [doc setFrameSize: document];
+  [sv reflectScrolledClipView: [sv contentView]];
+  [sv setFrame: NSMakeRect(0, 0, frame.width, frame.height)];
+  [sv tile];
+
+  *hasVert = [sv hasVerticalScroller];
+  *hasHoriz = [sv hasHorizontalScroller];
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSScrollView autohidesScrollers")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      BOOL hasVert, hasHoriz;
+      NSSize frame = NSMakeSize(800, 600);
+
+      /* The size that used to trigger the runaway recursion (bug #234): the
+         document is within a scroller width of the frame on both axes, so the
+         two scrollers keep flipping each other's visibility.  Reaching the
+         next line at all means the recursion is now bounded. */
+      layoutScrollView(frame, NSMakeSize(792, 595), &hasVert, &hasHoriz);
+      PASS(1, "autohidesScrollers does not recurse for a critical document size");
+
+      /* A document that fits needs neither scroller. */
+      layoutScrollView(frame, NSMakeSize(400, 300), &hasVert, &hasHoriz);
+      PASS(hasVert == NO && hasHoriz == NO,
+        "no scrollers are shown when the document fits");
+
+      /* A document taller than the frame needs a vertical scroller; that
+         scroller then narrows the clip view enough that the horizontal
+         scroller is needed too. */
+      layoutScrollView(frame, NSMakeSize(792, 640), &hasVert, &hasHoriz);
+      PASS(hasVert == YES && hasHoriz == YES,
+        "a scroller that narrows the clip view brings in the other scroller");
+
+      /* Symmetrically for a document wider than the frame. */
+      layoutScrollView(frame, NSMakeSize(840, 595), &hasVert, &hasHoriz);
+      PASS(hasVert == YES && hasHoriz == YES,
+        "a wide document brings in both scrollers");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSScrollView autohidesScrollers")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Fixes #234.

## Problem

With `autohidesScrollers = YES`, resizing a scroll view whose content is
close to the frame size can crash with a segmentation fault. The stack
trace is an unbounded `-reflectScrolledClipView:` / `-tile` recursion:

```
-[NSScrollView reflectScrolledClipView:]   (autohide toggles a scroller)
-[NSScrollView tile]
-[NSClipView setFrame:]
-[NSScrollView reflectScrolledClipView:]
...
```

`-reflectScrolledClipView:` decided each scroller independently by
comparing the document size to the current clip view bounds. Showing or
hiding a scroller calls `-tile`, which resizes the clip view and calls
`-reflectScrolledClipView:` again. A vertical scroller removes width and
a horizontal scroller removes height, so at sizes where the content is
within one scroller width of fitting, the two decisions keep flipping
each other and the method recurses until the stack is exhausted.

This also explains the question raised in the issue thread about how
disabling a scroller could create the need for that same scroller: the
coupling is across axes. Removing the vertical scroller gives back
width, which lets the horizontal scroller be removed, which gives back
height, which brings the vertical scroller back.

## Fix

Decide both scrollers together in a new private `-_autohideScrollers`.
It reconstructs the area the clip view would have with no scrollers (its
current bounds plus the footprint of whatever scrollers are currently
shown) and evaluates each axis against that area, allowing for the space
the other scroller occupies. The evaluation only ever turns scrollers
on, so it settles on one configuration. Because the reconstructed area
does not depend on which scrollers are currently shown, the `-tile`
triggered by applying the decision re-enters `-reflectScrolledClipView:`
with the same result, where `-setHasVerticalScroller:` /
`-setHasHorizontalScroller:` change nothing and the recursion stops. No
ivar or ABI change is needed.

The non-autohiding path is unchanged.

## Testing

Added `Tests/gui/NSScrollView/autohidesScrollers.m`. It lays out an
autohiding scroll view at the document size that used to recurse and
asserts the scroller visibility for fitting and overflowing documents.
Against the current library the test aborts (the crash); with this
change it passes. The existing NSScrollView, NSClipView, NSScroller,
NSTableView, NSTextView and NSBrowser test directories still pass.
