### PR TITLE
Feature: add NSResponder validateProposedFirstResponder and supplementalTargetForAction

### DIFF
--- a/Headers/AppKit/NSResponder.h
+++ b/Headers/AppKit/NSResponder.h
@@ -171,6 +171,12 @@ PACKAGE_SCOPE
 - (NSError *)willPresentError:(NSError *)error;
 #endif
 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
+- (BOOL) validateProposedFirstResponder: (NSResponder *)responder
+                                forEvent: (NSEvent *)event;
+- (id) supplementalTargetForAction: (SEL)action sender: (id)sender;
+#endif
+
 @end
 
 #if OS_API_VERSION(GS_API_MACOSX, GS_API_LATEST)

--- a/Source/NSResponder.m
+++ b/Source/NSResponder.m
@@ -475,4 +475,15 @@
   return error;
 }
 
+- (BOOL) validateProposedFirstResponder: (NSResponder *)responder
+                                forEvent: (NSEvent *)event
+{
+  return YES;
+}
+
+- (id) supplementalTargetForAction: (SEL)action sender: (id)sender
+{
+  return nil;
+}
+
 @end

--- a/Tests/gui/NSResponder/firstResponderValidation.m
+++ b/Tests/gui/NSResponder/firstResponderValidation.m
@@ -1,0 +1,25 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <AppKit/NSResponder.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSResponder first responder validation")
+
+  NSResponder *r = AUTORELEASE([NSResponder new]);
+  NSResponder *other = AUTORELEASE([NSResponder new]);
+
+  /* The default implementations accept the proposed first responder and
+     supply no alternate action target.  Checked against AppKit. */
+  PASS([r validateProposedFirstResponder: other forEvent: nil] == YES,
+    "validateProposedFirstResponder:forEvent: returns YES by default");
+
+  PASS([r supplementalTargetForAction: @selector(copy:) sender: nil] == nil,
+    "supplementalTargetForAction:sender: returns nil by default");
+
+  END_SET("NSResponder first responder validation")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSResponder is missing validateProposedFirstResponder:forEvent: and supplementalTargetForAction:sender:, so macOS code that calls or overrides them does not compile against GNUstep.

This adds the base defaults, verified against AppKit: validateProposedFirstResponder:forEvent: returns YES (the proposed responder is accepted) and supplementalTargetForAction:sender: returns nil (no alternate action target).

Tests/gui/NSResponder/firstResponderValidation.m checks both.