### PR TITLE
tests: add NSFont tests

### DIFF
--- a/Tests/gui/NSFont/constants.m
+++ b/Tests/gui/NSFont/constants.m
@@ -1,0 +1,61 @@
+/* Coverage for the NSFont-related global constants: the standard font weight
+ * values, the identity font matrix and the NSControlGlyph marker.  These are
+ * plain compile-time / linked constants and need no font backend, so the test
+ * runs anywhere.  The expected values are those reported by AppKit.
+ */
+#include "Testing.h"
+#include <math.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/NSFont.h>
+
+#define EQ(a, b) (fabs((double)(a) - (double)(b)) < 0.0001)
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("font weight constants")
+    PASS(EQ(NSFontWeightUltraLight, -0.8), "NSFontWeightUltraLight is -0.8");
+    PASS(EQ(NSFontWeightThin, -0.6), "NSFontWeightThin is -0.6");
+    PASS(EQ(NSFontWeightLight, -0.4), "NSFontWeightLight is -0.4");
+    PASS(EQ(NSFontWeightRegular, 0.0), "NSFontWeightRegular is 0");
+    PASS(EQ(NSFontWeightMedium, 0.23), "NSFontWeightMedium is 0.23");
+    PASS(EQ(NSFontWeightSemibold, 0.3), "NSFontWeightSemibold is 0.3");
+    PASS(EQ(NSFontWeightBold, 0.4), "NSFontWeightBold is 0.4");
+    PASS(EQ(NSFontWeightHeavy, 0.56), "NSFontWeightHeavy is 0.56");
+    PASS(EQ(NSFontWeightBlack, 0.62), "NSFontWeightBlack is 0.62");
+
+    PASS(NSFontWeightUltraLight < NSFontWeightRegular
+      && NSFontWeightRegular < NSFontWeightBold
+      && NSFontWeightBold < NSFontWeightBlack,
+      "the weight constants are monotonically ordered");
+  END_SET("font weight constants")
+
+  START_SET("identity matrix")
+    PASS(EQ(NSFontIdentityMatrix[0], 1.0), "identity matrix a is 1");
+    PASS(EQ(NSFontIdentityMatrix[1], 0.0), "identity matrix b is 0");
+    PASS(EQ(NSFontIdentityMatrix[2], 0.0), "identity matrix c is 0");
+    PASS(EQ(NSFontIdentityMatrix[3], 1.0), "identity matrix d is 1");
+    PASS(EQ(NSFontIdentityMatrix[4], 0.0), "identity matrix tx is 0");
+    PASS(EQ(NSFontIdentityMatrix[5], 0.0), "identity matrix ty is 0");
+  END_SET("identity matrix")
+
+  START_SET("glyph markers")
+    PASS(NSControlGlyph == 0x00ffffff, "NSControlGlyph is 0x00ffffff");
+    PASS(NSNullGlyph == 0x0, "NSNullGlyph is 0");
+  END_SET("glyph markers")
+
+  START_SET("rendering mode values")
+    PASS(NSFontDefaultRenderingMode == 0, "NSFontDefaultRenderingMode is 0");
+    PASS(NSFontAntialiasedRenderingMode == 1,
+      "NSFontAntialiasedRenderingMode is 1");
+    PASS(NSFontIntegerAdvancementsRenderingMode == 2,
+      "NSFontIntegerAdvancementsRenderingMode is 2");
+    PASS(NSFontAntialiasedIntegerAdvancementsRenderingMode == 3,
+      "NSFontAntialiasedIntegerAdvancementsRenderingMode is 3");
+  END_SET("rendering mode values")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSFont/named.m
+++ b/Tests/gui/NSFont/named.m
@@ -1,0 +1,81 @@
+/* Coverage for creating a font by name and by matrix: the requested name,
+ * point size and text matrix must round-trip on the returned font.  Building a
+ * font resolves it against the font backend, so the whole test is guarded and
+ * skips cleanly where no backend is available.
+ *
+ * The resolved family name, display name, fixed-pitch flag and glyph metrics
+ * depend on which physical font the backend substitutes for the request, so
+ * they are environment-specific and are not asserted here.
+ */
+#include "Testing.h"
+#include <math.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSFont.h>
+#include <AppKit/NSFontDescriptor.h>
+
+#define EQ(a, b) (fabs((double)(a) - (double)(b)) < 0.001)
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSFont creation")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("It looks like the GNUstep backend is not available")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSFont *h = [NSFont fontWithName: @"Helvetica" size: 24.0];
+      const CGFloat *m;
+
+      PASS(h != nil, "fontWithName:size: returns a font");
+      PASS([[h fontName] isEqualToString: @"Helvetica"],
+        "the font keeps the requested name");
+      PASS(EQ([h pointSize], 24.0), "the font has the requested point size");
+
+      m = [h matrix];
+      PASS(EQ(m[0], 24.0) && EQ(m[3], 24.0),
+        "the matrix diagonal is the point size");
+      PASS(EQ(m[1], 0.0) && EQ(m[2], 0.0) && EQ(m[4], 0.0) && EQ(m[5], 0.0),
+        "the matrix off-diagonal and translation are zero");
+
+      PASS(EQ([[h fontDescriptor] pointSize], 24.0),
+        "the font descriptor reports the point size");
+    }
+
+    {
+      const CGFloat wanted[6] = {30, 0, 0, 30, 0, 0};
+      NSFont *hm = [NSFont fontWithName: @"Helvetica" matrix: wanted];
+      const CGFloat *m;
+
+      PASS(hm != nil, "fontWithName:matrix: returns a font");
+      PASS(EQ([hm pointSize], 30.0),
+        "the point size comes from the matrix diagonal");
+      m = [hm matrix];
+      PASS(EQ(m[0], 30.0) && EQ(m[3], 30.0),
+        "the requested matrix round-trips");
+    }
+
+    {
+      NSFont *hb = [NSFont fontWithName: @"Helvetica-Bold" size: 12.0];
+
+      PASS(hb != nil, "a styled font name resolves");
+      PASS([[hb fontName] isEqualToString: @"Helvetica-Bold"],
+        "the styled name round-trips");
+      PASS(EQ([hb pointSize], 12.0), "the styled font has the requested size");
+    }
+  NS_HANDLER
+    SKIP("No font backend available to build fonts")
+  NS_ENDHANDLER
+
+  END_SET("NSFont creation")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSFont/sizes.m
+++ b/Tests/gui/NSFont/sizes.m
@@ -1,0 +1,47 @@
+/* Coverage for the standard system font sizes.  The absolute point sizes are a
+ * platform metric (and are read from user defaults), so only the structural
+ * relationships that hold across platforms are asserted here: the regular and
+ * small control sizes track the system and small-system sizes, the control
+ * sizes are ordered mini < small < regular, and every size is positive.  These
+ * need no font backend.
+ */
+#include "Testing.h"
+#include <math.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/NSFont.h>
+#include <AppKit/NSCell.h>
+
+#define EQ(a, b) (fabs((double)(a) - (double)(b)) < 0.001)
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  CGFloat system = [NSFont systemFontSize];
+  CGFloat small = [NSFont smallSystemFontSize];
+  CGFloat label = [NSFont labelFontSize];
+  CGFloat mini = [NSFont systemFontSizeForControlSize: NSMiniControlSize];
+  CGFloat cSmall = [NSFont systemFontSizeForControlSize: NSSmallControlSize];
+  CGFloat cRegular = [NSFont systemFontSizeForControlSize: NSRegularControlSize];
+
+  START_SET("system font sizes")
+    PASS(system > 0, "the system font size is positive");
+    PASS(small > 0, "the small system font size is positive");
+    PASS(label > 0, "the label font size is positive");
+    PASS(small < system, "the small system font size is below the system size");
+  END_SET("system font sizes")
+
+  START_SET("control sizes")
+    PASS(EQ(cRegular, system),
+      "the regular control size is the system font size");
+    PASS(EQ(cSmall, small),
+      "the small control size is the small system font size");
+    PASS(mini > 0, "the mini control size is positive");
+    PASS(mini < cSmall && cSmall < cRegular,
+      "the control sizes are ordered mini < small < regular");
+  END_SET("control sizes")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSFont/systemfonts.m
+++ b/Tests/gui/NSFont/systemfonts.m
@@ -1,0 +1,64 @@
+/* Coverage for the standard "role" fonts (system, bold system, user, user
+ * fixed-pitch and label).  The physical font behind each role is platform and
+ * configuration specific, so only the size behaviour is asserted: an explicit
+ * size is honoured, and a zero size resolves to the matching default size.
+ * Building the fonts needs the backend, so the test is guarded and skips
+ * cleanly when none is present.
+ */
+#include "Testing.h"
+#include <math.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSFont.h>
+
+#define EQ(a, b) (fabs((double)(a) - (double)(b)) < 0.001)
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("standard role fonts")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("It looks like the GNUstep backend is not available")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSFont *sys = [NSFont systemFontOfSize: 18.0];
+      NSFont *bold = [NSFont boldSystemFontOfSize: 18.0];
+      NSFont *user = [NSFont userFontOfSize: 14.0];
+      NSFont *fixed = [NSFont userFixedPitchFontOfSize: 14.0];
+      NSFont *label = [NSFont labelFontOfSize: 16.0];
+
+      PASS(sys != nil && EQ([sys pointSize], 18.0),
+        "systemFontOfSize: honours the requested size");
+      PASS(bold != nil && EQ([bold pointSize], 18.0),
+        "boldSystemFontOfSize: honours the requested size");
+      PASS(user != nil && EQ([user pointSize], 14.0),
+        "userFontOfSize: honours the requested size");
+      PASS(fixed != nil && EQ([fixed pointSize], 14.0),
+        "userFixedPitchFontOfSize: honours the requested size");
+      PASS(label != nil && EQ([label pointSize], 16.0),
+        "labelFontOfSize: honours the requested size");
+    }
+
+    {
+      NSFont *sys0 = [NSFont systemFontOfSize: 0.0];
+
+      PASS(sys0 != nil
+        && EQ([sys0 pointSize], [NSFont systemFontSize]),
+        "a zero size resolves to the system font size");
+    }
+  NS_HANDLER
+    SKIP("No font backend available to build fonts")
+  NS_ENDHANDLER
+
+  END_SET("standard role fonts")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for NSFont covering the parts of the class whose values are stable
across platforms:

- constants.m: the standard font weight constants, the identity font matrix and
  the glyph markers. These are plain constants and need no backend.
- sizes.m: the structural relationships between the system font sizes (the
  regular and small control sizes track the system and small-system sizes; the
  control sizes are ordered mini < small < regular). The absolute point sizes
  are a platform metric read from user defaults and are not pinned.
- named.m: creating a font by name and by matrix. The requested name, point size
  and text matrix round-trip on the returned font. The resolved family name,
  display name, fixed-pitch flag and glyph metrics depend on which physical font
  the backend substitutes, so they are not asserted.
- systemfonts.m: the standard role fonts honour an explicit size, and a zero
  size resolves to the matching default size.

The font-building tests are guarded and skip where no backend is available; the
constant and size tests run everywhere.
