### PR TITLE
Implement -[NSSavePanel message]

### DIFF
--- a/Headers/AppKit/NSSavePanel.h
+++ b/Headers/AppKit/NSSavePanel.h
@@ -121,6 +121,9 @@ APPKIT_EXPORT_CLASS
 
   NSMenu *_showsHiddenFilesMenu;
   GSSavePanelCompletionHandler _completionHandler;
+
+  NSString *_message;
+  NSTextField *_messageField;
 }
 
 /*

--- a/Source/NSSavePanel.m
+++ b/Source/NSSavePanel.m
@@ -369,8 +369,20 @@ setPath(NSBrowser *browser, NSString *path)
   [_topView addSubview: _titleField];
   [_titleField release];
 
+  r = NSMakeRect (67, 258, 233, 14);
+  _messageField = [[NSTextField alloc] initWithFrame: r];
+  [_messageField setSelectable: NO];
+  [_messageField setEditable: NO];
+  [_messageField setDrawsBackground: NO];
+  [_messageField setBezeled: NO];
+  [_messageField setBordered: NO];
+  [_messageField setFont: [NSFont messageFontOfSize: 12]];
+  [_messageField setAutoresizingMask: NSViewWidthSizable|NSViewMinYMargin];
+  [_topView addSubview: _messageField];
+  [_messageField release];
+
   r = NSMakeRect (0, 252, 308, 2);
-  bar = [[NSBox alloc] initWithFrame: r]; 
+  bar = [[NSBox alloc] initWithFrame: r];
   [bar setBorderType: NSGrooveBorder];
   [bar setTitlePosition: NSNoTitle];
   [bar setAutoresizingMask: NSViewWidthSizable|NSViewMinYMargin];
@@ -431,6 +443,7 @@ setPath(NSBrowser *browser, NSString *path)
   [self _setDefaultDirectory];
   [self setPrompt: _(@"Name:")];
   [self setTitle: _(@"Save")];
+  [self setMessage: @""];
   [self setAllowedFileTypes: nil];
   [self setAllowsOtherFileTypes: NO];
   [self setTreatsFilePackagesAsDirectories: NO];
@@ -708,8 +721,9 @@ selectCellWithString: (NSString*)title
 {
   [[NSNotificationCenter defaultCenter] removeObserver: self];
   TEST_RELEASE (_fullFileName);
-  TEST_RELEASE (_directory);  
+  TEST_RELEASE (_directory);
   TEST_RELEASE (_allowedFileTypes);
+  TEST_RELEASE (_message);
 
   [super dealloc];
 }
@@ -927,13 +941,13 @@ selectCellWithString: (NSString*)title
 
 - (void) setMessage: (NSString *)message
 {
-  // FIXME
+  ASSIGNCOPY(_message, message);
+  [_messageField setStringValue: (message != nil) ? message : @""];
 }
 
 - (NSString *) message
 {
-  // FIXME
-  return nil;
+  return (_message != nil) ? _message : @"";
 }
 
 

--- a/Tests/gui/NSSavePanel/message.m
+++ b/Tests/gui/NSSavePanel/message.m
@@ -1,0 +1,46 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSString.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSSavePanel.h>
+
+/* -message / -setMessage: were stubs: the setter did nothing and the getter
+   returned nil.  The message now defaults to an empty string (checked against
+   AppKit) and round-trips.  Needs a backend, so it keeps the guard. */
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSavePanel message")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSSavePanel *p = [NSSavePanel savePanel];
+
+      PASS([[p message] isEqual: @""], "message defaults to an empty string");
+
+      [p setMessage: @"Choose a destination"];
+      PASS([[p message] isEqual: @"Choose a destination"],
+        "setMessage: round-trips");
+
+      [p setMessage: @""];
+      PASS([[p message] isEqual: @""], "setMessage: with an empty string clears it");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSSavePanel message")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`-message` and `-setMessage:` were FIXME stubs: the setter did nothing and the
getter returned nil.

This stores the message in a new ivar, defaults it to an empty string (matching
AppKit, verified with a macOS probe), and shows it in a field below the panel
title so a message set by the application is actually displayed.

Test `Tests/gui/NSSavePanel/message.m` covers the default and the round-trip;
it fails against the old stub and passes with this change, and skips without a
display.  The existing `setDelegate_reload.m` still passes (no layout
regression), and the message was verified to render in the panel.