### PR TITLE
Fix: implement NSTableView indicatorImage accessors

### DIFF
--- a/Headers/AppKit/NSTableColumn.h
+++ b/Headers/AppKit/NSTableColumn.h
@@ -36,6 +36,7 @@
 
 @class NSSortDescriptor;
 @class NSCell;
+@class NSImage;
 @class NSTableView;
 @class NSMutableArray;
 
@@ -74,6 +75,7 @@ APPKIT_EXPORT_CLASS
   NSString *_headerToolTip;
   NSSortDescriptor *_sortDescriptorPrototype;
   NSMutableArray *_prototypeCellViews;
+  NSImage *_indicatorImage;
 }
 /* 
  * Initializing an NSTableColumn instance 

--- a/Source/GSThemeDrawing.m
+++ b/Source/GSThemeDrawing.m
@@ -3141,6 +3141,7 @@ static NSDictionary *titleTextAttributes[3] = {nil, nil, nil};
   float width;
   int i;
   NSCell *cell;
+  NSImage *indicatorImage;
 
   if (tableView == nil)
     return;
@@ -3177,6 +3178,24 @@ static NSDictionary *titleTextAttributes[3] = {nil, nil, nil};
         }
       [cell drawWithFrame: drawingRect
                            inView: tableHeaderView];
+
+      indicatorImage = [tableView indicatorImageInTableColumn: column];
+      if (indicatorImage != nil)
+        {
+          NSSize size = [indicatorImage size];
+          NSRect indicatorRect;
+
+          indicatorRect.size = size;
+          indicatorRect.origin.x = NSMaxX(drawingRect) - size.width - 4.0;
+          indicatorRect.origin.y = drawingRect.origin.y
+            + (drawingRect.size.height - size.height) / 2.0;
+          [indicatorImage drawInRect: indicatorRect
+                            fromRect: NSZeroRect
+                           operation: NSCompositeSourceOver
+                            fraction: 1.0
+                      respectFlipped: YES
+                               hints: nil];
+        }
       drawingRect.origin.x += width;
     }
 }

--- a/Source/NSTableColumn.m
+++ b/Source/NSTableColumn.m
@@ -152,6 +152,7 @@
   RELEASE(_dataCell);
   RELEASE(_sortDescriptorPrototype);
   RELEASE(_prototypeCellViews);
+  TEST_RELEASE(_indicatorImage);
   TEST_RELEASE(_identifier);
   [super dealloc];
 }
@@ -641,6 +642,16 @@ to YES. */
 - (NSArray *) _prototypeCellViews
 {
   return _prototypeCellViews;
+}
+
+- (void) _setIndicatorImage: (NSImage *)image
+{
+  ASSIGN(_indicatorImage, image);
+}
+
+- (NSImage *) _indicatorImage
+{
+  return _indicatorImage;
 }
 
 - (void) setTitle: (NSString *)title

--- a/Source/NSTableView.m
+++ b/Source/NSTableView.m
@@ -199,6 +199,8 @@ typedef struct _tableViewFlags
 - (void) _applyBindingsToCell: (NSCell *)cell
 			atRow: (NSInteger)index;
 - (NSString *) _keyPathForValueBinding;
+- (void) _setIndicatorImage: (NSImage *)image;
+- (NSImage *) _indicatorImage;
 @end
 
 /*
@@ -5525,18 +5527,13 @@ This method is deprecated, use -columnIndexesInRect:. */
 /* indicator image */
 - (NSImage *) indicatorImageInTableColumn: (NSTableColumn *)aTableColumn
 {
-  // TODO
-  NSLog(@"Method %s is not implemented for class %s",
-	"indicatorImageInTableColumn:", "NSTableView");
-  return nil;
+  return [aTableColumn _indicatorImage];
 }
 
 - (void) setIndicatorImage: (NSImage *)anImage
 	     inTableColumn: (NSTableColumn *)aTableColumn
 {
-  // TODO
-  NSLog(@"Method %s is not implemented for class %s",
-	"setIndicatorImage:inTableColumn:", "NSTableView");
+  [aTableColumn _setIndicatorImage: anImage];
 }
 
 /* highlighting columns */

--- a/Tests/gui/NSTableView/indicatorImage.m
+++ b/Tests/gui/NSTableView/indicatorImage.m
@@ -1,0 +1,53 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSTableView.h>
+#import <AppKit/NSTableColumn.h>
+#import <AppKit/NSImage.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTableView *tv;
+  NSTableColumn *col;
+  NSImage *img;
+
+  START_SET("NSTableView indicator image")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  tv = AUTORELEASE([[NSTableView alloc]
+    initWithFrame: NSMakeRect(0, 0, 200, 100)]);
+  col = AUTORELEASE([[NSTableColumn alloc] initWithIdentifier: @"c"]);
+  [tv addTableColumn: col];
+  img = AUTORELEASE([[NSImage alloc] initWithSize: NSMakeSize(8, 8)]);
+
+  /* Checked against AppKit: no indicator image is set by default; setting one
+     stores it for that column (retained, not copied); setting nil clears it. */
+  PASS([tv indicatorImageInTableColumn: col] == nil,
+    "indicatorImageInTableColumn: is nil by default");
+
+  [tv setIndicatorImage: img inTableColumn: col];
+  PASS([tv indicatorImageInTableColumn: col] == img,
+    "indicatorImageInTableColumn: returns the image set for the column");
+
+  [tv setIndicatorImage: nil inTableColumn: col];
+  PASS([tv indicatorImageInTableColumn: col] == nil,
+    "setIndicatorImage: nil clears the indicator image");
+
+  END_SET("NSTableView indicator image")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTableView/indicatorImage.m
+++ b/Tests/gui/NSTableView/indicatorImage.m
@@ -2,9 +2,33 @@
 #import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSGeometry.h>
 #import <AppKit/NSApplication.h>
+#import <AppKit/NSGraphics.h>
+#import <AppKit/NSImage.h>
+#import <AppKit/NSWindow.h>
 #import <AppKit/NSTableView.h>
 #import <AppKit/NSTableColumn.h>
-#import <AppKit/NSImage.h>
+#import <AppKit/NSTableHeaderView.h>
+
+/* Records whether the column header asked the indicator image to draw,
+   without depending on any particular backend's pixels. */
+@interface ProbeImage : NSImage
+{
+@public
+  BOOL drewInHeader;
+}
+@end
+
+@implementation ProbeImage
+- (void) drawInRect: (NSRect)dst
+           fromRect: (NSRect)src
+          operation: (NSCompositingOperation)op
+           fraction: (CGFloat)delta
+     respectFlipped: (BOOL)respectFlipped
+              hints: (NSDictionary *)hints
+{
+  drewInHeader = YES;
+}
+@end
 
 int
 main(int argc, const char **argv)
@@ -12,7 +36,9 @@ main(int argc, const char **argv)
   CREATE_AUTORELEASE_POOL(arp);
   NSTableView *tv;
   NSTableColumn *col;
-  NSImage *img;
+  ProbeImage *img;
+  NSWindow *w;
+  NSTableHeaderView *header;
 
   START_SET("NSTableView indicator image")
 
@@ -27,24 +53,63 @@ main(int argc, const char **argv)
     }
   NS_ENDHANDLER
 
-  tv = AUTORELEASE([[NSTableView alloc]
-    initWithFrame: NSMakeRect(0, 0, 200, 100)]);
-  col = AUTORELEASE([[NSTableColumn alloc] initWithIdentifier: @"c"]);
-  [tv addTableColumn: col];
-  img = AUTORELEASE([[NSImage alloc] initWithSize: NSMakeSize(8, 8)]);
+  NS_DURING
+    {
+      w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 120, 120)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      tv = AUTORELEASE([[NSTableView alloc]
+        initWithFrame: NSMakeRect(0, 0, 120, 80)]);
+      col = AUTORELEASE([[NSTableColumn alloc] initWithIdentifier: @"c"]);
+      [col setWidth: 120];
+      [tv addTableColumn: col];
 
-  /* Checked against AppKit: no indicator image is set by default; setting one
-     stores it for that column (retained, not copied); setting nil clears it. */
-  PASS([tv indicatorImageInTableColumn: col] == nil,
-    "indicatorImageInTableColumn: is nil by default");
+      /* Checked against AppKit: no indicator image by default; setting one
+         stores it for the column (retained, not copied); nil clears it. */
+      PASS([tv indicatorImageInTableColumn: col] == nil,
+        "indicatorImageInTableColumn: is nil by default");
 
-  [tv setIndicatorImage: img inTableColumn: col];
-  PASS([tv indicatorImageInTableColumn: col] == img,
-    "indicatorImageInTableColumn: returns the image set for the column");
+      img = AUTORELEASE([[ProbeImage alloc] initWithSize: NSMakeSize(12, 12)]);
+      [tv setIndicatorImage: img inTableColumn: col];
+      PASS([tv indicatorImageInTableColumn: col] == img,
+        "indicatorImageInTableColumn: returns the image set for the column");
 
-  [tv setIndicatorImage: nil inTableColumn: col];
-  PASS([tv indicatorImageInTableColumn: col] == nil,
-    "setIndicatorImage: nil clears the indicator image");
+      /* The table view and its header must share a window for the header to
+         lay out its columns. */
+      header = [tv headerView];
+      [header setFrame: NSMakeRect(0, 80, 120, 22)];
+      [[w contentView] addSubview: tv];
+      [[w contentView] addSubview: header];
+
+      /* Drawing the header draws the column's indicator image. */
+      img->drewInHeader = NO;
+      [header lockFocus];
+      [header drawRect: [header bounds]];
+      [header unlockFocus];
+      PASS(img->drewInHeader == YES,
+        "the indicator image is drawn in the column header");
+
+      /* After clearing it, the header no longer draws it. */
+      [tv setIndicatorImage: nil inTableColumn: col];
+      PASS([tv indicatorImageInTableColumn: col] == nil,
+        "setIndicatorImage: nil clears the indicator image");
+
+      img->drewInHeader = NO;
+      [header lockFocus];
+      [header drawRect: [header bounds]];
+      [header unlockFocus];
+      PASS(img->drewInHeader == NO,
+        "the indicator image is not drawn once it is cleared");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+    }
+  NS_ENDHANDLER
 
   END_SET("NSTableView indicator image")
 


### PR DESCRIPTION
indicatorImageInTableColumn: and setIndicatorImage:inTableColumn: were placeholders that only logged "not implemented": the setter discarded the image and the getter always returned nil.

The image is now stored on the table column (retained, matching AppKit, which returns the same object that was set) and returned by the getter. Verified against AppKit on macOS: nil by default, the set image is returned for the column, and setting nil clears it.

Tests/gui/NSTableView/indicatorImage.m covers the default, the set/get round-trip and clearing.