### PR TITLE
Fix: correct NSAnimation progress-mark ownership and replacement

### DIFF
--- a/Source/NSAnimation.m
+++ b/Source/NSAnimation.m
@@ -500,7 +500,7 @@ nsanimation_progressMarkSorter(NSAnimationProgress first, NSAnimationProgress se
       for (i = 0; i < count; i++)
         {
           _cachedProgressMarkNumbers[i] =
-           [NSNumber numberWithFloat: GSIArrayItemAtIndex (_progressMarks,i)];
+           RETAIN([NSNumber numberWithFloat: GSIArrayItemAtIndex (_progressMarks,i)]);
         }
       _cachedProgressMarkNumberCount = count;
       _isCachedProgressMarkNumbersValid = YES;
@@ -709,7 +709,7 @@ nsanimation_progressMarkSorter(NSAnimationProgress first, NSAnimationProgress se
   _NSANIMATION_LOCKING_SETUP;
 
   _NSANIMATION_LOCK;
-  GSIArrayEmpty(_progressMarks);
+  GSIArrayRemoveAllItems(_progressMarks);
   _nextMark = 0;
   if (marks != nil)
     {

--- a/Tests/gui/NSAnimation/progressmarks.m
+++ b/Tests/gui/NSAnimation/progressmarks.m
@@ -1,0 +1,60 @@
+/* NSAnimation progress marks.  Added marks are reported in sorted order and a
+   removed mark drops out; -progressMarks can be called repeatedly as the marks
+   change (it caches the numbers it returns, which the animation must own); and
+   setProgressMarks: replaces the set or clears it when passed nil. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSValue.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSAnimation.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSAnimation *a;
+  NSArray *marks;
+
+  a = AUTORELEASE([[NSAnimation alloc]
+    initWithDuration: 1.0 animationCurve: NSAnimationLinear]);
+
+  [a addProgressMark: 0.5];
+  [a addProgressMark: 0.25];
+  [a addProgressMark: 0.75];
+  marks = [a progressMarks];
+  PASS([marks count] == 3
+    && [[marks objectAtIndex: 0] floatValue] == 0.25
+    && [[marks objectAtIndex: 1] floatValue] == 0.5
+    && [[marks objectAtIndex: 2] floatValue] == 0.75,
+       "added marks are reported in sorted order");
+
+  [a removeProgressMark: 0.5];
+  marks = [a progressMarks];
+  PASS([marks count] == 2
+    && [[marks objectAtIndex: 0] floatValue] == 0.25
+    && [[marks objectAtIndex: 1] floatValue] == 0.75,
+       "a call after a removal reports the remaining marks");
+
+  [a addProgressMark: 0.875];
+  marks = [a progressMarks];
+  PASS([marks count] == 3
+    && [[marks objectAtIndex: 2] floatValue] == 0.875,
+       "a call after an addition reports the new set");
+
+  a = AUTORELEASE([[NSAnimation alloc]
+    initWithDuration: 1.0 animationCurve: NSAnimationLinear]);
+  [a addProgressMark: 0.1];
+  [a setProgressMarks: [NSArray arrayWithObjects:
+    [NSNumber numberWithFloat: 0.75],
+    [NSNumber numberWithFloat: 0.25], nil]];
+  marks = [a progressMarks];
+  PASS([marks count] == 2
+    && [[marks objectAtIndex: 0] floatValue] == 0.25
+    && [[marks objectAtIndex: 1] floatValue] == 0.75,
+       "setProgressMarks: replaces the previous marks, sorted");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Two problems in NSAnimation's progress-mark handling, submitted together because exercising either through -progressMarks needs both to be correct:

- -progressMarks caches the NSNumber objects it returns, releasing the previous cache when it is refreshed (after the marks change) and again in -dealloc. The numbers came from +numberWithFloat: and were stored without being retained, so a refresh or deallocation released numbers the animation did not own. They are now retained when cached.
- setProgressMarks: cleared the current marks with GSIArrayEmpty, which frees the array's backing store (it is the teardown call used in -dealloc), and then added the new marks to the freed array, tripping an assertion. It now uses GSIArrayRemoveAllItems, which clears the contents while keeping the array usable.

Added Tests/gui/NSAnimation/progressmarks.m covering sorted reporting of added marks, removal, repeated -progressMarks calls across changes, and setProgressMarks:.