### PR TITLE
tests: add NSFontManager tests

### DIFF
--- a/Tests/gui/NSFontManager/config.m
+++ b/Tests/gui/NSFontManager/config.m
@@ -1,0 +1,56 @@
+/* Coverage for the shared NSFontManager: the singleton, its default state and
+ * the selected-font round-trip.  Building the shared manager creates the font
+ * enumerator, so the test is guarded and skips cleanly when no backend is
+ * available.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSFont.h>
+#include <AppKit/NSFontManager.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("shared font manager")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("It looks like the GNUstep backend is not available")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSFontManager *fm = [NSFontManager sharedFontManager];
+
+      PASS(fm != nil, "sharedFontManager returns a manager");
+      PASS(fm == [NSFontManager sharedFontManager],
+        "sharedFontManager is a singleton");
+      PASS([fm isMultiple] == NO, "the manager is not multiple by default");
+      PASS(sel_isEqual([fm action], @selector(changeFont:)),
+        "the default action is changeFont:");
+      PASS([fm selectedFont] == nil, "there is no selected font by default");
+      PASS([fm delegate] == nil, "there is no delegate by default");
+
+      {
+        NSFont *f = [NSFont fontWithName: @"Helvetica" size: 18.0];
+
+        [fm setSelectedFont: f isMultiple: YES];
+        PASS([fm selectedFont] == f, "the selected font round-trips");
+        PASS([fm isMultiple] == YES, "the multiple flag is set");
+        [fm setSelectedFont: f isMultiple: NO];
+        PASS([fm isMultiple] == NO, "the multiple flag clears");
+      }
+    }
+  NS_HANDLER
+    SKIP("No font backend available for the font manager")
+  NS_ENDHANDLER
+
+  END_SET("shared font manager")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSFontManager/constants.m
+++ b/Tests/gui/NSFontManager/constants.m
@@ -1,0 +1,42 @@
+/* Coverage for the NSFontManager trait mask and font action constants.  These
+ * are plain enumeration values and need no font backend, so the test runs
+ * anywhere.  The expected values are those used by AppKit.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSFontManager.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("trait mask values")
+    PASS(NSItalicFontMask == 1, "NSItalicFontMask is 1");
+    PASS(NSBoldFontMask == 2, "NSBoldFontMask is 2");
+    PASS(NSUnboldFontMask == 4, "NSUnboldFontMask is 4");
+    PASS(NSNonStandardCharacterSetFontMask == 8,
+      "NSNonStandardCharacterSetFontMask is 8");
+    PASS(NSNarrowFontMask == 16, "NSNarrowFontMask is 16");
+    PASS(NSExpandedFontMask == 32, "NSExpandedFontMask is 32");
+    PASS(NSCondensedFontMask == 64, "NSCondensedFontMask is 64");
+    PASS(NSSmallCapsFontMask == 128, "NSSmallCapsFontMask is 128");
+    PASS(NSPosterFontMask == 256, "NSPosterFontMask is 256");
+    PASS(NSCompressedFontMask == 512, "NSCompressedFontMask is 512");
+    PASS(NSFixedPitchFontMask == 1024, "NSFixedPitchFontMask is 1024");
+    PASS(NSUnitalicFontMask == (1 << 24), "NSUnitalicFontMask is 1 << 24");
+  END_SET("trait mask values")
+
+  /* Only the first three font action values match AppKit; the ordering of the
+   * remaining values differs between the two, so they are compared by symbol
+   * elsewhere rather than pinned to a number here.
+   */
+  START_SET("font action values")
+    PASS(NSNoFontChangeAction == 0, "NSNoFontChangeAction is 0");
+    PASS(NSViaPanelFontAction == 1, "NSViaPanelFontAction is 1");
+    PASS(NSAddTraitFontAction == 2, "NSAddTraitFontAction is 2");
+  END_SET("font action values")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSFontManager/convert.m
+++ b/Tests/gui/NSFontManager/convert.m
@@ -1,0 +1,54 @@
+/* Coverage for -convertFont:toSize:: the returned font has the requested size
+ * and keeps the original name, and converting to the same size returns the
+ * original font.  Building fonts needs the backend, so the test is guarded and
+ * skips cleanly when none is present.
+ *
+ * The trait, weight, family and face conversions resolve against the physical
+ * fonts the backend provides, so their results are environment-specific and are
+ * not asserted here.
+ */
+#include "Testing.h"
+#include <math.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSFont.h>
+#include <AppKit/NSFontManager.h>
+
+#define EQ(a, b) (fabs((double)(a) - (double)(b)) < 0.001)
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("convertFont:toSize:")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("It looks like the GNUstep backend is not available")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSFontManager *fm = [NSFontManager sharedFontManager];
+      NSFont *h24 = [NSFont fontWithName: @"Helvetica" size: 24.0];
+      NSFont *h12 = [fm convertFont: h24 toSize: 12.0];
+      NSFont *same = [fm convertFont: h24 toSize: 24.0];
+
+      PASS(h12 != nil && EQ([h12 pointSize], 12.0),
+        "the converted font has the requested size");
+      PASS([[h12 fontName] isEqualToString: [h24 fontName]],
+        "the converted font keeps the original name");
+      PASS(same == h24,
+        "converting to the current size returns the original font");
+    }
+  NS_HANDLER
+    SKIP("No font backend available to convert fonts")
+  NS_ENDHANDLER
+
+  END_SET("convertFont:toSize:")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds tests for NSFontManager covering the parts of the class whose values are
stable across platforms:

- constants.m: the trait mask values and the three font action values that are
  common across platforms. These are plain constants and need no backend.
- config.m: the shared manager is a singleton, its default state (not multiple,
  changeFont: action, no selected font, no delegate) and the selected-font
  round-trip. Building the shared manager creates the font enumerator, so the
  test is guarded and skips where no backend is available.
- convert.m: -convertFont:toSize: gives the requested size and keeps the
  original name, and converting to the current size returns the original font.

The trait, weight, family and face conversions resolve against the physical
fonts the backend provides, so their results are environment-specific and are
not asserted.
