### PR TITLE
Implement -[NSDataLink updateDestination]

### DIFF
--- a/Source/NSDataLink.m
+++ b/Source/NSDataLink.m
@@ -27,6 +27,7 @@
 */ 
 
 #include "config.h"
+#import <Foundation/NSDate.h>
 #import <Foundation/NSFileManager.h>
 #import <Foundation/NSArchiver.h>
 #import <Foundation/NSData.h>
@@ -297,7 +298,48 @@
 
 - (BOOL)updateDestination
 {
-  return NO;
+  id destinationDelegate = [_destinationManager delegate];
+  BOOL updated = NO;
+
+  // Only a link installed in a destination document can be updated.
+  if (_destinationManager == nil)
+    {
+      return NO;
+    }
+
+  // If the source document is available in the same process, copy its current
+  // data through a pasteboard and let the destination paste it.
+  if (_sourceManager != nil
+    && [[_sourceManager delegate] respondsToSelector:
+	  @selector(copyToPasteboard:at:cheapCopyAllowed:)]
+    && [destinationDelegate respondsToSelector:
+	  @selector(pasteFromPasteboard:at:)])
+    {
+      NSPasteboard *pb = [NSPasteboard pasteboardWithUniqueName];
+
+      if ([[_sourceManager delegate] copyToPasteboard: pb
+					           at: _sourceSelection
+				         cheapCopyAllowed: YES])
+	{
+	  updated = [destinationDelegate pasteFromPasteboard: pb
+						          at: _destinationSelection];
+	}
+    }
+  // Otherwise re-import the source file directly.
+  else if (_sourceFilename != nil
+    && [destinationDelegate respondsToSelector: @selector(importFile:at:)])
+    {
+      updated = [destinationDelegate importFile: _sourceFilename
+					     at: _destinationSelection];
+    }
+
+  if (updated)
+    {
+      ASSIGN(_lastUpdateTime, [NSDate date]);
+      _flags.isDirty = NO;
+    }
+
+  return updated;
 }
 
 - (NSDataLinkUpdateMode)updateMode

--- a/Tests/gui/NSDataLink/updateDestination.m
+++ b/Tests/gui/NSDataLink/updateDestination.m
@@ -1,0 +1,125 @@
+#import "Testing.h"
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+#import <AppKit/NSDataLink.h>
+#import <AppKit/NSDataLinkManager.h>
+#import <AppKit/NSSelection.h>
+
+/* A document standing in for the source and destination of a link.  It
+   records the data-transfer messages -[NSDataLink updateDestination] sends. */
+@interface DLDoc : NSObject
+{
+@public
+  BOOL importCalled;
+  BOOL pasteCalled;
+  BOOL copyCalled;
+  BOOL wantsUpdate;
+  NSString *importedFile;
+}
+@end
+
+@implementation DLDoc
+- (BOOL) importFile: (NSString *)filename at: (NSSelection *)selection
+{
+  importCalled = YES;
+  ASSIGN(importedFile, filename);
+  return YES;
+}
+- (BOOL) pasteFromPasteboard: (NSPasteboard *)pb at: (NSSelection *)selection
+{
+  pasteCalled = YES;
+  return YES;
+}
+- (BOOL) copyToPasteboard: (NSPasteboard *)pb
+                       at: (NSSelection *)selection
+         cheapCopyAllowed: (BOOL)flag
+{
+  copyCalled = YES;
+  [pb declareTypes: [NSArray arrayWithObject: NSStringPboardType] owner: nil];
+  [pb setString: @"payload" forType: NSStringPboardType];
+  return YES;
+}
+- (BOOL) dataLinkManager: (NSDataLinkManager *)m isUpdateNeededForLink: (NSDataLink *)l
+{
+  return wantsUpdate;
+}
+- (void) dealloc { RELEASE(importedFile); [super dealloc]; }
+@end
+
+static NSSelection *aSelection(void)
+{
+  return [NSSelection selectionWithDescriptionData:
+           [@"sel" dataUsingEncoding: NSUTF8StringEncoding]];
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSDataLink updateDestination")
+
+  // A link with no destination manager cannot update anything.
+  {
+    NSDataLink *link = AUTORELEASE([[NSDataLink alloc] init]);
+    PASS([link updateDestination] == NO,
+      "updateDestination returns NO with no destination manager");
+  }
+
+  // File source: the destination delegate re-imports the source file.
+  {
+    DLDoc *dst = AUTORELEASE([DLDoc new]);
+    NSDataLinkManager *dstMgr = AUTORELEASE([[NSDataLinkManager alloc]
+      initWithDelegate: dst]);
+    NSDataLink *link = AUTORELEASE([[NSDataLink alloc]
+      initLinkedToFile: @"/tmp/nsdl-source.txt"]);
+
+    [dstMgr addLink: link at: aSelection()];
+    BOOL ok = [link updateDestination];
+    PASS(ok == YES, "updateDestination returns YES for a file source");
+    PASS(dst->importCalled, "the destination delegate is asked to import the file");
+    PASS([dst->importedFile isEqual: @"/tmp/nsdl-source.txt"],
+      "the source filename is passed to importFile:at:");
+    PASS([link lastUpdateTime] != nil, "lastUpdateTime is set after a successful update");
+  }
+
+  // In-process source: source copied through a pasteboard, destination pastes.
+  {
+    DLDoc *src = AUTORELEASE([DLDoc new]);
+    DLDoc *dst = AUTORELEASE([DLDoc new]);
+    NSDataLinkManager *srcMgr = AUTORELEASE([[NSDataLinkManager alloc]
+      initWithDelegate: src]);
+    NSDataLinkManager *dstMgr = AUTORELEASE([[NSDataLinkManager alloc]
+      initWithDelegate: dst]);
+    NSDataLink *link = AUTORELEASE([[NSDataLink alloc]
+      initLinkedToSourceSelection: aSelection()
+                        managedBy: srcMgr
+                  supportingTypes: [NSArray arrayWithObject: NSStringPboardType]]);
+
+    [dstMgr addLink: link at: aSelection()];
+    BOOL ok = [link updateDestination];
+    PASS(ok == YES, "updateDestination returns YES for an in-process source");
+    PASS(src->copyCalled, "the source delegate is asked to copy to the pasteboard");
+    PASS(dst->pasteCalled, "the destination delegate is asked to paste from the pasteboard");
+  }
+
+  // checkForLinkUpdates drives updateDestination for destination links the
+  // delegate flags as needing an update.
+  {
+    DLDoc *dst = AUTORELEASE([DLDoc new]);
+    dst->wantsUpdate = YES;
+    NSDataLinkManager *dstMgr = AUTORELEASE([[NSDataLinkManager alloc]
+      initWithDelegate: dst]);
+    NSDataLink *link = AUTORELEASE([[NSDataLink alloc]
+      initLinkedToFile: @"/tmp/nsdl-source.txt"]);
+
+    [dstMgr addLink: link at: aSelection()];
+    [dstMgr checkForLinkUpdates];
+    PASS(dst->importCalled,
+      "checkForLinkUpdates updates a destination link the delegate flags");
+  }
+
+  END_SET("NSDataLink updateDestination")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Part of finishing NSDataLink (#167). Follows #690.

## What this does

`-[NSDataLink updateDestination]` was a stub returning NO, so
`-[NSDataLinkManager checkForLinkUpdates]` (and the source monitor) had nothing
to call. This implements it through the documented delegate protocol:

- If the source document is available in the same process, ask the source
  delegate to `copyToPasteboard:at:cheapCopyAllowed:` and let the destination
  delegate `pasteFromPasteboard:at:`.
- Otherwise re-import the source file through the destination delegate's
  `importFile:at:`.

On success the link's update time is recorded and the dirty flag cleared. A
link with no destination manager returns NO. With this in place
`checkForLinkUpdates` is functional: an application can drive link updates
manually or from its own change tracking.

## Testing

`Tests/gui/NSDataLink/updateDestination.m`: no destination manager returns NO;
a file-backed source re-imports through `importFile:at:` and sets the update
time; an in-process source is copied through a pasteboard and pasted; and
`checkForLinkUpdates` drives the update for a destination link the delegate
flags. Against the stub these fail; with this change they pass, and `basic.m`
still passes.

## Follow-up

I also prototyped wiring the inotify watches (currently set up in the manager
but never registered) into `-addLink:` so edits to a source file drive
`updateDestination` automatically. That works end to end, but it surfaced a
problem worth handling on its own: the monitor thread retains the
manager and runs indefinitely, while the delegate is (correctly) not retained,
so the monitor can message a deallocated delegate once the document goes away.
I have left the automatic monitoring out of this PR and will send it separately
with the thread lifecycle addressed (stop on document close, and make the
monitor safe against a delegate that has gone away). I would value your view on
the threading model there, @gcasa .
