### PR TITLE
tests: add NSArrayController tests

### DIFF
--- a/Tests/gui/NSArrayController/config.m
+++ b/Tests/gui/NSArrayController/config.m
@@ -1,0 +1,55 @@
+/* Coverage for NSArrayController defaults and behavior-flag round-trips: a new
+   controller selects inserted objects, does not use the multiple-values marker,
+   does not automatically rearrange, and starts with no arranged objects, no
+   selection, no sort descriptors and no filter predicate.  Every assertion here
+   matches AppKit (verified on a macOS runner) and passes on unmodified
+   GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSIndexSet.h>
+
+#include <AppKit/NSArrayController.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSArrayController *ac;
+
+  ac = AUTORELEASE([[NSArrayController alloc] init]);
+
+  PASS([ac selectsInsertedObjects] == YES,
+       "default selectsInsertedObjects is YES");
+  PASS([ac alwaysUsesMultipleValuesMarker] == NO,
+       "default alwaysUsesMultipleValuesMarker is NO");
+  PASS([ac automaticallyRearrangesObjects] == NO,
+       "default automaticallyRearrangesObjects is NO");
+  PASS([[ac arrangedObjects] count] == 0,
+       "a new controller has no arranged objects");
+  PASS([[ac selectionIndexes] count] == 0,
+       "a new controller has an empty selection");
+  PASS([ac sortDescriptors] == nil || [[ac sortDescriptors] count] == 0,
+       "a new controller has no sort descriptors");
+  PASS([ac filterPredicate] == nil,
+       "a new controller has no filter predicate");
+
+  [ac setSelectsInsertedObjects: NO];
+  PASS([ac selectsInsertedObjects] == NO, "selectsInsertedObjects round-trips");
+  [ac setAvoidsEmptySelection: YES];
+  PASS([ac avoidsEmptySelection] == YES, "avoidsEmptySelection round-trips");
+  [ac setPreservesSelection: NO];
+  PASS([ac preservesSelection] == NO, "preservesSelection round-trips");
+  [ac setAlwaysUsesMultipleValuesMarker: YES];
+  PASS([ac alwaysUsesMultipleValuesMarker] == YES,
+       "alwaysUsesMultipleValuesMarker round-trips");
+  [ac setClearsFilterPredicateOnInsertion: YES];
+  PASS([ac clearsFilterPredicateOnInsertion] == YES,
+       "clearsFilterPredicateOnInsertion round-trips");
+  [ac setAutomaticallyRearrangesObjects: YES];
+  PASS([ac automaticallyRearrangesObjects] == YES,
+       "automaticallyRearrangesObjects round-trips");
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSArrayController/content.m
+++ b/Tests/gui/NSArrayController/content.m
@@ -1,0 +1,46 @@
+/* Coverage for NSArrayController content handling: added objects appear in the
+   arranged objects, sort descriptors order them, and setting a selection index
+   selects the object at that position.  Matches AppKit (verified on a macOS
+   runner) and passes on unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSSortDescriptor.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSArrayController.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSArrayController *ac;
+  NSSortDescriptor *sd;
+  NSArray *arranged;
+
+  ac = AUTORELEASE([[NSArrayController alloc] init]);
+  [ac addObject: @"charlie"];
+  [ac addObject: @"alpha"];
+  [ac addObject: @"bravo"];
+  PASS([[ac arrangedObjects] count] == 3, "three added objects are arranged");
+
+  sd = AUTORELEASE([[NSSortDescriptor alloc]
+    initWithKey: @"self" ascending: YES selector: @selector(compare:)]);
+  [ac setSortDescriptors: [NSArray arrayWithObject: sd]];
+  [ac rearrangeObjects];
+  arranged = [ac arrangedObjects];
+  PASS([[arranged objectAtIndex: 0] isEqual: @"alpha"],
+       "sort descriptors order the arranged objects (first)");
+  PASS([[arranged objectAtIndex: 2] isEqual: @"charlie"],
+       "sort descriptors order the arranged objects (last)");
+  PASS([[ac sortDescriptors] count] == 1, "sortDescriptors round-trips");
+
+  [ac setSelectionIndex: 1];
+  PASS([ac selectionIndex] == 1, "setSelectionIndex round-trips");
+  PASS([[ac selectedObjects] count] == 1, "one object is selected");
+  PASS([[[ac selectedObjects] objectAtIndex: 0] isEqual: @"bravo"],
+       "the selected object is the one at the selection index");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds coverage for NSArrayController:

- behavior-flag defaults that match AppKit (selectsInsertedObjects YES, alwaysUsesMultipleValuesMarker NO, automaticallyRearrangesObjects NO) and the empty arrangement, selection, sort descriptors and filter predicate of a new controller
- round-trips of the six behavior flags
- adding objects to the arrangement, ordering it with a sort descriptor, and selecting an object by index

The tests need no window server and run on all backends. Verified locally: 20 passing tests.