### PR TITLE
Fix: encode instead of decode in NSSplitViewController -encodeWithCoder:

### DIFF
--- a/Source/NSSplitViewController.m
+++ b/Source/NSSplitViewController.m
@@ -190,12 +190,10 @@
   [super encodeWithCoder: coder];
   if ([coder allowsKeyedCoding])
     {
-      NSSplitView *sv = [coder decodeObjectForKey: @"NSSplitView"];
-      [self setSplitView: sv];
-      NSArray *items = [coder decodeObjectForKey: @"NSSplitViewItems"];
-      [_splitViewItems addObjectsFromArray: items];
-      _minimumThicknessForInlineSidebars =
-        [coder decodeFloatForKey: @"NSMinimumThicknessForInlineSidebars"];
+      [coder encodeObject: [self splitView] forKey: @"NSSplitView"];
+      [coder encodeObject: [self splitViewItems] forKey: @"NSSplitViewItems"];
+      [coder encodeFloat: _minimumThicknessForInlineSidebars
+                  forKey: @"NSMinimumThicknessForInlineSidebars"];
     }
   else
     {

--- a/Tests/gui/NSSplitViewController/coding.m
+++ b/Tests/gui/NSSplitViewController/coding.m
@@ -1,0 +1,50 @@
+/* NSSplitViewController archives correctly with a keyed archiver: encoding does
+   not corrupt the controller (the keyed encode branch used to decode into the
+   receiver), and the minimum inline-sidebar thickness survives a keyed archive
+   and unarchive round-trip. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSData.h>
+#include <Foundation/NSKeyedArchiver.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSplitViewController.h>
+#include <AppKit/NSSplitView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSSplitViewController *svc;
+  NSSplitViewController *decoded;
+  NSSplitView *before;
+  NSData *data;
+
+  START_SET("NSSplitViewController coding")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  svc = AUTORELEASE([[NSSplitViewController alloc] init]);
+  [svc setMinimumThicknessForInlineSidebars: 123.0];
+  before = [svc splitView];
+
+  data = [NSKeyedArchiver archivedDataWithRootObject: svc];
+  PASS([svc splitView] == before,
+       "archiving does not replace the controller's split view");
+
+  decoded = [NSKeyedUnarchiver unarchiveObjectWithData: data];
+  PASS([decoded isKindOfClass: [NSSplitViewController class]],
+       "the archive decodes to an NSSplitViewController");
+  PASS([decoded minimumThicknessForInlineSidebars] == 123.0,
+       "the minimum inline-sidebar thickness survives the round-trip");
+
+  END_SET("NSSplitViewController coding")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The keyed-coding branch of -encodeWithCoder: was a copy of -initWithCoder: and called decodeObjectForKey: / decodeFloatForKey: while encoding. So a keyed archive stored none of the split view, split view items or minimum inline sidebar thickness. Worse, -setSplitView: was called with the nil result of decoding, so archiving the controller replaced its split view.

Encode the split view, split view items and minimum thickness under the same keys -initWithCoder: reads.

Added Tests/gui/NSSplitViewController/coding.m checking that archiving does not replace the split view and that the minimum thickness survives a keyed archive round-trip.