### PR TITLE
Fix: implement NSTextView toggleTraditionalCharacterShape:

### DIFF
--- a/Source/NSTextView_actions.m
+++ b/Source/NSTextView_actions.m
@@ -12,7 +12,7 @@
    Author: Felipe A. Rodriguez <far@ix.netcom.com>
    Date: July 1998
 
-   Author: Daniel Böhringer <boehring@biomed.ruhr-uni-bochum.de>
+   Author: Daniel Bï¿½hringer <boehring@biomed.ruhr-uni-bochum.de>
    Date: August 1998
 
    Author: Fred Kiefer <FredKiefer@gmx.de>
@@ -515,9 +515,33 @@ static NSNumber *float_plus_one(NSNumber *cur)
 
 - (void) toggleTraditionalCharacterShape: (id)sender
 {
-  // TODO
-  NSLog(@"Method %s is not implemented for class %s",
-	"toggleTraditionalCharacterShape:", "NSTextView");
+  NSRange aRange = [self rangeForUserCharacterAttributeChange];
+  NSNumber *current;
+  int shape;
+
+  if (aRange.location == NSNotFound)
+    return;
+
+  if (![self shouldChangeTextInRange: aRange
+	    replacementString: nil])
+    return;
+
+  if (aRange.length > 0)
+    current = [_textStorage attribute: NSCharacterShapeAttributeName
+			      atIndex: aRange.location
+		       effectiveRange: NULL];
+  else
+    current = [_layoutManager->_typingAttributes
+		objectForKey: NSCharacterShapeAttributeName];
+
+  shape = ([current intValue] == 1) ? 0 : 1;
+
+  [_textStorage addAttribute: NSCharacterShapeAttributeName
+		value: [NSNumber numberWithInt: shape]
+		range: aRange];
+  [_layoutManager->_typingAttributes setObject: [NSNumber numberWithInt: shape]
+    forKey: NSCharacterShapeAttributeName];
+  [self didChangeText];
 }
 
 

--- a/Source/NSTextView_actions.m
+++ b/Source/NSTextView_actions.m
@@ -12,7 +12,7 @@
    Author: Felipe A. Rodriguez <far@ix.netcom.com>
    Date: July 1998
 
-   Author: Daniel B�hringer <boehring@biomed.ruhr-uni-bochum.de>
+   Author: Daniel Böhringer <boehring@biomed.ruhr-uni-bochum.de>
    Date: August 1998
 
    Author: Fred Kiefer <FredKiefer@gmx.de>

--- a/Tests/gui/NSTextView/characterShape.m
+++ b/Tests/gui/NSTextView/characterShape.m
@@ -1,0 +1,74 @@
+/* NSTextView -toggleTraditionalCharacterShape: sets NSCharacterShapeAttributeName
+   over the selection, toggling between the traditional shape (1) and the
+   default shape (0).  The sequence (no attribute -> 1 -> 0 -> 1) matches AppKit
+   (verified on a macOS runner).  NSTextView needs the text system and the font
+   backend, so the set is skipped when the backend is unavailable. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSRange.h>
+#include <Foundation/NSValue.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSAttributedString.h>
+#include <AppKit/NSTextView.h>
+#include <AppKit/NSTextStorage.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTextView *tv;
+
+  START_SET("NSTextView character shape")
+
+  NS_DURING
+  {
+    [NSApplication sharedApplication];
+  }
+  NS_HANDLER
+  {
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  }
+  NS_ENDHANDLER
+
+  tv = AUTORELEASE([[NSTextView alloc] initWithFrame: NSMakeRect(0, 0, 200, 100)]);
+  [tv setString: @"hello"];
+  [tv setSelectedRange: NSMakeRange(0, 5)];
+
+  PASS([[tv textStorage] attribute: NSCharacterShapeAttributeName
+                        atIndex: 0
+                 effectiveRange: NULL] == nil,
+    "no character shape attribute by default");
+
+  [tv toggleTraditionalCharacterShape: nil];
+  PASS([[[tv textStorage] attribute: NSCharacterShapeAttributeName
+                          atIndex: 0
+                   effectiveRange: NULL] intValue] == 1,
+    "the first toggle sets the traditional character shape (1)");
+
+  [tv toggleTraditionalCharacterShape: nil];
+  PASS([[[tv textStorage] attribute: NSCharacterShapeAttributeName
+                          atIndex: 0
+                   effectiveRange: NULL] intValue] == 0,
+    "the second toggle sets the default character shape (0)");
+
+  [tv toggleTraditionalCharacterShape: nil];
+  PASS([[[tv textStorage] attribute: NSCharacterShapeAttributeName
+                          atIndex: 0
+                   effectiveRange: NULL] intValue] == 1,
+    "the third toggle sets the traditional character shape again");
+
+  /* The attribute covers the whole selection, not just the first character. */
+  PASS([[[tv textStorage] attribute: NSCharacterShapeAttributeName
+                          atIndex: 4
+                   effectiveRange: NULL] intValue] == 1,
+    "the character shape is applied across the selection");
+
+  END_SET("NSTextView character shape")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
toggleTraditionalCharacterShape: was a placeholder that only logged "not implemented".

It now sets NSCharacterShapeAttributeName over the selection, toggling between the traditional character shape (1) and the default shape (0) based on the current value, and updates the typing attributes, following the same pattern as the ligature actions (useAllLigatures: etc).

Verified against AppKit on macOS: from no attribute the toggles produce 1, then 0, then 1. Tests/gui/NSTextView/characterShape.m checks that sequence and that the attribute is applied across the whole selection. Verified passing under the xlib, art and cairo backends.