### PR TITLE
Fix: set NSArrayController initial defaults and selection index set

### DIFF
--- a/Source/NSArrayController.m
+++ b/Source/NSArrayController.m
@@ -157,7 +157,11 @@
 {
   if ((self = [super initWithContent: content]) != nil)
     {
+      _selection_indexes = [[NSIndexSet alloc] init];
       [self setSelectsInsertedObjects: YES];
+      [self setAvoidsEmptySelection: YES];
+      [self setPreservesSelection: YES];
+      [self setClearsFilterPredicateOnInsertion: YES];
     }
 
   return self;

--- a/Tests/gui/NSArrayController/defaults.m
+++ b/Tests/gui/NSArrayController/defaults.m
@@ -1,0 +1,34 @@
+/* NSArrayController initial-state defaults: a new controller avoids an empty
+   selection, preserves the selection and clears the filter predicate on
+   insertion, and an empty controller reports no selection index (NSNotFound)
+   and an empty selected-objects array rather than raising.  Matches AppKit
+   (verified on a macOS runner). */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+
+#include <AppKit/NSArrayController.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSArrayController *ac;
+
+  ac = AUTORELEASE([[NSArrayController alloc] init]);
+
+  PASS([ac avoidsEmptySelection] == YES,
+       "default avoidsEmptySelection is YES");
+  PASS([ac preservesSelection] == YES,
+       "default preservesSelection is YES");
+  PASS([ac clearsFilterPredicateOnInsertion] == YES,
+       "default clearsFilterPredicateOnInsertion is YES");
+
+  PASS([ac selectionIndex] == NSNotFound,
+       "an empty controller has no selection index");
+  PASS([[ac selectedObjects] count] == 0,
+       "an empty controller has an empty selected-objects array");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
initWithContent: set only selectsInsertedObjects, leaving avoidsEmptySelection, preservesSelection and clearsFilterPredicateOnInsertion at NO. AppKit defaults all three to YES.

It also never created _selection_indexes. With that ivar nil, -selectionIndex returned 0 (from -[nil firstIndex]) instead of NSNotFound, and -selectedObjects (which does objectsAtIndexes: on the arranged objects) raised an out-of-range exception on an empty controller instead of returning an empty array. AppKit reports NSNotFound and an empty array.

Set the three flags and initialise the selection to an empty index set.

Added Tests/gui/NSArrayController/defaults.m covering the three flag defaults, the empty-controller selection index and the empty selected-objects array.