### PR TITLE
Fix: match NSTitlebarSeparatorStyle values to AppKit

### DIFF
--- a/Headers/AppKit/NSSplitViewItem.h
+++ b/Headers/AppKit/NSSplitViewItem.h
@@ -54,8 +54,8 @@ typedef NSInteger NSSplitViewItemCollapseBehavior;
 enum
 {
  NSTitlebarSeparatorStyleAutomatic,
- NSTitlebarSeparatorStyleLine,
  NSTitlebarSeparatorStyleNone,
+ NSTitlebarSeparatorStyleLine,
  NSTitlebarSeparatorStyleShadow
 };
 typedef NSInteger NSTitlebarSeparatorStyle;

--- a/Tests/gui/NSSplitViewItem/enumvalues.m
+++ b/Tests/gui/NSSplitViewItem/enumvalues.m
@@ -1,0 +1,25 @@
+/* The NSTitlebarSeparatorStyle values match AppKit: Automatic, None, Line,
+   Shadow are 0, 1, 2, 3. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSplitViewItem.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  PASS(NSTitlebarSeparatorStyleAutomatic == 0,
+       "NSTitlebarSeparatorStyleAutomatic is 0");
+  PASS(NSTitlebarSeparatorStyleNone == 1,
+       "NSTitlebarSeparatorStyleNone is 1");
+  PASS(NSTitlebarSeparatorStyleLine == 2,
+       "NSTitlebarSeparatorStyleLine is 2");
+  PASS(NSTitlebarSeparatorStyleShadow == 3,
+       "NSTitlebarSeparatorStyleShadow is 3");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The NSTitlebarSeparatorStyle enumeration ordered the constants Automatic, Line, None, Shadow (0, 1, 2, 3), but AppKit orders them Automatic, None, Line, Shadow, so NSTitlebarSeparatorStyleLine and NSTitlebarSeparatorStyleNone had swapped values. Swap them to agree with AppKit. The class only stores and returns the value, so nothing else needs to change.

Added Tests/gui/NSSplitViewItem/enumvalues.m checking the four constants.