### PR TITLE
Fix: forward-declare dictionary types in NSDictionaryController.h

### DIFF
--- a/Headers/AppKit/NSDictionaryController.h
+++ b/Headers/AppKit/NSDictionaryController.h
@@ -29,6 +29,8 @@
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
 
+@class NSDictionary, NSMutableDictionary;
+
 APPKIT_EXPORT_CLASS
 @interface NSDictionaryControllerKeyValuePair : NSObject
 {

--- a/Tests/gui/NSDictionaryController/headeronly.m
+++ b/Tests/gui/NSDictionaryController/headeronly.m
@@ -1,0 +1,19 @@
+/* NSDictionaryController.h is self-contained: including it on its own declares
+   the dictionary types its interface uses, so this compiles without including
+   NSDictionary.h. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSDictionaryController.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  PASS([NSDictionaryController class] != Nil,
+       "the NSDictionaryController class is available");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The NSDictionaryController interface uses NSMutableDictionary (the _contentDictionary instance variable) and NSDictionary (the localizedKeyDictionary type), but the header declared neither NSArrayController.h forward-declares NSArray/NSString but not the dictionary types. Including NSDictionaryController.h without NSDictionary.h failed to compile with "unknown type name NSMutableDictionary".

Add the forward declarations.

Added Tests/gui/NSDictionaryController/headeronly.m, which includes only NSDictionaryController.h.