### PR TITLE
Feature: add the NSButton convenience constructors

### DIFF
--- a/Headers/AppKit/NSButton.h
+++ b/Headers/AppKit/NSButton.h
@@ -45,8 +45,30 @@ APPKIT_EXPORT_CLASS
   // Attributes
 }
 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_12, GS_API_LATEST)
 //
-// Setting the Button Type 
+// Creating Buttons
+//
++ (instancetype)buttonWithTitle:(NSString *)title
+                         target:(id)target
+                         action:(SEL)action;
++ (instancetype)buttonWithImage:(NSImage *)image
+                         target:(id)target
+                         action:(SEL)action;
++ (instancetype)buttonWithTitle:(NSString *)title
+                          image:(NSImage *)image
+                         target:(id)target
+                         action:(SEL)action;
++ (instancetype)checkboxWithTitle:(NSString *)title
+                           target:(id)target
+                           action:(SEL)action;
++ (instancetype)radioButtonWithTitle:(NSString *)title
+                              target:(id)target
+                              action:(SEL)action;
+#endif
+
+//
+// Setting the Button Type
 //
 - (void)setButtonType:(NSButtonType)aType;
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)

--- a/Source/NSButton.m
+++ b/Source/NSButton.m
@@ -81,6 +81,85 @@ static id buttonCellClass = nil;
   buttonCellClass = classId;
 }
 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_12, GS_API_LATEST)
++ (instancetype) buttonWithTitle: (NSString *)title
+                          target: (id)target
+                          action: (SEL)action
+{
+  NSButton *button = AUTORELEASE([[self alloc] initWithFrame: NSZeroRect]);
+
+  [button setTitle: title];
+  [button setTarget: target];
+  [button setAction: action];
+  [button setBezelStyle: NSRoundedBezelStyle];
+  [button setButtonType: NSMomentaryPushInButton];
+  [button sizeToFit];
+  return button;
+}
+
++ (instancetype) buttonWithImage: (NSImage *)image
+                          target: (id)target
+                          action: (SEL)action
+{
+  NSButton *button = AUTORELEASE([[self alloc] initWithFrame: NSZeroRect]);
+
+  [button setImage: image];
+  [button setImagePosition: NSImageOnly];
+  [button setTarget: target];
+  [button setAction: action];
+  [button setBezelStyle: NSRoundedBezelStyle];
+  [button setButtonType: NSMomentaryPushInButton];
+  [button sizeToFit];
+  return button;
+}
+
++ (instancetype) buttonWithTitle: (NSString *)title
+                           image: (NSImage *)image
+                          target: (id)target
+                          action: (SEL)action
+{
+  NSButton *button = AUTORELEASE([[self alloc] initWithFrame: NSZeroRect]);
+
+  [button setTitle: title];
+  [button setImage: image];
+  [button setImagePosition: NSImageLeft];
+  [button setTarget: target];
+  [button setAction: action];
+  [button setBezelStyle: NSRoundedBezelStyle];
+  [button setButtonType: NSMomentaryPushInButton];
+  [button sizeToFit];
+  return button;
+}
+
++ (instancetype) checkboxWithTitle: (NSString *)title
+                            target: (id)target
+                            action: (SEL)action
+{
+  NSButton *button = AUTORELEASE([[self alloc] initWithFrame: NSZeroRect]);
+
+  [button setTitle: title];
+  [button setTarget: target];
+  [button setAction: action];
+  [button setButtonType: NSSwitchButton];
+  [button sizeToFit];
+  return button;
+}
+
++ (instancetype) radioButtonWithTitle: (NSString *)title
+                               target: (id)target
+                               action: (SEL)action
+{
+  NSButton *button = AUTORELEASE([[self alloc] initWithFrame: NSZeroRect]);
+
+  [button setTitle: title];
+  [button setTarget: target];
+  [button setAction: action];
+  [button setButtonType: NSRadioButton];
+  [button sizeToFit];
+  return button;
+}
+#endif
+
 //
 // Instance methods
 //

--- a/Tests/gui/NSButton/convenienceConstructors.m
+++ b/Tests/gui/NSButton/convenienceConstructors.m
@@ -1,0 +1,85 @@
+/* Coverage for the NSButton convenience constructors: each builds a button
+   wired to the given target/action, a push button is bordered while a checkbox
+   or radio button is not (and carries a mark image), and the button starts in
+   the off state.  Checked against AppKit on a macOS runner.  Building the
+   button touches the font/graphics backend, so the set is skipped when the
+   backend is unavailable. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSButton.h>
+#include <AppKit/NSImage.h>
+
+@interface CtorTarget : NSObject
+- (void) fire: (id)sender;
+@end
+@implementation CtorTarget
+- (void) fire: (id)sender { }
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  CtorTarget *t;
+  NSImage *image;
+
+  START_SET("NSButton convenience constructors")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSButton *b;
+      SEL a = @selector(fire:);
+
+      t = AUTORELEASE([[CtorTarget alloc] init]);
+      image = AUTORELEASE([[NSImage alloc] initWithSize: NSMakeSize(16, 16)]);
+
+      b = [NSButton buttonWithTitle: @"Go" target: t action: a];
+      PASS(b != nil && [[b title] isEqual: @"Go"] && [b target] == t
+        && sel_isEqual([b action], a) && [b isBordered] == YES
+        && [b state] == NSOffState,
+        "buttonWithTitle:target:action: makes a bordered push button");
+
+      b = [NSButton buttonWithImage: image target: t action: a];
+      PASS(b != nil && [b image] == image && [b target] == t
+        && sel_isEqual([b action], a) && [b isBordered] == YES,
+        "buttonWithImage:target:action: makes a bordered image button");
+
+      b = [NSButton buttonWithTitle: @"Go" image: image target: t action: a];
+      PASS(b != nil && [[b title] isEqual: @"Go"] && [b image] == image
+        && [b target] == t && sel_isEqual([b action], a) && [b isBordered] == YES,
+        "buttonWithTitle:image:target:action: carries both title and image");
+
+      b = [NSButton checkboxWithTitle: @"Check" target: t action: a];
+      PASS(b != nil && [[b title] isEqual: @"Check"] && [b target] == t
+        && sel_isEqual([b action], a) && [b isBordered] == NO
+        && [b image] != nil && [b state] == NSOffState,
+        "checkboxWithTitle:target:action: makes an unbordered checkbox");
+
+      b = [NSButton radioButtonWithTitle: @"Radio" target: t action: a];
+      PASS(b != nil && [[b title] isEqual: @"Radio"] && [b target] == t
+        && sel_isEqual([b action], a) && [b isBordered] == NO
+        && [b image] != nil && [b state] == NSOffState,
+        "radioButtonWithTitle:target:action: makes an unbordered radio button");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSButton convenience constructors")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds the AppKit 10.12+ NSButton factory methods, which GNUstep was missing:

- `+buttonWithTitle:target:action:` — a bordered momentary push button
- `+buttonWithImage:target:action:` — a bordered image button
- `+buttonWithTitle:image:target:action:` — title and image together
- `+checkboxWithTitle:target:action:` — an unbordered checkbox (switch button)
- `+radioButtonWithTitle:target:action:` — an unbordered radio button

Each wires up the target and action and returns an autoreleased, sized button. The configuration (bordered push vs unbordered checkbox/radio, the mark image, the off starting state, the wired target/action) was checked against AppKit on a macOS runner. Adds `Tests/gui/NSButton/convenienceConstructors.m`.