### PR TITLE
Fix: give NSDictionaryController a working -init

### DIFF
--- a/Source/NSDictionaryController.m
+++ b/Source/NSDictionaryController.m
@@ -172,6 +172,15 @@
   return self;
 }
 
+- (instancetype) init
+{
+  NSMutableDictionary *content = [[NSMutableDictionary alloc] init];
+
+  self = [self initWithContent: content];
+  RELEASE(content);
+  return self;
+}
+
 - (void) dealloc
 {
   RELEASE(_contentDictionary);

--- a/Tests/gui/NSDictionaryController/plaininit.m
+++ b/Tests/gui/NSDictionaryController/plaininit.m
@@ -1,0 +1,23 @@
+/* [[NSDictionaryController alloc] init] creates a controller with a dictionary
+   content, so it does not raise, and reports the default initial key, as AppKit
+   does. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSDictionary.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSDictionaryController.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSDictionaryController *dc;
+
+  dc = AUTORELEASE([[NSDictionaryController alloc] init]);
+  PASS(dc != nil, "a dictionary controller can be created with -init");
+  PASS([[dc initialKey] isEqual: @"key"], "its initial key is the default");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSDictionaryController inherited -init from NSArrayController, which sets the content to an empty array. But NSDictionaryController treats its content as a dictionary: -setContent: runs it through -keysSortedByValueUsingSelector:. So [[NSDictionaryController alloc] init] raised "GSMutableArray does not recognize keysSortedByValueUsingSelector:".

Override -init to use an empty dictionary as the content, matching -[NSArrayController init] but with the right content type.

Added Tests/gui/NSDictionaryController/plaininit.m, which creates a controller with -init and checks it is non-nil and reports the default initial key.