### PR TITLE
Feature: Implement -[NSOpenPanel resolvesAliases]

### DIFF
--- a/Headers/AppKit/NSOpenPanel.h
+++ b/Headers/AppKit/NSOpenPanel.h
@@ -48,6 +48,7 @@ APPKIT_EXPORT_CLASS
 {
   BOOL _canChooseDirectories;
   BOOL _canChooseFiles;
+  BOOL _resolvesAliases;
 }
 // Accessing the NSOpenPanel shared instance
 + (NSOpenPanel *) openPanel;

--- a/Source/NSOpenPanel.m
+++ b/Source/NSOpenPanel.m
@@ -93,6 +93,7 @@ static NSOpenPanel *_gs_gui_open_panel = nil;
   [self setCanChooseFiles: YES];
   [self setCanChooseDirectories: YES];
   [self setAllowsMultipleSelection: NO];
+  [self setResolvesAliases: YES];
   [_okButton setEnabled: NO];
 }
 
@@ -221,6 +222,7 @@ static NSOpenPanel *_gs_gui_open_panel = nil;
     {
       _canChooseDirectories = YES;
       _canChooseFiles = YES;
+      _resolvesAliases = YES;
     }
   return self;
 }
@@ -319,14 +321,11 @@ static NSOpenPanel *_gs_gui_open_panel = nil;
 */
 - (NSArray *) filenames
 {
+  NSMutableArray *ret = [NSMutableArray array];
+  NSString       *dir = [self directory];
+
   if ([_browser allowsMultipleSelection])
     {
-      NSArray         *cells = [_browser selectedCells];
-      NSEnumerator    *cellEnum = [cells objectEnumerator];
-      NSBrowserCell   *currCell;
-      NSMutableArray  *ret = [NSMutableArray array];
-      NSString        *dir = [self directory];
-      
       if ([_browser selectedColumn] != [_browser lastColumn])
 	{
 	  /*
@@ -340,24 +339,43 @@ static NSOpenPanel *_gs_gui_open_panel = nil;
 	}
       else
 	{
-	  while ((currCell = [cellEnum nextObject]))
+	  NSEnumerator  *cellEnum = [[_browser selectedCells] objectEnumerator];
+	  NSBrowserCell *currCell;
+
+	  while ((currCell = [cellEnum nextObject]) != nil)
 	    {
 	      [ret addObject:
                 [dir stringByAppendingPathComponent: [currCell stringValue]]];
 	    }
 	}
-      return ret;
     }
   else
     {
-      if (_canChooseDirectories == YES)
+      if (_canChooseDirectories == YES
+	&& [_browser selectedColumn] != [_browser lastColumn])
 	{
-	  if ([_browser selectedColumn] != [_browser lastColumn])
-	    return [NSArray arrayWithObject: [self directory]];
+	  [ret addObject: dir];
 	}
-
-      return [NSArray arrayWithObject: [super filename]];
+      else
+	{
+	  [ret addObject: [super filename]];
+	}
     }
+
+  /* Resolve symbolic links in the chosen paths unless asked not to. */
+  if (_resolvesAliases)
+    {
+      NSUInteger i, count = [ret count];
+
+      for (i = 0; i < count; i++)
+	{
+	  [ret replaceObjectAtIndex: i
+			 withObject: [[ret objectAtIndex: i]
+			   stringByResolvingSymlinksInPath]];
+	}
+    }
+
+  return ret;
 }
 
 /** Returns an array of the selected files as URLs */
@@ -548,13 +566,12 @@ static NSOpenPanel *_gs_gui_open_panel = nil;
 
 - (BOOL) resolvesAliases
 {
-  // FIXME
-  return YES;
+  return _resolvesAliases;
 }
 
 - (void) setResolvesAliases: (BOOL) flag
 {
-  // FIXME
+  _resolvesAliases = flag;
 }
 
 /*

--- a/Tests/gui/NSOpenPanel/resolvesAliases.m
+++ b/Tests/gui/NSOpenPanel/resolvesAliases.m
@@ -1,0 +1,43 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSOpenPanel.h>
+
+/* -resolvesAliases / -setResolvesAliases: were stubs: the setter did nothing
+   and the getter always returned YES.  The flag now defaults to YES (checked
+   against AppKit) and round-trips.  Needs a backend, so it keeps the guard. */
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSOpenPanel resolvesAliases")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSOpenPanel *p = [NSOpenPanel openPanel];
+
+      PASS([p resolvesAliases] == YES, "resolvesAliases defaults to YES");
+
+      [p setResolvesAliases: NO];
+      PASS([p resolvesAliases] == NO, "setResolvesAliases: NO round-trips");
+      [p setResolvesAliases: YES];
+      PASS([p resolvesAliases] == YES, "setResolvesAliases: YES round-trips");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSOpenPanel resolvesAliases")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-resolvesAliases` and `-setResolvesAliases:` were FIXME stubs: the setter
did nothing and the getter always returned YES.

This stores the flag in a new ivar, defaults it to YES (matching AppKit,
verified with a macOS probe), and honours it in `-filenames` by resolving
symbolic links in the chosen paths when it is set.

Test `Tests/gui/NSOpenPanel/resolvesAliases.m` covers the default and the
round-trip; it fails against the old stub and passes with this change, and
skips without a display.  Manually verified the behaviour: with resolving on, a
path through a symlinked directory comes back resolved; with it off, the
symlink is kept.