### PR TITLE
Fix: return nil from NSDataLink loaders instead of raising on bad data

### DIFF
--- a/Source/NSDataLink.m
+++ b/Source/NSDataLink.m
@@ -30,6 +30,7 @@
 #import <Foundation/NSFileManager.h>
 #import <Foundation/NSArchiver.h>
 #import <Foundation/NSData.h>
+#import <Foundation/NSException.h>
 #import "AppKit/NSDataLink.h"
 #import "AppKit/NSDataLinkManager.h"
 #import "AppKit/NSPasteboard.h"
@@ -120,9 +121,20 @@
 - (id)initWithContentsOfFile:(NSString *)filename
 {
   NSData *data = [[NSData alloc] initWithContentsOfFile: filename];
-  id object = [NSUnarchiver unarchiveObjectWithData: data];
+  id object = nil;
 
-  RELEASE(data);
+  // A missing, unreadable or corrupt file must yield nil rather than an
+  // exception: -[NSUnarchiver unarchiveObjectWithData:] raises outright for
+  // nil data and raises while decoding malformed data.
+  if (data != nil)
+    {
+      NS_DURING
+	object = [NSUnarchiver unarchiveObjectWithData: data];
+      NS_HANDLER
+	object = nil;
+      NS_ENDHANDLER
+      RELEASE(data);
+    }
   RELEASE(self);
   return RETAIN(object);
 }
@@ -130,8 +142,17 @@
 - (id)initWithPasteboard:(NSPasteboard *)pasteboard
 {
   NSData *data = [pasteboard dataForType: NSDataLinkPboardType];
-  id object = [NSUnarchiver unarchiveObjectWithData: data];
+  id object = nil;
 
+  // A pasteboard without valid link data must yield nil in the same way.
+  if (data != nil)
+    {
+      NS_DURING
+	object = [NSUnarchiver unarchiveObjectWithData: data];
+      NS_HANDLER
+	object = nil;
+      NS_ENDHANDLER
+    }
   RELEASE(self);
   return RETAIN(object);
 }

--- a/Tests/gui/NSDataLink/initFailure.m
+++ b/Tests/gui/NSDataLink/initFailure.m
@@ -1,0 +1,62 @@
+#import "Testing.h"
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSFileManager.h>
+#import <Foundation/NSPathUtilities.h>
+#import <Foundation/NSString.h>
+#import <AppKit/NSDataLink.h>
+#import <AppKit/NSPasteboard.h>
+
+/* -[NSDataLink initWithContentsOfFile:] and -initWithPasteboard: handed the
+   loaded data straight to NSUnarchiver, which raises for nil data (a missing
+   file or a pasteboard with no link) and while decoding malformed data.  A
+   failed load must return nil instead (gnustep/libs-gui issue #215/#167). */
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSDataLink init failure")
+
+  NSFileManager *fm = [NSFileManager defaultManager];
+  NSString *dir = NSTemporaryDirectory();
+  NSString *missing = [dir stringByAppendingPathComponent: @"nsdl-missing.dlf"];
+  NSString *empty = [dir stringByAppendingPathComponent: @"nsdl-empty.dlf"];
+  NSString *corrupt = [dir stringByAppendingPathComponent: @"nsdl-corrupt.dlf"];
+  id link;
+
+  [fm removeFileAtPath: missing handler: nil];
+  [[NSData data] writeToFile: empty atomically: YES];
+  [[@"not a valid archive" dataUsingEncoding: NSUTF8StringEncoding]
+    writeToFile: corrupt atomically: YES];
+
+  link = AUTORELEASE([[NSDataLink alloc] initWithContentsOfFile: missing]);
+  PASS(link == nil, "initWithContentsOfFile: returns nil for a missing file");
+
+  link = AUTORELEASE([[NSDataLink alloc] initWithContentsOfFile: empty]);
+  PASS(link == nil, "initWithContentsOfFile: returns nil for an empty file");
+
+  link = AUTORELEASE([[NSDataLink alloc] initWithContentsOfFile: corrupt]);
+  PASS(link == nil, "initWithContentsOfFile: returns nil for a corrupt file");
+
+  NS_DURING
+    {
+      NSPasteboard *pb = [NSPasteboard pasteboardWithName: @"nsdl init test"];
+      [pb declareTypes: [NSArray arrayWithObject: NSStringPboardType]
+                 owner: nil];
+      link = AUTORELEASE([[NSDataLink alloc] initWithPasteboard: pb]);
+      PASS(link == nil,
+        "initWithPasteboard: returns nil when there is no link data");
+    }
+  NS_HANDLER
+    SKIP("pasteboard server is not available")
+  NS_ENDHANDLER
+
+  [fm removeFileAtPath: empty handler: nil];
+  [fm removeFileAtPath: corrupt handler: nil];
+
+  END_SET("NSDataLink init failure")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Part of finishing NSDataLink (#167): the two loaders crashed on bad input.

## Problem

`-[NSDataLink initWithContentsOfFile:]` and `-initWithPasteboard:` passed the
loaded data straight to `NSUnarchiver`.
`+[NSUnarchiver unarchiveObjectWithData:]` raises for nil data, so:

- `initWithContentsOfFile:` on a missing or unreadable file raised
  `NSInvalidArgumentException` instead of returning nil.
- `initWithPasteboard:` raised the same way when the pasteboard held no link.
- A malformed `.dlf` file raised while decoding.

In a running application the uncaught exception surfaces as a blocking error
panel.

## Fix

Unarchive only when there is data, and treat a decoding failure as "no link",
so a failed load returns nil.

## Testing

Added `Tests/gui/NSDataLink/initFailure.m`: missing, empty and corrupt files,
and a pasteboard with no link data, all return nil. Without the change the
test aborts on the exception; with it the four cases pass. The existing
`basic.m` still passes, and valid file/pasteboard round-trips are unaffected.

This is the first of a series to finish NSDataLink/NSDataLinkManager; the
larger items (wiring the inotify watches that are set up but never registered,
implementing `-updateDestination`, and portable filesystem monitoring) will
follow separately.
