### PR TITLE
Feature: add NSCell expansion, focus ring and field editor defaults

### DIFF
--- a/Headers/AppKit/NSCell.h
+++ b/Headers/AppKit/NSCell.h
@@ -675,6 +675,16 @@ APPKIT_EXPORT_CLASS
 - (void) setUsesSingleLineMode: (BOOL)flag;
 - (BOOL) usesSingleLineMode;
 #endif
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
+- (NSRect) expansionFrameWithFrame: (NSRect)cellFrame inView: (NSView *)view;
+- (BOOL) wantsNotificationForMarkedText;
+#endif
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
+- (NSText *) fieldEditorForView: (NSView *)controlView;
+#endif
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
+- (NSRect) focusRingMaskBoundsForFrame: (NSRect)cellFrame inView: (NSView *)view;
+#endif
 
 //
 // Target and Action

--- a/Source/NSCell.m
+++ b/Source/NSCell.m
@@ -2924,6 +2924,26 @@ static NSColor *dtxtCol;
   return _cell.uses_single_line_mode;
 }
 
+- (NSRect) expansionFrameWithFrame: (NSRect)cellFrame inView: (NSView *)view
+{
+  return NSZeroRect;
+}
+
+- (BOOL) wantsNotificationForMarkedText
+{
+  return NO;
+}
+
+- (NSText *) fieldEditorForView: (NSView *)controlView
+{
+  return nil;
+}
+
+- (NSRect) focusRingMaskBoundsForFrame: (NSRect)cellFrame inView: (NSView *)view
+{
+  return NSZeroRect;
+}
+
 @end
 
 @implementation NSCell (PrivateMethods)

--- a/Tests/gui/NSCell/cellDefaults.m
+++ b/Tests/gui/NSCell/cellDefaults.m
@@ -1,0 +1,53 @@
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSCell.h>
+#include <AppKit/NSText.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSCell *cell;
+  NSRect frame = NSMakeRect(10, 20, 100, 40);
+  NSRect r;
+
+  START_SET("NSCell defaults")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  cell = AUTORELEASE([[NSCell alloc] initTextCell: @"hello"]);
+
+  /* The base NSCell implementations of these methods return the empty
+     defaults; the text-clipping and focus-ring behaviour is provided by
+     subclasses.  Checked against AppKit. */
+  PASS([cell fieldEditorForView: nil] == nil,
+    "fieldEditorForView: returns nil by default");
+
+  PASS([cell wantsNotificationForMarkedText] == NO,
+    "wantsNotificationForMarkedText is NO by default");
+
+  r = [cell expansionFrameWithFrame: frame inView: nil];
+  PASS(NSEqualRects(r, NSZeroRect),
+    "expansionFrameWithFrame:inView: returns NSZeroRect by default");
+
+  r = [cell focusRingMaskBoundsForFrame: frame inView: nil];
+  PASS(NSEqualRects(r, NSZeroRect),
+    "focusRingMaskBoundsForFrame:inView: returns NSZeroRect by default");
+
+  END_SET("NSCell defaults")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSCell is missing expansionFrameWithFrame:inView:, focusRingMaskBoundsForFrame:inView:, fieldEditorForView: and wantsNotificationForMarkedText, so macOS code that calls or overrides them does not compile against GNUstep.

This adds the base implementations. Verified against AppKit on macOS: for a plain NSCell all four return the empty defaults, expansionFrameWithFrame:inView: returns NSZeroRect even for clipped text (the truncation-aware behaviour belongs to NSTextFieldCell), focusRingMaskBoundsForFrame:inView: returns NSZeroRect, fieldEditorForView: returns nil and wantsNotificationForMarkedText returns NO.

Tests/gui/NSCell/cellDefaults.m checks all four.