### PR TITLE
Fix: default NSTreeController selection behavior flags to YES

### DIFF
--- a/Source/NSTreeController.m
+++ b/Source/NSTreeController.m
@@ -73,6 +73,10 @@
   _canInsertChild = YES;
   _canAddChild = YES;
 
+  _avoidsEmptySelection = YES;
+  _preservesSelection = YES;
+  _selectsInsertedObjects = YES;
+
   [self setObjectClass: [NSMutableDictionary class]];
 }
 

--- a/Tests/gui/NSTreeController/defaults.m
+++ b/Tests/gui/NSTreeController/defaults.m
@@ -1,0 +1,26 @@
+/* NSTreeController initial-state defaults: a new controller avoids an empty
+   selection, preserves the selection, and selects inserted objects, as AppKit
+   does. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSTreeController.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTreeController *tc;
+
+  tc = AUTORELEASE([[NSTreeController alloc] init]);
+
+  PASS([tc avoidsEmptySelection] == YES,
+       "default avoidsEmptySelection is YES");
+  PASS([tc preservesSelection] == YES,
+       "default preservesSelection is YES");
+  PASS([tc selectsInsertedObjects] == YES,
+       "default selectsInsertedObjects is YES");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
_initDefaults set canInsert, canInsertChild and canAddChild, but left avoidsEmptySelection, preservesSelection and selectsInsertedObjects at their zero-initialised NO. AppKit defaults all three to YES. Set them in _initDefaults.

Added Tests/gui/NSTreeController/defaults.m covering the three flag defaults.