### PR TITLE
Fix: NSFontManager is enabled by default

### DIFF
--- a/Headers/AppKit/NSFontManager.h
+++ b/Headers/AppKit/NSFontManager.h
@@ -95,6 +95,7 @@ APPKIT_EXPORT_CLASS
   id _fontEnumerator;
   NSDictionary *_selectedAttributes;
   NSMutableDictionary *_collections;
+  BOOL _enabled;
 }
 
 //

--- a/Source/NSFontManager.m
+++ b/Source/NSFontManager.m
@@ -120,6 +120,7 @@ static Class         fontPanelClass = Nil;
 
   _action = @selector(changeFont:);
   _storedTag = NSNoFontChangeAction;
+  _enabled = YES;
   _fontEnumerator = RETAIN([GSFontEnumerator sharedEnumerator]);
   _collections = [[NSMutableDictionary alloc] initWithCapacity: 3];
 
@@ -870,12 +871,7 @@ static Class         fontPanelClass = Nil;
  */
 - (BOOL) isEnabled
 {
-  if (fontPanel != nil)
-    {
-      return [fontPanel isEnabled];
-    }
-  else
-    return NO;
+  return _enabled;
 }
 
 /**<p>Enables/disables the NSFontPanel and the font menu ( if they exist )</p>
@@ -884,6 +880,8 @@ static Class         fontPanelClass = Nil;
 - (void) setEnabled: (BOOL)flag
 {
   int i;
+
+  _enabled = flag;
 
   if (_fontMenu != nil)
     {

--- a/Tests/gui/NSFontManager/enabled.m
+++ b/Tests/gui/NSFontManager/enabled.m
@@ -1,0 +1,42 @@
+/* Regression test: the shared font manager is enabled by default and the
+ * enabled state round-trips through -setEnabled: without requiring a font panel
+ * to have been created.  Building the shared manager needs the backend, so the
+ * test is guarded and skips cleanly when none is present.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSFontManager.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("font manager enabled state")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("It looks like the GNUstep backend is not available")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSFontManager *fm = [NSFontManager sharedFontManager];
+
+      PASS([fm isEnabled] == YES, "the font manager is enabled by default");
+      [fm setEnabled: NO];
+      PASS([fm isEnabled] == NO, "setEnabled: NO disables the manager");
+      [fm setEnabled: YES];
+      PASS([fm isEnabled] == YES, "setEnabled: YES re-enables the manager");
+    }
+  NS_HANDLER
+    SKIP("No font backend available for the font manager")
+  NS_ENDHANDLER
+
+  END_SET("font manager enabled state")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The shared font manager reported -isEnabled as NO until a font panel had been
created, because -isEnabled read the enabled state back from the font panel and
returned NO when there was none. A newly obtained font manager is enabled, and
-setEnabled: did not record the state, so it did not round-trip before a panel
existed.

This stores the enabled state in the manager (default YES), returns it from
-isEnabled, and keeps -setEnabled: propagating to the font menu and panel when
they exist. enabled.m covers the default and the round-trip.
