### PR TITLE
Feature: add the NSSlider convenience constructors

### DIFF
--- a/Headers/AppKit/NSSlider.h
+++ b/Headers/AppKit/NSSlider.h
@@ -40,7 +40,17 @@
 
 APPKIT_EXPORT_CLASS
 @interface NSSlider : NSControl
-// appearance 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_12, GS_API_LATEST)
+// Creating Sliders
++ (instancetype) sliderWithTarget: (id)target
+                           action: (SEL)action;
++ (instancetype) sliderWithValue: (double)value
+                        minValue: (double)minValue
+                        maxValue: (double)maxValue
+                          target: (id)target
+                          action: (SEL)action;
+#endif
+// appearance
 - (double) altIncrementValue;
 - (NSImage*) image;
 - (NSInteger) isVertical;

--- a/Source/NSSlider.m
+++ b/Source/NSSlider.m
@@ -89,6 +89,39 @@ static Class cellClass;
   return cellClass;
 }
 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_12, GS_API_LATEST)
++ (instancetype) sliderWithTarget: (id)target
+                           action: (SEL)action
+{
+  NSSlider *slider = AUTORELEASE([[self alloc]
+    initWithFrame: NSMakeRect(0, 0, 100, 20)]);
+
+  [slider setMinValue: 0.0];
+  [slider setMaxValue: 1.0];
+  [slider setDoubleValue: 0.0];
+  [slider setTarget: target];
+  [slider setAction: action];
+  return slider;
+}
+
++ (instancetype) sliderWithValue: (double)value
+                        minValue: (double)minValue
+                        maxValue: (double)maxValue
+                          target: (id)target
+                          action: (SEL)action
+{
+  NSSlider *slider = AUTORELEASE([[self alloc]
+    initWithFrame: NSMakeRect(0, 0, 100, 20)]);
+
+  [slider setMinValue: minValue];
+  [slider setMaxValue: maxValue];
+  [slider setDoubleValue: value];
+  [slider setTarget: target];
+  [slider setAction: action];
+  return slider;
+}
+#endif
+
 - (id) initWithFrame: (NSRect)frameRect
 {
   self = [super initWithFrame: frameRect];

--- a/Tests/gui/NSSlider/convenienceConstructors.m
+++ b/Tests/gui/NSSlider/convenienceConstructors.m
@@ -1,0 +1,65 @@
+/* Coverage for the NSSlider convenience constructors: sliderWithTarget:action:
+   makes a slider over the default zero-to-one range wired to the action, and
+   sliderWithValue:minValue:maxValue:target:action: sets the given range and
+   value.  Checked against AppKit on a macOS runner.  Building the slider
+   touches the font/graphics backend, so the set is skipped when the backend is
+   unavailable. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSlider.h>
+
+@interface SliderTarget : NSObject
+- (void) moved: (id)sender;
+@end
+@implementation SliderTarget
+- (void) moved: (id)sender { }
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  SliderTarget *t;
+
+  START_SET("NSSlider convenience constructors")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSSlider *s;
+      SEL a = @selector(moved:);
+
+      t = AUTORELEASE([[SliderTarget alloc] init]);
+
+      s = [NSSlider sliderWithTarget: t action: a];
+      PASS(s != nil && [s minValue] == 0.0 && [s maxValue] == 1.0
+        && [s doubleValue] == 0.0 && [s target] == t && sel_isEqual([s action], a),
+        "sliderWithTarget:action: makes a zero-to-one slider wired to the action");
+
+      s = [NSSlider sliderWithValue: 5.0 minValue: 2.0 maxValue: 9.0
+                             target: t action: a];
+      PASS(s != nil && [s minValue] == 2.0 && [s maxValue] == 9.0
+        && [s doubleValue] == 5.0 && [s target] == t && sel_isEqual([s action], a),
+        "sliderWithValue:minValue:maxValue:target:action: sets the range and value");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSSlider convenience constructors")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds the AppKit 10.12+ NSSlider factory methods, which GNUstep was missing:

- `+sliderWithTarget:action:` — a slider over the default zero-to-one range
- `+sliderWithValue:minValue:maxValue:target:action:` — a slider with the given range and value

Each wires up the target and action and returns an autoreleased slider. The configuration was checked against AppKit on a macOS runner. Adds `Tests/gui/NSSlider/convenienceConstructors.m`.