### PR TITLE
Feature: add NSView viewDidHide and viewDidUnhide

### DIFF
--- a/Headers/AppKit/NSView.h
+++ b/Headers/AppKit/NSView.h
@@ -374,6 +374,8 @@ PACKAGE_SCOPE
 - (void) setHidden: (BOOL)flag;
 - (BOOL) isHidden;
 - (BOOL) isHiddenOrHasHiddenAncestor;
+- (void) viewDidHide;
+- (void) viewDidUnhide;
 #endif
 
 - (void) drawRect: (NSRect)rect;

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -2982,12 +2982,36 @@ in the main thread.
 /*
  * Hidding Views
  */
+- (void) _sendViewDidUnhide: (BOOL)unhide
+{
+  NSUInteger i, count;
+
+  if (unhide)
+    [self viewDidUnhide];
+  else
+    [self viewDidHide];
+
+  count = [_sub_views count];
+  for (i = 0; i < count; i++)
+    {
+      NSView *sub = [_sub_views objectAtIndex: i];
+
+      if (![sub isHidden])
+        [sub _sendViewDidUnhide: unhide];
+    }
+}
+
 - (void) setHidden: (BOOL)flag
 {
   id view;
+  BOOL notify;
 
   if (_is_hidden == flag)
       return;
+
+  /* The view and its unhidden descendants only change effective visibility
+     when no ancestor is already hidden. */
+  notify = (_super_view == nil) || ![_super_view isHiddenOrHasHiddenAncestor];
 
   _is_hidden = flag;
 
@@ -3039,6 +3063,19 @@ in the main thread.
         }
       [self setNeedsDisplay: YES];
     }
+
+  if (notify)
+    {
+      [self _sendViewDidUnhide: (flag == NO)];
+    }
+}
+
+- (void) viewDidHide
+{
+}
+
+- (void) viewDidUnhide
+{
 }
 
 - (BOOL) isHidden

--- a/Tests/gui/NSView/hiddenNotifications.m
+++ b/Tests/gui/NSView/hiddenNotifications.m
@@ -1,0 +1,95 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSView.h>
+
+@interface HideRecorder : NSView
+{
+@public
+  int hideCount;
+  int unhideCount;
+}
+@end
+
+@implementation HideRecorder
+- (void) viewDidHide { hideCount++; }
+- (void) viewDidUnhide { unhideCount++; }
+@end
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  HideRecorder *parent, *visibleChild, *hiddenChild;
+
+  START_SET("NSView hidden notifications")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  parent = AUTORELEASE([[HideRecorder alloc]
+    initWithFrame: NSMakeRect(0, 0, 100, 100)]);
+  visibleChild = AUTORELEASE([[HideRecorder alloc]
+    initWithFrame: NSMakeRect(0, 0, 50, 50)]);
+  hiddenChild = AUTORELEASE([[HideRecorder alloc]
+    initWithFrame: NSMakeRect(0, 0, 50, 50)]);
+  [parent addSubview: visibleChild];
+  [parent addSubview: hiddenChild];
+
+  /* Directly hiding a view whose ancestors are visible sends viewDidHide to
+     it.  Checked against AppKit. */
+  [hiddenChild setHidden: YES];
+  PASS(hiddenChild->hideCount == 1,
+    "setHidden: YES sends viewDidHide to the view");
+
+  parent->hideCount = 0;
+  visibleChild->hideCount = 0;
+  hiddenChild->hideCount = 0;
+
+  /* Hiding a view sends viewDidHide to the view and to its unhidden
+     descendants, but not to descendants that are already hidden. */
+  [parent setHidden: YES];
+  PASS(parent->hideCount == 1,
+    "viewDidHide is sent to the hidden view");
+  PASS(visibleChild->hideCount == 1,
+    "viewDidHide is sent to an unhidden descendant");
+  PASS(hiddenChild->hideCount == 0,
+    "viewDidHide is not sent to an already-hidden descendant");
+
+  /* Changing the hidden state of a view below a hidden ancestor does not
+     change effective visibility, so no notification is sent. */
+  hiddenChild->hideCount = 0;
+  hiddenChild->unhideCount = 0;
+  [hiddenChild setHidden: NO];
+  PASS(hiddenChild->unhideCount == 0,
+    "no viewDidUnhide is sent below a hidden ancestor");
+  [hiddenChild setHidden: YES];
+  PASS(hiddenChild->hideCount == 0,
+    "no viewDidHide is sent below a hidden ancestor");
+
+  /* Unhiding sends viewDidUnhide to the view and its unhidden descendants. */
+  parent->unhideCount = 0;
+  visibleChild->unhideCount = 0;
+  hiddenChild->unhideCount = 0;
+  [parent setHidden: NO];
+  PASS(parent->unhideCount == 1,
+    "viewDidUnhide is sent to the unhidden view");
+  PASS(visibleChild->unhideCount == 1,
+    "viewDidUnhide is sent to an unhidden descendant");
+  PASS(hiddenChild->unhideCount == 0,
+    "viewDidUnhide is not sent to a still-hidden descendant");
+
+  END_SET("NSView hidden notifications")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSView does not implement viewDidHide and viewDidUnhide, so code written for macOS that overrides them to react to visibility changes does not compile or run against GNUstep.

setHidden: now sends these messages to the view and to the descendants whose effective visibility changes with it. A descendant that is itself hidden is skipped, and a view below an already-hidden ancestor is not notified, since in those cases the effective visibility does not change. This matches AppKit.

Tests/gui/NSView/hiddenNotifications.m covers direct hide and unhide, recursion into unhidden descendants, skipping already-hidden descendants, and the absence of notifications below a hidden ancestor.