### PR TITLE
Feature: add the NSSegmentedControl convenience constructors

### DIFF
--- a/Headers/AppKit/NSSegmentedCell.h
+++ b/Headers/AppKit/NSSegmentedCell.h
@@ -27,14 +27,8 @@
 #define _GNUstep_H_NSSegmentedCell
 
 #import <AppKit/NSActionCell.h>
+// NSSegmentedControl.h declares NSSegmentSwitchTracking (and NSSegmentStyle).
 #import <AppKit/NSSegmentedControl.h>
-
-// tracking types...
-typedef enum {
-  NSSegmentSwitchTrackingSelectOne = 0,
-  NSSegmentSwitchTrackingSelectAny = 1,
-  NSSegmentSwitchTrackingMomentary = 2 
-} NSSegmentSwitchTracking;
 
 // forward declarations
 @class NSMutableArray;

--- a/Headers/AppKit/NSSegmentedControl.h
+++ b/Headers/AppKit/NSSegmentedControl.h
@@ -40,8 +40,27 @@ typedef enum _NSSegmentStyle {
 } NSSegmentStyle;
 #endif
 
+// tracking types...
+typedef enum {
+  NSSegmentSwitchTrackingSelectOne = 0,
+  NSSegmentSwitchTrackingSelectAny = 1,
+  NSSegmentSwitchTrackingMomentary = 2
+} NSSegmentSwitchTracking;
+
 APPKIT_EXPORT_CLASS
 @interface NSSegmentedControl : NSControl
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_12, GS_API_LATEST)
+// Creating Segmented Controls
++ (instancetype) segmentedControlWithLabels: (NSArray *)labels
+                               trackingMode: (NSSegmentSwitchTracking)trackingMode
+                                     target: (id)target
+                                     action: (SEL)action;
++ (instancetype) segmentedControlWithImages: (NSArray *)images
+                               trackingMode: (NSSegmentSwitchTracking)trackingMode
+                                     target: (id)target
+                                     action: (SEL)action;
+#endif
 
 // Specifying number of segments...
 - (void) setSegmentCount: (NSInteger)count;

--- a/Source/NSSegmentedControl.m
+++ b/Source/NSSegmentedControl.m
@@ -46,6 +46,50 @@ static Class segmentedControlCellClass;
   return segmentedControlCellClass;
 }
 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_12, GS_API_LATEST)
++ (instancetype) segmentedControlWithLabels: (NSArray *)labels
+                               trackingMode: (NSSegmentSwitchTracking)trackingMode
+                                     target: (id)target
+                                     action: (SEL)action
+{
+  NSSegmentedControl *control = AUTORELEASE([[self alloc]
+    initWithFrame: NSMakeRect(0, 0, 100, 24)]);
+  NSUInteger i, count = [labels count];
+
+  [control setSegmentCount: count];
+  for (i = 0; i < count; i++)
+    {
+      [control setLabel: [labels objectAtIndex: i] forSegment: i];
+    }
+  [(NSSegmentedCell *)[control cell] setTrackingMode: trackingMode];
+  [control setTarget: target];
+  [control setAction: action];
+  [control sizeToFit];
+  return control;
+}
+
++ (instancetype) segmentedControlWithImages: (NSArray *)images
+                               trackingMode: (NSSegmentSwitchTracking)trackingMode
+                                     target: (id)target
+                                     action: (SEL)action
+{
+  NSSegmentedControl *control = AUTORELEASE([[self alloc]
+    initWithFrame: NSMakeRect(0, 0, 100, 24)]);
+  NSUInteger i, count = [images count];
+
+  [control setSegmentCount: count];
+  for (i = 0; i < count; i++)
+    {
+      [control setImage: [images objectAtIndex: i] forSegment: i];
+    }
+  [(NSSegmentedCell *)[control cell] setTrackingMode: trackingMode];
+  [control setTarget: target];
+  [control setAction: action];
+  [control sizeToFit];
+  return control;
+}
+#endif
+
 // Specifying number of segments...
 - (void) setSegmentCount: (NSInteger) count
 {

--- a/Tests/gui/NSSegmentedControl/convenienceConstructors.m
+++ b/Tests/gui/NSSegmentedControl/convenienceConstructors.m
@@ -1,0 +1,83 @@
+/* Coverage for the NSSegmentedControl convenience constructors: the labelled
+   and image variants build one segment per element, carry the tracking mode,
+   and wire up the target and action.  Checked against AppKit on a macOS runner.
+   Building the control touches the font/graphics backend, so the set is skipped
+   when the backend is unavailable. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSArray.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSegmentedControl.h>
+#include <AppKit/NSSegmentedCell.h>
+#include <AppKit/NSImage.h>
+
+@interface SegTarget : NSObject
+- (void) picked: (id)sender;
+@end
+@implementation SegTarget
+- (void) picked: (id)sender { }
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  SegTarget *t;
+
+  START_SET("NSSegmentedControl convenience constructors")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSSegmentedControl *sc;
+      NSImage *image;
+      SEL a = @selector(picked:);
+
+      t = AUTORELEASE([[SegTarget alloc] init]);
+
+      sc = [NSSegmentedControl
+        segmentedControlWithLabels:
+          [NSArray arrayWithObjects: @"One", @"Two", @"Three", nil]
+        trackingMode: NSSegmentSwitchTrackingSelectOne
+        target: t action: a];
+      PASS(sc != nil && [sc segmentCount] == 3
+        && [[sc labelForSegment: 0] isEqual: @"One"]
+        && [[sc labelForSegment: 2] isEqual: @"Three"]
+        && [(NSSegmentedCell *)[sc cell] trackingMode]
+             == NSSegmentSwitchTrackingSelectOne
+        && [sc target] == t && sel_isEqual([sc action], a),
+        "segmentedControlWithLabels:... builds one labelled segment per element");
+
+      image = AUTORELEASE([[NSImage alloc] initWithSize: NSMakeSize(16, 16)]);
+      sc = [NSSegmentedControl
+        segmentedControlWithImages:
+          [NSArray arrayWithObjects: image, image, nil]
+        trackingMode: NSSegmentSwitchTrackingSelectAny
+        target: t action: a];
+      PASS(sc != nil && [sc segmentCount] == 2
+        && [sc imageForSegment: 0] == image
+        && [(NSSegmentedCell *)[sc cell] trackingMode]
+             == NSSegmentSwitchTrackingSelectAny
+        && [sc target] == t && sel_isEqual([sc action], a),
+        "segmentedControlWithImages:... builds one image segment per element");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSSegmentedControl convenience constructors")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Adds the AppKit 10.12+ NSSegmentedControl factory methods, which GNUstep was missing:

- `+segmentedControlWithLabels:trackingMode:target:action:`
- `+segmentedControlWithImages:trackingMode:target:action:`

Each builds one segment per array element, applies the tracking mode, and wires up the target and action. The segment count, labels/images and tracking mode were checked against AppKit on a macOS runner.

To declare these, `NSSegmentSwitchTracking` had to be visible in `NSSegmentedControl.h`, but it lived in `NSSegmentedCell.h`, which imports `NSSegmentedControl.h` — so referencing it here created a circular include ("expected a type"). This moves the `NSSegmentSwitchTracking` enum to `NSSegmentedControl.h`, which is where AppKit declares it. `NSSegmentedCell.h` still imports `NSSegmentedControl.h`, so any file that includes the cell header keeps seeing the type; nothing else changes.

Adds `Tests/gui/NSSegmentedControl/convenienceConstructors.m`.