### PR TITLE
Fix: hold the color panel weakly in NSColorPicker

### DIFF
--- a/Source/NSColorPicker.m
+++ b/Source/NSColorPicker.m
@@ -61,7 +61,9 @@
 - (id)initWithPickerMask:(int)aMask
 	      colorPanel:(NSColorPanel *)colorPanel
 {
-  ASSIGN(_colorPanel, colorPanel);
+  /* The panel retains its pickers, so the back reference is not retained to
+     avoid a retain cycle. */
+  _colorPanel = colorPanel;
   return self;
 }
 

--- a/Tests/gui/NSColorPicker/retain.m
+++ b/Tests/gui/NSColorPicker/retain.m
@@ -1,0 +1,42 @@
+/* An NSColorPicker does not retain the color panel it is created with: the
+   panel owns its pickers, so a retained back reference would be a retain cycle.
+   Releasing the panel while the picker is alive therefore deallocates it. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSObject.h>
+
+#include <AppKit/NSColorPicker.h>
+
+static BOOL panelDeallocated;
+
+@interface ColorPickerPanelStub : NSObject
+@end
+
+@implementation ColorPickerPanelStub
+- (void) dealloc
+{
+  panelDeallocated = YES;
+  [super dealloc];
+}
+@end
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSColorPicker *picker;
+  id panel;
+
+  panelDeallocated = NO;
+  panel = [[ColorPickerPanelStub alloc] init];
+  picker = [[NSColorPicker alloc] initWithPickerMask: 0
+                                          colorPanel: (NSColorPanel *)panel];
+  RELEASE(panel);
+  PASS(panelDeallocated == YES,
+       "the picker does not retain its color panel");
+
+  RELEASE(picker);
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
initWithPickerMask:colorPanel: stored the color panel with ASSIGN, retaining it. But NSColorPanel retains its pickers (it keeps them in its _pickers array and releases that array in its own -dealloc), so the retained back reference formed a panel/picker retain cycle and neither object was ever deallocated.

Store the panel without retaining it, matching the usual parent-owns-child / weak-back-reference pattern.

Added Tests/gui/NSColorPicker/retain.m, which creates a picker with a panel stub that records its deallocation and checks the picker does not keep it alive.