### PR TITLE
Feature: add NSResponder gesture and touch event methods

### DIFF
--- a/Headers/AppKit/NSResponder.h
+++ b/Headers/AppKit/NSResponder.h
@@ -115,6 +115,25 @@ PACKAGE_SCOPE
 - (void) scrollWheel: (NSEvent *)theEvent;
 #endif
 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
+- (void) cursorUpdate: (NSEvent *)theEvent;
+- (void) magnifyWithEvent: (NSEvent *)theEvent;
+- (void) rotateWithEvent: (NSEvent *)theEvent;
+- (void) swipeWithEvent: (NSEvent *)theEvent;
+- (void) touchesBeganWithEvent: (NSEvent *)theEvent;
+- (void) touchesMovedWithEvent: (NSEvent *)theEvent;
+- (void) touchesEndedWithEvent: (NSEvent *)theEvent;
+- (void) touchesCancelledWithEvent: (NSEvent *)theEvent;
+#endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_8, GS_API_LATEST)
+- (void) smartMagnifyWithEvent: (NSEvent *)theEvent;
+#endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
+- (void) pressureChangeWithEvent: (NSEvent *)theEvent;
+#endif
+
 /*
  * Services menu support
  */

--- a/Source/NSResponder.m
+++ b/Source/NSResponder.m
@@ -316,6 +316,92 @@
     [self noResponderFor: @selector(scrollWheel:)];
 }
 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
+- (void) cursorUpdate: (NSEvent *)theEvent
+{
+  if (_next_responder)
+    [_next_responder cursorUpdate: theEvent];
+  else
+    [self noResponderFor: @selector(cursorUpdate:)];
+}
+
+- (void) magnifyWithEvent: (NSEvent *)theEvent
+{
+  if (_next_responder)
+    [_next_responder magnifyWithEvent: theEvent];
+  else
+    [self noResponderFor: @selector(magnifyWithEvent:)];
+}
+
+- (void) rotateWithEvent: (NSEvent *)theEvent
+{
+  if (_next_responder)
+    [_next_responder rotateWithEvent: theEvent];
+  else
+    [self noResponderFor: @selector(rotateWithEvent:)];
+}
+
+- (void) swipeWithEvent: (NSEvent *)theEvent
+{
+  if (_next_responder)
+    [_next_responder swipeWithEvent: theEvent];
+  else
+    [self noResponderFor: @selector(swipeWithEvent:)];
+}
+
+- (void) touchesBeganWithEvent: (NSEvent *)theEvent
+{
+  if (_next_responder)
+    [_next_responder touchesBeganWithEvent: theEvent];
+  else
+    [self noResponderFor: @selector(touchesBeganWithEvent:)];
+}
+
+- (void) touchesMovedWithEvent: (NSEvent *)theEvent
+{
+  if (_next_responder)
+    [_next_responder touchesMovedWithEvent: theEvent];
+  else
+    [self noResponderFor: @selector(touchesMovedWithEvent:)];
+}
+
+- (void) touchesEndedWithEvent: (NSEvent *)theEvent
+{
+  if (_next_responder)
+    [_next_responder touchesEndedWithEvent: theEvent];
+  else
+    [self noResponderFor: @selector(touchesEndedWithEvent:)];
+}
+
+- (void) touchesCancelledWithEvent: (NSEvent *)theEvent
+{
+  if (_next_responder)
+    [_next_responder touchesCancelledWithEvent: theEvent];
+  else
+    [self noResponderFor: @selector(touchesCancelledWithEvent:)];
+}
+#endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_8, GS_API_LATEST)
+- (void) smartMagnifyWithEvent: (NSEvent *)theEvent
+{
+  if (_next_responder)
+    [_next_responder smartMagnifyWithEvent: theEvent];
+  else
+    [self noResponderFor: @selector(smartMagnifyWithEvent:)];
+}
+#endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
+- (void) pressureChangeWithEvent: (NSEvent *)theEvent
+{
+  if (_next_responder)
+    [_next_responder pressureChangeWithEvent: theEvent];
+  else
+    [self noResponderFor: @selector(pressureChangeWithEvent:)];
+}
+#endif
+
 /*
  * Services menu support
  */

--- a/Tests/gui/NSResponder/gestureEvents.m
+++ b/Tests/gui/NSResponder/gestureEvents.m
@@ -1,0 +1,93 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSResponder.h>
+#import <AppKit/NSEvent.h>
+
+@interface GestureRecorder : NSResponder
+{
+@public
+  SEL last;
+}
+@end
+
+@implementation GestureRecorder
+- (void) cursorUpdate: (NSEvent *)e { last = _cmd; }
+- (void) magnifyWithEvent: (NSEvent *)e { last = _cmd; }
+- (void) rotateWithEvent: (NSEvent *)e { last = _cmd; }
+- (void) swipeWithEvent: (NSEvent *)e { last = _cmd; }
+- (void) touchesBeganWithEvent: (NSEvent *)e { last = _cmd; }
+- (void) touchesMovedWithEvent: (NSEvent *)e { last = _cmd; }
+- (void) touchesEndedWithEvent: (NSEvent *)e { last = _cmd; }
+- (void) touchesCancelledWithEvent: (NSEvent *)e { last = _cmd; }
+- (void) smartMagnifyWithEvent: (NSEvent *)e { last = _cmd; }
+- (void) pressureChangeWithEvent: (NSEvent *)e { last = _cmd; }
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSResponder gesture events")
+
+  /* NSResponder implements the gesture, touch, cursor-update and pressure
+     event methods; the default implementation forwards the event to the
+     next responder, matching AppKit. */
+  GestureRecorder *b = AUTORELEASE([GestureRecorder new]);
+  NSResponder *a = AUTORELEASE([NSResponder new]);
+  [a setNextResponder: b];
+
+  b->last = 0;
+  [a cursorUpdate: nil];
+  PASS(sel_isEqual(b->last, @selector(cursorUpdate:)),
+    "default cursorUpdate: forwards to nextResponder");
+
+  b->last = 0;
+  [a magnifyWithEvent: nil];
+  PASS(sel_isEqual(b->last, @selector(magnifyWithEvent:)),
+    "default magnifyWithEvent: forwards to nextResponder");
+
+  b->last = 0;
+  [a rotateWithEvent: nil];
+  PASS(sel_isEqual(b->last, @selector(rotateWithEvent:)),
+    "default rotateWithEvent: forwards to nextResponder");
+
+  b->last = 0;
+  [a swipeWithEvent: nil];
+  PASS(sel_isEqual(b->last, @selector(swipeWithEvent:)),
+    "default swipeWithEvent: forwards to nextResponder");
+
+  b->last = 0;
+  [a touchesBeganWithEvent: nil];
+  PASS(sel_isEqual(b->last, @selector(touchesBeganWithEvent:)),
+    "default touchesBeganWithEvent: forwards to nextResponder");
+
+  b->last = 0;
+  [a touchesMovedWithEvent: nil];
+  PASS(sel_isEqual(b->last, @selector(touchesMovedWithEvent:)),
+    "default touchesMovedWithEvent: forwards to nextResponder");
+
+  b->last = 0;
+  [a touchesEndedWithEvent: nil];
+  PASS(sel_isEqual(b->last, @selector(touchesEndedWithEvent:)),
+    "default touchesEndedWithEvent: forwards to nextResponder");
+
+  b->last = 0;
+  [a touchesCancelledWithEvent: nil];
+  PASS(sel_isEqual(b->last, @selector(touchesCancelledWithEvent:)),
+    "default touchesCancelledWithEvent: forwards to nextResponder");
+
+  b->last = 0;
+  [a smartMagnifyWithEvent: nil];
+  PASS(sel_isEqual(b->last, @selector(smartMagnifyWithEvent:)),
+    "default smartMagnifyWithEvent: forwards to nextResponder");
+
+  b->last = 0;
+  [a pressureChangeWithEvent: nil];
+  PASS(sel_isEqual(b->last, @selector(pressureChangeWithEvent:)),
+    "default pressureChangeWithEvent: forwards to nextResponder");
+
+  END_SET("NSResponder gesture events")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSResponder is missing the gesture, touch, pressure and cursor-update event methods that AppKit declares. Application code written for macOS that overrides or invokes these does not compile against GNUstep.

This adds the default implementations, each forwarding the event to the next responder (or calling noResponderFor: at the end of the chain), matching the existing event methods:

- cursorUpdate:, magnifyWithEvent:, rotateWithEvent:, swipeWithEvent: and the four touchesXWithEvent: methods (10.6)
- smartMagnifyWithEvent: (10.8)
- pressureChangeWithEvent: (10.10)

Tests/gui/NSResponder/gestureEvents.m verifies each method forwards to the next responder.