### PR TITLE
ci: start the distributed notification server before running tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,6 +130,11 @@ jobs:
       - name: Run tests
         run: |
           . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
+          # Start the distributed notification server up front. Tests that post a
+          # distributed notification otherwise race its on-demand launch, which
+          # intermittently times out on a headless runner.
+          gdnc &
+          sleep 1
           make check
 
       - name: Upload logs
@@ -206,6 +211,11 @@ jobs:
       - name: Run tests
         run: |
           . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
+          # Start the distributed notification server up front. Tests that post a
+          # distributed notification otherwise race its on-demand launch, which
+          # intermittently times out on a headless runner.
+          gdnc &
+          sleep 1
           xvfb-run -a make check
 
       - name: Upload logs


### PR DESCRIPTION
Tests that post a distributed notification rely on the gdnc server. On a headless runner gdnc is launched on demand by the first such test, and that startup intermittently times out with "unable to contact GDNC server", aborting the set. NSHelpManager basic.m (context help mode) and NSMenuItem encoding.m (key equivalent mask) fail this way.

Start gdnc before running the tests in both the matrix job and the cairo/Xvfb job so the daemon is already up. With this change all four jobs run the full suite green.
