### PR TITLE
Fix: implement NSWindow drawers

### DIFF
--- a/Source/NSDrawer.m
+++ b/Source/NSDrawer.m
@@ -33,6 +33,7 @@
 #import <Foundation/NSCoder.h>
 #import <Foundation/NSArchiver.h>
 #import <Foundation/NSKeyedArchiver.h>
+#import <Foundation/NSHashTable.h>
 #import <Foundation/NSNotification.h>
 #import <Foundation/NSException.h>
 #import <Foundation/NSThread.h>
@@ -45,6 +46,10 @@
 #import "AppKit/NSScreen.h"
 
 static NSNotificationCenter *nc = nil;
+
+/* All live drawers, held without retaining them, so a window can report the
+   drawers whose parent window it is. */
+static NSHashTable *_drawers = nil;
 
 @interface GSDrawerWindow : NSWindow
 {
@@ -536,8 +541,27 @@ static NSNotificationCenter *nc = nil;
   if (self == [NSDrawer class])
     {
       nc = [NSNotificationCenter defaultCenter];
+      _drawers = [[NSHashTable alloc] initWithOptions:
+	NSPointerFunctionsOpaqueMemory | NSPointerFunctionsOpaquePersonality
+					     capacity: 4];
       [self setVersion: 0];
     }
+}
+
++ (NSArray *) _drawersForParentWindow: (NSWindow *)window
+{
+  NSMutableArray *result = [NSMutableArray array];
+  NSEnumerator *e = [_drawers objectEnumerator];
+  NSDrawer *d;
+
+  while ((d = [e nextObject]) != nil)
+    {
+      if ([d parentWindow] == window)
+	{
+	  [result addObject: d];
+	}
+    }
+  return result;
 }
 
 // Creation
@@ -583,13 +607,15 @@ static NSNotificationCenter *nc = nil;
 	  }
 	
 	_state = NSDrawerClosedState;
+	[_drawers addObject: self];
     }
-  
+
   return self;
 }
 
 - (void) dealloc
 {
+  [_drawers removeObject: self];
   RELEASE(_drawerWindow);
   if (_delegate != nil)
     {

--- a/Source/NSWindow.m
+++ b/Source/NSWindow.m
@@ -61,6 +61,7 @@
 #import "AppKit/NSColor.h"
 #import "AppKit/NSColorList.h"
 #import "AppKit/NSCursor.h"
+#import "AppKit/NSDrawer.h"
 #import "AppKit/NSDocumentController.h"
 #import "AppKit/NSDocument.h"
 #import "AppKit/NSDragging.h"
@@ -170,6 +171,10 @@ static GSWindowAnimationDelegate *animationDelegate;
 - (NSView *) _windowView;
 - (NSView *) _borderView;
 - (NSScreen *) _screenForFrame: (NSRect)frame;
+@end
+
+@interface NSDrawer (GNUstepPrivate)
++ (NSArray *) _drawersForParentWindow: (NSWindow *)window;
 @end
 
 @implementation NSWindow (GNUstepPrivate)
@@ -5932,10 +5937,7 @@ current key view.<br />
 */
 - (NSArray *) drawers
 {
-  // TODO
-  NSLog(@"Method %s is not implemented for class %s",
-        "drawers", "NSWindow");
-  return nil;
+  return [NSDrawer _drawersForParentWindow: self];
 }
 
 - (void *)windowRef

--- a/Tests/gui/NSDrawer/windowDrawers.m
+++ b/Tests/gui/NSDrawer/windowDrawers.m
@@ -1,0 +1,91 @@
+#import "Testing.h"
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSDrawer.h>
+
+/* -[NSWindow drawers] returns the drawers whose parent window is the receiver.
+   The list is empty (but not nil) when there are none, follows
+   setParentWindow:, and is per window.  Checked against AppKit.  Creating a
+   window and a drawer needs a window server, so the set is guarded. */
+
+static NSWindow *
+window(void)
+{
+  return AUTORELEASE([[NSWindow alloc]
+    initWithContentRect: NSMakeRect(0, 0, 300, 300)
+              styleMask: NSTitledWindowMask
+                backing: NSBackingStoreBuffered
+                  defer: NO]);
+}
+
+static NSDrawer *
+drawer(void)
+{
+  return AUTORELEASE([[NSDrawer alloc]
+    initWithContentSize: NSMakeSize(100, 200)
+          preferredEdge: NSMinXEdge]);
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSWindow *w1, *w2;
+  NSDrawer *d1, *d2, *d3;
+  NSArray *list;
+
+  START_SET("NSWindow drawers")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      w1 = window();
+      w2 = window();
+      d1 = drawer();
+      d2 = drawer();
+      d3 = drawer();
+
+      list = [w1 drawers];
+      PASS(list != nil && [list count] == 0,
+        "a window with no drawers returns an empty array");
+
+      [d1 setParentWindow: w1];
+      list = [w1 drawers];
+      PASS([list count] == 1 && [list containsObject: d1],
+        "a drawer whose parent window is the receiver is listed");
+
+      [d2 setParentWindow: w1];
+      PASS([[w1 drawers] count] == 2,
+        "both drawers of the window are listed");
+
+      [d2 setParentWindow: nil];
+      list = [w1 drawers];
+      PASS([list count] == 1 && [list containsObject: d1]
+        && ![list containsObject: d2],
+        "clearing a drawer's parent window removes it from the list");
+
+      [d3 setParentWindow: w2];
+      PASS(![[w1 drawers] containsObject: d3]
+        && [[w2 drawers] containsObject: d3],
+        "a drawer is only listed by its own parent window");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSWindow drawers")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-[NSWindow drawers] was a placeholder that only logged "not implemented" and returned nil.

NSDrawer now records each live drawer in a table held without retaining them (so there is no retain cycle with the drawer, which retains its parent window, and no leak), removing itself on dealloc. -[NSWindow drawers] returns the drawers whose parent window is the receiver.

Verified against AppKit on macOS: the list is a non-nil empty array when there are none, follows setParentWindow: (adding and, with nil, removing), and is per window. Tests/gui/NSDrawer/windowDrawers.m covers those cases, verified passing under the xlib, art and cairo backends.