### PR TITLE
Fix: NSMutableFontCollection can be mutated after creation

### DIFF
--- a/Source/NSFontCollection.m
+++ b/Source/NSFontCollection.m
@@ -288,7 +288,10 @@ static NSLock *_fontCollectionLock = nil;
 
 - (void) _setFontCollectionDictionary: (NSMutableDictionary *)dict
 {
-  ASSIGNCOPY(_fontCollectionDictionary, dict);
+  NSMutableDictionary *d = [dict mutableCopy];
+
+  RELEASE(_fontCollectionDictionary);
+  _fontCollectionDictionary = d;
 }
 
 - (void) _setQueryDescriptors: (NSArray *)queryDescriptors
@@ -581,7 +584,11 @@ static NSLock *_fontCollectionLock = nil;
 
 - (void) setQueryDescriptors: (NSArray *)queryDescriptors
 {
-  [super _setQueryDescriptors: [queryDescriptors mutableCopy]];
+  NSMutableArray *copy = queryDescriptors ? [queryDescriptors mutableCopy]
+                                          : [[NSMutableArray alloc] init];
+
+  [super _setQueryDescriptors: copy];
+  RELEASE(copy);
 }
 
 - (NSArray *) exclusionDescriptors
@@ -591,8 +598,12 @@ static NSLock *_fontCollectionLock = nil;
 
 - (void) setExclusionDescriptors: (NSArray *)exclusionDescriptors
 {
-  [_fontCollectionDictionary setObject: [exclusionDescriptors mutableCopy]
+  NSMutableArray *copy = exclusionDescriptors ? [exclusionDescriptors mutableCopy]
+                                              : [[NSMutableArray alloc] init];
+
+  [_fontCollectionDictionary setObject: copy
                                 forKey: @"NSFontExclusionDescriptorAttributes"];
+  RELEASE(copy);
 
 }
 

--- a/Tests/gui/NSFontCollection/mutable.m
+++ b/Tests/gui/NSFontCollection/mutable.m
@@ -1,0 +1,50 @@
+/* Regression test: the mutating methods of NSMutableFontCollection work on a
+ * collection obtained through +fontCollectionWithDescriptors: (which builds the
+ * mutable collection by copying an immutable one).  The mutating calls are
+ * evaluated inside PASS so that, should they raise, the failure is reported
+ * rather than aborting the process.  This needs no font backend.
+ */
+#include "Testing.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/NSFontDescriptor.h>
+#include <AppKit/NSFontCollection.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  NSFontDescriptor *fd = [NSFontDescriptor fontDescriptorWithFontAttributes:
+    [NSDictionary dictionaryWithObject: @"Helvetica" forKey: NSFontFamilyAttribute]];
+  NSFontDescriptor *fd2 = [NSFontDescriptor fontDescriptorWithFontAttributes:
+    [NSDictionary dictionaryWithObject: @"Courier" forKey: NSFontFamilyAttribute]];
+
+  START_SET("set query and exclusion descriptors")
+    NSMutableFontCollection *mc = [NSMutableFontCollection
+      fontCollectionWithDescriptors: [NSArray arrayWithObject: fd]];
+
+    PASS(([mc setQueryDescriptors: [NSArray arrayWithObjects: fd, fd2, nil]],
+          [[mc queryDescriptors] count] == 2),
+      "setQueryDescriptors: replaces the query descriptors");
+    PASS(([mc setExclusionDescriptors: [NSArray arrayWithObject: fd2]],
+          [[mc exclusionDescriptors] count] == 1
+          && [[mc exclusionDescriptors] containsObject: fd2]),
+      "setExclusionDescriptors: stores the exclusion descriptors");
+  END_SET("set query and exclusion descriptors")
+
+  START_SET("add and remove query descriptors")
+    NSMutableFontCollection *mc = [NSMutableFontCollection
+      fontCollectionWithDescriptors: [NSArray array]];
+
+    PASS(([mc addQueryForDescriptors: [NSArray arrayWithObject: fd]],
+          [[mc queryDescriptors] count] == 1
+          && [[mc queryDescriptors] containsObject: fd]),
+      "addQueryForDescriptors: adds to the query");
+    PASS(([mc removeQueryForDescriptors: [NSArray arrayWithObject: fd]],
+          [[mc queryDescriptors] count] == 0),
+      "removeQueryForDescriptors: removes from the query");
+  END_SET("add and remove query descriptors")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The mutating methods of NSMutableFontCollection raised and left the collection
unchanged. A mutable collection is built by taking a mutable copy of an
immutable one, but -_setFontCollectionDictionary: stored an immutable copy of
the dictionary, so every later -setObject:forKey: on it raised. In addition
-setQueryDescriptors: and -setExclusionDescriptors: passed the result of
-mutableCopy straight to the dictionary: that raised when given nil (as
-addQueryForDescriptors: does when there are no exclusions yet) and leaked the
copy.

This keeps the collection dictionary mutable, treats a nil descriptor list as an
empty one, and releases the working copies. mutable.m covers setting the query
and exclusion descriptors and adding and removing query descriptors.
