### PR TITLE
tests: add NSColorPicker tests

### DIFF
--- a/Tests/gui/NSColorPicker/backend.m
+++ b/Tests/gui/NSColorPicker/backend.m
@@ -1,0 +1,49 @@
+/* Coverage for NSColorPicker with the window server: -colorPanel reports the
+   shared color panel it was created with, and insertNewButtonImage:in: sets the
+   image on the button cell.  Matches AppKit (verified on a macOS runner) and
+   passes on unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSColorPicker.h>
+#include <AppKit/NSColorPanel.h>
+#include <AppKit/NSButtonCell.h>
+#include <AppKit/NSImage.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSColorPicker *picker;
+  NSColorPanel *panel;
+  NSButtonCell *cell;
+  NSImage *image;
+
+  START_SET("NSColorPicker backend")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  panel = [NSColorPanel sharedColorPanel];
+  picker = AUTORELEASE([[NSColorPicker alloc]
+    initWithPickerMask: 0 colorPanel: panel]);
+  PASS([picker colorPanel] == panel,
+       "colorPanel returns the panel passed to the initializer");
+
+  cell = AUTORELEASE([[NSButtonCell alloc] init]);
+  image = AUTORELEASE([[NSImage alloc] initWithSize: NSMakeSize(16, 16)]);
+  [picker insertNewButtonImage: image in: cell];
+  PASS([cell image] == image,
+       "insertNewButtonImage:in: sets the image on the button cell");
+
+  END_SET("NSColorPicker backend")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSColorPicker/config.m
+++ b/Tests/gui/NSColorPicker/config.m
@@ -1,0 +1,24 @@
+/* Coverage for NSColorPicker: the color panel passed to the initializer is
+   reported back by -colorPanel, and a nil panel stays nil.  This state needs no
+   window server.  Every assertion here matches AppKit (verified on a macOS
+   runner) and passes on unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSColorPicker.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSColorPicker *picker;
+
+  picker = AUTORELEASE([[NSColorPicker alloc]
+    initWithPickerMask: 0 colorPanel: nil]);
+
+  PASS(picker != nil, "a picker with a nil panel is created");
+  PASS([picker colorPanel] == nil, "a nil color panel stays nil");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds coverage for NSColorPicker: -colorPanel reports the panel passed to initWithPickerMask:colorPanel: (both a nil panel, which needs no window server, and the shared color panel), and insertNewButtonImage:in: sets the image on the button cell.

Verified locally: 4 passing tests.