### PR TITLE
Fix: NSSwitch is enabled by default and handles -performClick:

### DIFF
--- a/Source/NSSwitch.m
+++ b/Source/NSSwitch.m
@@ -35,6 +35,16 @@
     }
 }
 
+- (instancetype) initWithFrame: (NSRect)frameRect
+{
+  self = [super initWithFrame: frameRect];
+  if (self != nil)
+    {
+      _enabled = YES;
+    }
+  return self;
+}
+
 - (void) setState: (NSControlStateValue)s
 {
   _state = s;
@@ -154,14 +164,13 @@
                             enabled: [self isEnabled]];
 }
 
-- (void) mouseDown: (NSEvent *)event
+- (void) performClick: (id)sender
 {
   if (![self isEnabled])
     {
-      [super mouseDown: event];
       return;
     }
-  
+
   if (_state == NSControlStateValueOn)
     {
       [self setState: NSControlStateValueOff];
@@ -176,6 +185,17 @@
       [self sendAction: _action
                     to: _target];
     }
+}
+
+- (void) mouseDown: (NSEvent *)event
+{
+  if (![self isEnabled])
+    {
+      [super mouseDown: event];
+      return;
+    }
+
+  [self performClick: self];
 }
 
 // Accessibility
@@ -229,6 +249,7 @@
 {
   if ((self = [super initWithCoder: coder]) != nil)
     {
+      _enabled = YES;
       if ([coder allowsKeyedCoding])
         {
           if ([coder containsValueForKey: @"NSControlContents"])

--- a/Tests/gui/NSSwitch/interact.m
+++ b/Tests/gui/NSSwitch/interact.m
@@ -1,0 +1,89 @@
+/* Interaction coverage for NSSwitch: a switch is enabled by default (checked
+   against AppKit), and a click - delivered with -performClick: - toggles its
+   state and sends the target/action, while a disabled switch ignores the
+   click.  The switch uses the theme and font backend, so the set is skipped
+   when the backend is unavailable. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSwitch.h>
+
+@interface SwitchTarget : NSObject
+{
+@public
+  int count;
+}
+- (void) toggled: (id)sender;
+@end
+
+@implementation SwitchTarget
+- (void) toggled: (id)sender
+{
+  count++;
+}
+@end
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSSwitch *sw;
+  SwitchTarget *t;
+
+  START_SET("NSSwitch interaction")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      t = AUTORELEASE([[SwitchTarget alloc] init]);
+      sw = AUTORELEASE([[NSSwitch alloc]
+        initWithFrame: NSMakeRect(0, 0, 40, 24)]);
+      [sw setTarget: t];
+      [sw setAction: @selector(toggled:)];
+
+      PASS([sw isEnabled] == YES, "a switch is enabled by default");
+
+      /* A click turns the switch on and sends the action. */
+      [sw performClick: nil];
+      PASS([sw state] == NSControlStateValueOn && t->count == 1,
+        "clicking an off switch turns it on and sends the action");
+
+      /* Clicking again turns it off and sends the action again. */
+      [sw performClick: nil];
+      PASS([sw state] == NSControlStateValueOff && t->count == 2,
+        "clicking an on switch turns it off and sends the action again");
+
+      /* A disabled switch ignores the click. */
+      [sw setEnabled: NO];
+      [sw performClick: nil];
+      PASS([sw state] == NSControlStateValueOff && t->count == 2,
+        "a disabled switch ignores the click");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSSwitch interaction")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Two related defects in NSSwitch:

**Disabled by default.** A switch created with `-initWithFrame:` left its `_enabled` ivar at the zero value, so `-isEnabled` returned NO and the switch ignored every click (`-mouseDown:` returns early when not enabled). AppKit enables a switch by default. This sets `_enabled` in a new `-initWithFrame:`, and defaults it to YES in `-initWithCoder:` as well, so a switch decoded from a nib that does not archive an `NSEnabled` key is also enabled.

**No `-performClick:`.** NSSwitch manages its own state, action and target rather than using a cell, but it did not override `-performClick:`. The inherited `NSControl` implementation dispatches to the (unused) cell, so `[aSwitch performClick: nil]` did nothing. The toggle-and-send-action logic is moved out of `-mouseDown:` into `-performClick:`, and `-mouseDown:` now calls it, so a programmatic click toggles the switch and sends its action the same way a real click does.

Adds `Tests/gui/NSSwitch/interact.m`: the switch is enabled by default, a click toggles the state and sends the target/action, a second click toggles it back, and a disabled switch ignores the click. Verified fail-before/pass-after on GNUstep (before: `isEnabled` NO and `-performClick:` a no-op).