### PR TITLE
Fix: correct NSTextView acceptsGlyphInfo and document-background defaults

### DIFF
--- a/Source/NSTextView.m
+++ b/Source/NSTextView.m
@@ -766,8 +766,8 @@ If a text view is added to an empty text network, it keeps its attributes.
   _tf.allows_undo = NO;
   _tf.smart_insert_delete = YES;
   _tf.uses_find_panel = NO;
-  _tf.accepts_glyph_info = NO;
-  _tf.allows_document_background_color_change = YES;
+  _tf.accepts_glyph_info = YES;
+  _tf.allows_document_background_color_change = NO;
 
   _dragTargetLocation = NSNotFound;
 

--- a/Tests/gui/NSTextView/defaults.m
+++ b/Tests/gui/NSTextView/defaults.m
@@ -1,0 +1,36 @@
+/* NSTextView default flags that match AppKit: a new text view accepts glyph
+   info and does not allow the document background colour to be changed. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTextView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTextView *tv;
+
+  START_SET("NSTextView defaults")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  tv = AUTORELEASE([[NSTextView alloc]
+    initWithFrame: NSMakeRect(0, 0, 300, 200)]);
+
+  PASS([tv acceptsGlyphInfo] == YES, "default acceptsGlyphInfo is YES");
+  PASS([tv allowsDocumentBackgroundColorChange] == NO,
+       "default allowsDocumentBackgroundColorChange is NO");
+
+  END_SET("NSTextView defaults")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A new NSTextView defaulted acceptsGlyphInfo to NO and allowsDocumentBackgroundColorChange to YES. AppKit defaults these the other way round: acceptsGlyphInfo YES and allowsDocumentBackgroundColorChange NO. Swap the two initial values in the text view initialisation.

Added Tests/gui/NSTextView/defaults.m covering both defaults.