### PR TITLE
Fix: NSSavePanel offers to create directories by default

### DIFF
--- a/Source/NSSavePanel.m
+++ b/Source/NSSavePanel.m
@@ -434,6 +434,7 @@ setPath(NSBrowser *browser, NSString *path)
   [self setAllowedFileTypes: nil];
   [self setAllowsOtherFileTypes: NO];
   [self setTreatsFilePackagesAsDirectories: NO];
+  [self setCanCreateDirectories: YES];
   [self setDelegate: nil];
   [self setAccessoryView: nil];
 }

--- a/Tests/gui/NSSavePanel/canCreateDirectories.m
+++ b/Tests/gui/NSSavePanel/canCreateDirectories.m
@@ -1,0 +1,39 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSSavePanel.h>
+
+/* A save panel offers to create directories by default (checked against
+   AppKit); it defaulted to not offering that.  Creating the panel needs a
+   backend, so this keeps the usual guard. */
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSavePanel canCreateDirectories default")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSSavePanel *p = [NSSavePanel savePanel];
+
+      PASS([p canCreateDirectories] == YES,
+        "canCreateDirectories defaults to YES");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSSavePanel canCreateDirectories default")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A save panel did not offer directory creation by default.  AppKit enables it:
`canCreateDirectories` defaults to YES (verified with a macOS probe).  Set it
in `-_resetDefaults`, which runs for every `+savePanel`.

Test `Tests/gui/NSSavePanel/canCreateDirectories.m` asserts the default; it
fails against the old value and passes with this change, and skips without a
display.