### PR TITLE
Fix: archive the rest of NSSplitViewItem's state

### DIFF
--- a/Source/NSSplitViewItem.m
+++ b/Source/NSSplitViewItem.m
@@ -162,6 +162,19 @@
         {
           _viewController = [coder decodeObjectForKey: @"NSSplitViewItemViewController"];
         }
+      _automaticMaximumThickness =
+        [coder decodeDoubleForKey: @"NSAutomaticMaximumThickness"];
+      _preferredThicknessFraction =
+        [coder decodeDoubleForKey: @"NSPreferredThicknessFraction"];
+      _minimumThickness = [coder decodeDoubleForKey: @"NSMinimumThickness"];
+      _maximumThickness = [coder decodeDoubleForKey: @"NSMaximumThickness"];
+      _holdingPriority = [coder decodeDoubleForKey: @"NSHoldingPriority"];
+      _collapseBehavior = [coder decodeIntegerForKey: @"NSCollapseBehavior"];
+      _titlebarSeparatorStyle =
+        [coder decodeIntegerForKey: @"NSTitlebarSeparatorStyle"];
+      _springLoaded = [coder decodeBoolForKey: @"NSSpringLoaded"];
+      _allowsFullHeightLayout =
+        [coder decodeBoolForKey: @"NSAllowsFullHeightLayout"];
     }
   return self;
 }
@@ -172,6 +185,19 @@
     {
       [coder encodeObject: _viewController
                    forKey: @"NSSplitViewItemViewController"];
+      [coder encodeDouble: _automaticMaximumThickness
+                   forKey: @"NSAutomaticMaximumThickness"];
+      [coder encodeDouble: _preferredThicknessFraction
+                   forKey: @"NSPreferredThicknessFraction"];
+      [coder encodeDouble: _minimumThickness forKey: @"NSMinimumThickness"];
+      [coder encodeDouble: _maximumThickness forKey: @"NSMaximumThickness"];
+      [coder encodeDouble: _holdingPriority forKey: @"NSHoldingPriority"];
+      [coder encodeInteger: _collapseBehavior forKey: @"NSCollapseBehavior"];
+      [coder encodeInteger: _titlebarSeparatorStyle
+                    forKey: @"NSTitlebarSeparatorStyle"];
+      [coder encodeBool: _springLoaded forKey: @"NSSpringLoaded"];
+      [coder encodeBool: _allowsFullHeightLayout
+                 forKey: @"NSAllowsFullHeightLayout"];
     }
 }
 

--- a/Tests/gui/NSSplitViewItem/coding.m
+++ b/Tests/gui/NSSplitViewItem/coding.m
@@ -1,0 +1,50 @@
+/* NSSplitViewItem round-trips its thickness, priority, collapse behaviour and
+   flag state through a keyed archive, not just its view controller. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSData.h>
+#include <Foundation/NSKeyedArchiver.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSplitViewItem.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSSplitViewItem *item;
+  NSSplitViewItem *decoded;
+  NSData *data;
+
+  item = [NSSplitViewItem splitViewItemWithViewController: nil];
+  [item setMinimumThickness: 50.0];
+  [item setMaximumThickness: 300.0];
+  [item setPreferredThicknessFraction: 0.25];
+  [item setAutomaticMaximumThickness: 200.0];
+  [item setSpringLoaded: YES];
+  [item setAllowsFullHeightLayout: YES];
+  [item setTitlebarSeparatorStyle: NSTitlebarSeparatorStyleLine];
+
+  data = [NSKeyedArchiver archivedDataWithRootObject: item];
+  decoded = [NSKeyedUnarchiver unarchiveObjectWithData: data];
+
+  PASS([decoded isKindOfClass: [NSSplitViewItem class]],
+       "the archive decodes to an NSSplitViewItem");
+  PASS([decoded minimumThickness] == 50.0,
+       "minimumThickness survives the round-trip");
+  PASS([decoded maximumThickness] == 300.0,
+       "maximumThickness survives the round-trip");
+  PASS([decoded preferredThicknessFraction] == 0.25,
+       "preferredThicknessFraction survives the round-trip");
+  PASS([decoded automaticMaximumThickness] == 200.0,
+       "automaticMaximumThickness survives the round-trip");
+  PASS([decoded isSpringLoaded] == YES,
+       "springLoaded survives the round-trip");
+  PASS([decoded allowsFullHeightLayout] == YES,
+       "allowsFullHeightLayout survives the round-trip");
+  PASS([decoded titlebarSeparatorStyle] == NSTitlebarSeparatorStyleLine,
+       "titlebarSeparatorStyle survives the round-trip");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSSplitViewItem's -encodeWithCoder: / -initWithCoder: only coded the view controller, so the thickness values, preferred thickness fraction, holding priority, collapse behaviour, titlebar separator style and the spring-loaded and full-height-layout flags were all lost on a keyed archive round-trip. Encode and decode them under keyed keys.

Added Tests/gui/NSSplitViewItem/coding.m checking that the settable values survive a keyed archive round-trip.