### PR TITLE
Fix: NSColorPanel shows the alpha control by default

### DIFF
--- a/Source/NSColorPanel.m
+++ b/Source/NSColorPanel.m
@@ -534,7 +534,7 @@ static int _gs_gui_color_picker_mode = NSWheelModeColorPanel;
   [self _loadPickers];
   [self _setupPickers];
   [self setMode: _gs_gui_color_picker_mode];
-  [self setShowsAlpha: ![NSColor ignoresAlpha]];
+  [self setShowsAlpha: YES];
 
   return self;
 }

--- a/Tests/gui/NSColorPanel/showsalpha.m
+++ b/Tests/gui/NSColorPanel/showsalpha.m
@@ -1,0 +1,29 @@
+/* A colour panel shows the alpha (opacity) control by default, as AppKit does. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSColorPanel.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSColorPanel showsAlpha")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  PASS([[NSColorPanel sharedColorPanel] showsAlpha] == YES,
+       "a colour panel shows the alpha control by default");
+
+  END_SET("NSColorPanel showsAlpha")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The shared colour panel set showsAlpha from ![NSColor ignoresAlpha]. +[NSColor ignoresAlpha] defaults to YES, so showsAlpha defaulted to NO and the opacity slider was hidden. AppKit shows the alpha control by default.

Set showsAlpha to YES at initialisation. This is the targeted fix that leaves the library-wide +[NSColor ignoresAlpha] setting (and everything that depends on it) unchanged.

Added Tests/gui/NSColorPanel/showsalpha.m checking the default.