### PR TITLE
Fix: retain the view controller an NSSplitViewItem holds

### DIFF
--- a/Source/NSSplitViewItem.m
+++ b/Source/NSSplitViewItem.m
@@ -49,7 +49,13 @@
 
 + (instancetype) splitViewItemWithViewController: (NSViewController *)viewController
 {
-  return AUTORELEASE([[NSSplitViewItem alloc] initWithViewController: viewController]);  
+  return AUTORELEASE([[NSSplitViewItem alloc] initWithViewController: viewController]);
+}
+
+- (void) dealloc
+{
+  RELEASE(_viewController);
+  [super dealloc];
 }
 
 - (CGFloat) automaticMaximumThickness
@@ -149,7 +155,7 @@
 
 - (void) setViewController: (NSViewController *)vc
 {
-  _viewController = vc;
+  ASSIGN(_viewController, vc);
 }
 
 // NSCoding
@@ -160,7 +166,8 @@
     {
       if ([coder containsValueForKey: @"NSSplitViewItemViewController"])
         {
-          _viewController = [coder decodeObjectForKey: @"NSSplitViewItemViewController"];
+          ASSIGN(_viewController,
+            [coder decodeObjectForKey: @"NSSplitViewItemViewController"]);
         }
     }
   return self;

--- a/Tests/gui/NSSplitViewItem/memory.m
+++ b/Tests/gui/NSSplitViewItem/memory.m
@@ -1,0 +1,52 @@
+/* NSSplitViewItem owns the view controller it holds: setViewController: keeps
+   it alive and a deallocated item releases it. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSplitViewItem.h>
+#include <AppKit/NSViewController.h>
+
+static BOOL vcDeallocated;
+
+@interface ProbeViewController : NSViewController
+@end
+
+@implementation ProbeViewController
+- (void) dealloc
+{
+  vcDeallocated = YES;
+  [super dealloc];
+}
+@end
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSAutoreleasePool *pool;
+  NSSplitViewItem *item;
+  ProbeViewController *vc;
+
+  /* Keep the only reference to the item so that releasing it below runs its
+     deallocation. */
+  pool = [NSAutoreleasePool new];
+  item = RETAIN([NSSplitViewItem splitViewItemWithViewController: nil]);
+  RELEASE(pool);
+
+  vcDeallocated = NO;
+  vc = [[ProbeViewController alloc] init];
+  [item setViewController: vc];
+  RELEASE(vc);
+  PASS(vcDeallocated == NO,
+       "setViewController retains the view controller");
+  PASS([item viewController] == vc,
+       "the item still holds the view controller");
+
+  RELEASE(item);
+  PASS(vcDeallocated == YES,
+       "a deallocated item releases its view controller");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
initWithViewController: retained the view controller it was given, but setViewController: and the keyed decoder assigned it without retaining, and there was no dealloc to release it. So an item leaked the view controller it was created with, and after a later setViewController: it held a dangling pointer to a released controller.

setViewController: and initWithCoder: now retain, and a new dealloc releases, so the item consistently owns its view controller.

Added Tests/gui/NSSplitViewItem/memory.m, which uses a view controller subclass that records its deallocation to check the setter keeps it alive and dealloc releases it.