### PR TITLE
Fix: NSAnimation -setProgressMarks: leaves the mark array usable

### DIFF
--- a/Source/NSAnimation.m
+++ b/Source/NSAnimation.m
@@ -709,7 +709,7 @@ nsanimation_progressMarkSorter(NSAnimationProgress first, NSAnimationProgress se
   _NSANIMATION_LOCKING_SETUP;
 
   _NSANIMATION_LOCK;
-  GSIArrayEmpty(_progressMarks);
+  GSIArrayRemoveAllItems(_progressMarks);
   _nextMark = 0;
   if (marks != nil)
     {

--- a/Tests/gui/NSAnimation/setmarks.m
+++ b/Tests/gui/NSAnimation/setmarks.m
@@ -1,0 +1,50 @@
+/* NSAnimation -setProgressMarks: replaces the current marks with the ones in
+   the array, reported in sorted order, and clears them when passed nil. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSValue.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSAnimation.h>
+
+static NSAnimation *
+freshAnimation(void)
+{
+  return AUTORELEASE([[NSAnimation alloc]
+    initWithDuration: 1.0 animationCurve: NSAnimationLinear]);
+}
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSAnimation *a;
+  NSArray *marks;
+
+  a = freshAnimation();
+  [a addProgressMark: 0.1];
+  [a setProgressMarks: [NSArray arrayWithObjects:
+    [NSNumber numberWithFloat: 0.75],
+    [NSNumber numberWithFloat: 0.25], nil]];
+  marks = [a progressMarks];
+  PASS([marks count] == 2, "setProgressMarks: replaces the previous marks");
+  PASS([[marks objectAtIndex: 0] floatValue] == 0.25
+    && [[marks objectAtIndex: 1] floatValue] == 0.75,
+       "the new marks are reported in sorted order");
+
+  a = freshAnimation();
+  [a addProgressMark: 0.5];
+  [a setProgressMarks: nil];
+  PASS([[a progressMarks] count] == 0, "setProgressMarks: nil clears the marks");
+
+  a = freshAnimation();
+  [a setProgressMarks: [NSArray arrayWithObject:
+    [NSNumber numberWithFloat: 0.25]]];
+  [a addProgressMark: 0.75];
+  PASS([[a progressMarks] count] == 2,
+       "a mark can be added after the set is replaced");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
setProgressMarks: cleared the current marks with GSIArrayEmpty and then added the new ones. GSIArrayEmpty frees the array's backing store (it is the teardown call used in dealloc), so the following addProgressMark: added to a freed array and tripped an assertion. Using GSIArrayRemoveAllItems clears the contents while keeping the array usable.

Added Tests/gui/NSAnimation/setmarks.m covering replacing the marks, clearing them with nil, and adding a mark afterwards.