### PR TITLE
Fix: forward-declare NSCollectionView in NSCollectionViewItem.h

### DIFF
--- a/Headers/AppKit/NSCollectionViewItem.h
+++ b/Headers/AppKit/NSCollectionViewItem.h
@@ -39,7 +39,7 @@
 extern "C" {
 #endif
 
-@class NSImageView, NSTextField;
+@class NSCollectionView, NSImageView, NSTextField;
 
 APPKIT_EXPORT_CLASS
 /**

--- a/Tests/gui/NSCollectionViewItem/headeronly.m
+++ b/Tests/gui/NSCollectionViewItem/headeronly.m
@@ -1,0 +1,33 @@
+/* NSCollectionViewItem.h is self-contained: including it on its own declares
+   the NSCollectionView type used by -collectionView, so this compiles without
+   including NSCollectionView.h. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSCollectionViewItem.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSCollectionViewItem *item;
+
+  START_SET("NSCollectionViewItem header")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  item = AUTORELEASE([[NSCollectionViewItem alloc] init]);
+  PASS([item collectionView] == nil,
+       "collectionView is nil for an item that is not in a collection");
+
+  END_SET("NSCollectionViewItem header")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The -collectionView method returns an NSCollectionView*, but NSCollectionViewItem.h declared only NSImageView and NSTextField, not NSCollectionView. Including the header on its own (without NSCollectionView.h) failed to compile with "expected a type". Adding NSCollectionView to the forward declaration makes the header self-contained.

Added Tests/gui/NSCollectionViewItem/headeronly.m, which includes only NSCollectionViewItem.h and uses -collectionView.