### PR TITLE
tests: add NSTextStorage tests

### DIFF
--- a/Tests/gui/NSTextStorage/config.m
+++ b/Tests/gui/NSTextStorage/config.m
@@ -1,0 +1,42 @@
+/* Coverage for NSTextStorage state that needs no window server: the edited-mask
+   enum values, the initial string and length, the empty layout-manager list, a
+   nil delegate, the zero editing state, and the delegate round-trip.  Every
+   assertion here matches AppKit (verified on a macOS runner) and passes on
+   unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSObject.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSArray.h>
+
+#include <AppKit/NSTextStorage.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTextStorage *ts;
+  id delegate;
+
+  PASS(NSTextStorageEditedAttributes == 1,
+       "NSTextStorageEditedAttributes is 1");
+  PASS(NSTextStorageEditedCharacters == 2,
+       "NSTextStorageEditedCharacters is 2");
+
+  ts = AUTORELEASE([[NSTextStorage alloc] initWithString: @"hello"]);
+
+  PASS([ts length] == 5, "length is the length of the initial string");
+  PASS([[ts string] isEqual: @"hello"], "string is the initial string");
+  PASS([[ts layoutManagers] count] == 0,
+       "a new text storage has no layout managers");
+  PASS([ts delegate] == nil, "default delegate is nil");
+  PASS([ts editedMask] == 0, "default editedMask is 0");
+  PASS([ts changeInLength] == 0, "default changeInLength is 0");
+
+  delegate = AUTORELEASE([[NSObject alloc] init]);
+  [ts setDelegate: delegate];
+  PASS([ts delegate] == delegate, "delegate round-trips");
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTextStorage/editing.m
+++ b/Tests/gui/NSTextStorage/editing.m
@@ -1,0 +1,66 @@
+/* Coverage for NSTextStorage editing and layout managers.  An insertion inside
+   a beginEditing/endEditing group records the edited characters and the change
+   in length and is applied to the string; an added attribute is reported within
+   its range and absent outside it; and a layout manager can be added and
+   removed.  Processing the edit fixes attributes (which needs the font system),
+   so these are guarded by the usual backend check.  Matches AppKit (verified on
+   a macOS runner) and passes on unmodified GNUstep. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSRange.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTextStorage.h>
+#include <AppKit/NSLayoutManager.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTextStorage *ts;
+  NSLayoutManager *lm;
+
+  START_SET("NSTextStorage editing")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  ts = AUTORELEASE([[NSTextStorage alloc] initWithString: @"hello"]);
+
+  [ts beginEditing];
+  [ts replaceCharactersInRange: NSMakeRange(0, 0) withString: @"X"];
+  PASS(([ts editedMask] & NSTextStorageEditedCharacters) != 0,
+       "an insertion records edited characters");
+  PASS([ts changeInLength] == 1,
+       "an insertion records a change in length of one");
+  [ts endEditing];
+  PASS([[ts string] isEqual: @"Xhello"],
+       "the insertion is applied to the string");
+  PASS([ts length] == 6, "the length reflects the insertion");
+
+  [ts addAttribute: @"testAttr" value: @"testVal" range: NSMakeRange(0, 3)];
+  PASS([[ts attribute: @"testAttr" atIndex: 0 effectiveRange: NULL]
+         isEqual: @"testVal"],
+       "an added attribute is returned within its range");
+  PASS([ts attribute: @"testAttr" atIndex: 5 effectiveRange: NULL] == nil,
+       "the attribute is absent outside its range");
+
+  lm = AUTORELEASE([[NSLayoutManager alloc] init]);
+  [ts addLayoutManager: lm];
+  PASS([[ts layoutManagers] count] == 1, "a layout manager can be added");
+  PASS([[ts layoutManagers] containsObject: lm],
+       "the added layout manager is in the list");
+  [ts removeLayoutManager: lm];
+  PASS([[ts layoutManagers] count] == 0, "a layout manager can be removed");
+
+  END_SET("NSTextStorage editing")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds coverage for NSTextStorage:

- the NSTextStorageEdited* enum values, the initial string and length, the empty layout-manager list, the nil delegate, the zero editedMask/changeInLength, and the delegate round-trip (no window server needed)
- behind the usual backend guard (processing an edit fixes attributes, which uses the font system): an insertion inside a beginEditing/endEditing group records the edited characters and change in length and is applied to the string; an added attribute is reported within its range and absent outside it; and a layout manager can be added and removed

Verified locally: 18 passing tests.