### PR TITLE
Fix: NSOpenPanel does not choose directories by default

### DIFF
--- a/Source/NSOpenPanel.m
+++ b/Source/NSOpenPanel.m
@@ -91,7 +91,7 @@ static NSOpenPanel *_gs_gui_open_panel = nil;
   [super _resetDefaults];
   [self setTitle: _(@"Open")];
   [self setCanChooseFiles: YES];
-  [self setCanChooseDirectories: YES];
+  [self setCanChooseDirectories: NO];
   [self setAllowsMultipleSelection: NO];
   [_okButton setEnabled: NO];
 }
@@ -219,7 +219,7 @@ static NSOpenPanel *_gs_gui_open_panel = nil;
   self = [super init];
   if (self != nil)
     {
-      _canChooseDirectories = YES;
+      _canChooseDirectories = NO;
       _canChooseFiles = YES;
     }
   return self;

--- a/Tests/gui/NSOpenPanel/canChooseDirectories.m
+++ b/Tests/gui/NSOpenPanel/canChooseDirectories.m
@@ -1,0 +1,40 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSOpenPanel.h>
+
+/* An open panel lets the user choose files but not directories by default
+   (checked against AppKit); it defaulted to allowing directories.  Creating the
+   panel needs a backend, so this keeps the usual guard. */
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSOpenPanel canChooseDirectories default")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSOpenPanel *p = [NSOpenPanel openPanel];
+
+      PASS([p canChooseFiles] == YES, "canChooseFiles defaults to YES");
+      PASS([p canChooseDirectories] == NO,
+        "canChooseDirectories defaults to NO");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSOpenPanel canChooseDirectories default")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSOpenPanel/interact.m
+++ b/Tests/gui/NSOpenPanel/interact.m
@@ -30,12 +30,14 @@ main(int argc, const char **argv)
     {
       NSString *dir = dummyDir();
 
-      /* Confirming returns NSOKButton and a non-empty list of URLs.  (Which
-         file is chosen is driven by browser selection, exercised elsewhere.) */
+      /* Confirming returns NSOKButton and a non-empty list of URLs.  With no
+         browser selection the current directory is the result, so directories
+         are enabled here; browser-driven file choice is exercised elsewhere. */
       {
         NSOpenPanel *p = [NSOpenPanel openPanel];
         NSInteger r;
         [p setCanChooseFiles: YES];
+        [p setCanChooseDirectories: YES];
         [p setAllowsMultipleSelection: NO];
         [p setDirectory: dir];
         r = GSRunModalDismissing(p, @selector(ok:), 0.2);


### PR DESCRIPTION
An open panel let the user choose directories as well as files by default.
AppKit chooses files only: `canChooseDirectories` defaults to NO.  Verified
with a macOS probe (canChooseFiles YES, canChooseDirectories NO,
allowsMultipleSelection NO).

`-_resetDefaults` (run on every `+openPanel`) and `-init` now set
canChooseDirectories to NO.

Test `Tests/gui/NSOpenPanel/canChooseDirectories.m` asserts the default; it
fails against the old value and passes with this change, and skips without a
display.