### PR TITLE
Fix: initialise NSSplitViewItem thickness and priority defaults

### DIFF
--- a/Source/NSSplitViewItem.m
+++ b/Source/NSSplitViewItem.m
@@ -24,7 +24,10 @@
 
 #import <Foundation/NSArchiver.h>
 #import "AppKit/NSSplitViewItem.h"
+#import "AppKit/NSLayoutConstraint.h"
 #import "AppKit/NSViewController.h"
+
+const CGFloat NSSplitViewItemUnspecifiedDimension = -1.0;
 
 @implementation NSSplitViewItem
 - (instancetype) initWithViewController: (NSViewController *)viewController
@@ -32,6 +35,12 @@
   self = [super init];
   if (self != nil)
     {
+      _automaticMaximumThickness = NSSplitViewItemUnspecifiedDimension;
+      _preferredThicknessFraction = NSSplitViewItemUnspecifiedDimension;
+      _minimumThickness = NSSplitViewItemUnspecifiedDimension;
+      _maximumThickness = NSSplitViewItemUnspecifiedDimension;
+      _holdingPriority = NSLayoutPriorityDefaultLow;
+      _allowsFullHeightLayout = YES;
       ASSIGN(_viewController, viewController);
     }
   return self;

--- a/Tests/gui/NSSplitViewItem/defaults.m
+++ b/Tests/gui/NSSplitViewItem/defaults.m
@@ -1,0 +1,38 @@
+/* Coverage for NSSplitViewItem thickness and priority defaults.  A newly
+   created item reports the unspecified dimension for its thickness values and
+   preferred thickness fraction, a default-low holding priority, and allows a
+   full height layout, as AppKit does (verified on a macOS runner). */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSLayoutConstraint.h>
+#include <AppKit/NSSplitViewItem.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSSplitViewItem *item;
+
+  PASS(NSSplitViewItemUnspecifiedDimension == -1.0,
+       "NSSplitViewItemUnspecifiedDimension is -1");
+
+  item = [NSSplitViewItem splitViewItemWithViewController: nil];
+
+  PASS([item automaticMaximumThickness] == NSSplitViewItemUnspecifiedDimension,
+       "default automaticMaximumThickness is the unspecified dimension");
+  PASS([item preferredThicknessFraction] == NSSplitViewItemUnspecifiedDimension,
+       "default preferredThicknessFraction is the unspecified dimension");
+  PASS([item minimumThickness] == NSSplitViewItemUnspecifiedDimension,
+       "default minimumThickness is the unspecified dimension");
+  PASS([item maximumThickness] == NSSplitViewItemUnspecifiedDimension,
+       "default maximumThickness is the unspecified dimension");
+  PASS([item holdingPriority] == NSLayoutPriorityDefaultLow,
+       "default holdingPriority is NSLayoutPriorityDefaultLow");
+  PASS([item allowsFullHeightLayout] == YES,
+       "default allowsFullHeightLayout is YES");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSSplitViewItemUnspecifiedDimension was declared in the header but never defined in any source file, so a client that referenced it failed to link. This defines it as -1.

A newly created NSSplitViewItem also left its thickness values, preferred thickness fraction, holding priority and full-height-layout flag at zero. AppKit reports the unspecified dimension for the four thickness/fraction values, NSLayoutPriorityDefaultLow (250) for the holding priority, and YES for allowsFullHeightLayout. initWithViewController: now sets those, so the defaults match.

Added Tests/gui/NSSplitViewItem/defaults.m covering the constant and the six defaults.