### PR TITLE
Fix: implement -[NSView backingAlignedRect:options:]

### DIFF
--- a/Headers/AppKit/NSView.h
+++ b/Headers/AppKit/NSView.h
@@ -311,6 +311,10 @@ PACKAGE_SCOPE
 - (NSSize) convertSizeFromBase: (NSSize)aSize;
 - (NSSize) convertSizeToBase: (NSSize)aSize;
 #endif
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
+- (NSRect) backingAlignedRect: (NSRect)aRect
+                      options: (NSAlignmentOptions)options;
+#endif
 
 /*
  * Notifying Ancestor Views

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -1744,6 +1744,34 @@ static NSSize _computeScale(NSSize fs, NSSize bs)
   return aRect;
 }
 
+- (NSRect) backingAlignedRect: (NSRect)aRect
+                      options: (NSAlignmentOptions)options
+{
+  CGFloat scale = 1.0;
+
+  if (_window != nil)
+    {
+      scale = [_window backingScaleFactor];
+    }
+  if (scale <= 0.0)
+    {
+      scale = 1.0;
+    }
+
+  if (scale == 1.0)
+    {
+      return NSIntegralRectWithOptions(aRect, options);
+    }
+
+  /* Align on the backing store pixel grid: scale the rectangle into backing
+     coordinates, align it to whole pixels there, then scale it back. */
+  aRect = NSMakeRect(NSMinX(aRect) * scale, NSMinY(aRect) * scale,
+                     NSWidth(aRect) * scale, NSHeight(aRect) * scale);
+  aRect = NSIntegralRectWithOptions(aRect, options);
+  return NSMakeRect(NSMinX(aRect) / scale, NSMinY(aRect) / scale,
+                    NSWidth(aRect) / scale, NSHeight(aRect) / scale);
+}
+
 - (NSPoint) convertPoint: (NSPoint)aPoint fromView: (NSView*)aView
 {
   NSPoint inBase;

--- a/Tests/gui/NSView/backingAligned.m
+++ b/Tests/gui/NSView/backingAligned.m
@@ -1,0 +1,119 @@
+#include "Testing.h"
+
+#include <math.h>
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSException.h>
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSView.h>
+
+/* -[NSView backingAlignedRect:options:] aligns each axis of a rectangle to the
+   backing store grid (scale 1 for a windowless view). The expected values were
+   checked against AppKit on a macOS runner. */
+
+static BOOL
+rectEqual(NSRect r, CGFloat x, CGFloat y, CGFloat w, CGFloat h)
+{
+  if (fabs(r.origin.x - x) > 0.001 || fabs(r.origin.y - y) > 0.001
+    || fabs(r.size.width - w) > 0.001 || fabs(r.size.height - h) > 0.001)
+    {
+      printf("expected (%g %g)+(%g %g), got (%g %g)+(%g %g)\n",
+             x, y, w, h,
+             r.origin.x, r.origin.y, r.size.width, r.size.height);
+      return NO;
+    }
+  return YES;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSView *v;
+  NSRect r;
+  NSRect n;
+
+  START_SET("NSView backingAlignedRect")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  v = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+
+  /* minX=10.3 minY=20.7 maxX=15.7 maxY=27.5 */
+  r = NSMakeRect(10.3, 20.7, 5.4, 6.8);
+
+  PASS(rectEqual([v backingAlignedRect: r options: NSAlignAllEdgesNearest],
+                 10, 21, 6, 7),
+       "all edges nearest rounds each edge to the closest pixel");
+  PASS(rectEqual([v backingAlignedRect: r options: NSAlignAllEdgesInward],
+                 11, 21, 4, 6),
+       "all edges inward shrinks the rectangle to whole pixels");
+  PASS(rectEqual([v backingAlignedRect: r options: NSAlignAllEdgesOutward],
+                 10, 20, 6, 8),
+       "all edges outward grows the rectangle to whole pixels");
+
+  PASS(rectEqual([v backingAlignedRect: r
+                              options: NSAlignMinXNearest | NSAlignWidthNearest
+                                       | NSAlignMinYNearest | NSAlignHeightNearest],
+                 10, 21, 5, 7),
+       "a min edge with a size rounds the origin and size independently");
+  PASS(rectEqual([v backingAlignedRect: r
+                              options: NSAlignMaxXNearest | NSAlignWidthNearest
+                                       | NSAlignMaxYNearest | NSAlignHeightNearest],
+                 11, 21, 5, 7),
+       "a max edge with a size anchors the far edge and rounds the size");
+  PASS(rectEqual([v backingAlignedRect: r
+                              options: NSAlignMinXInward | NSAlignMaxXOutward
+                                       | NSAlignMinYNearest | NSAlignMaxYNearest],
+                 11, 21, 5, 7),
+       "each edge takes its own rounding direction");
+
+  PASS(rectEqual([v backingAlignedRect: r
+                              options: NSAlignAllEdgesNearest | NSAlignRectFlipped],
+                 10, 21, 6, 6),
+       "the flipped flag rounds a tie on the max Y edge downward");
+
+  /* minX=-3.4 minY=-5.6 maxX=-1.2 maxY=-2.3 */
+  n = NSMakeRect(-3.4, -5.6, 2.2, 3.3);
+  PASS(rectEqual([v backingAlignedRect: n options: NSAlignAllEdgesNearest],
+                 -3, -6, 2, 4),
+       "nearest handles a negative-origin rectangle");
+  PASS(rectEqual([v backingAlignedRect: n options: NSAlignAllEdgesInward],
+                 -3, -5, 1, 2),
+       "inward shrinks a negative-origin rectangle");
+  PASS(rectEqual([v backingAlignedRect: n options: NSAlignAllEdgesOutward],
+                 -4, -6, 3, 4),
+       "outward grows a negative-origin rectangle");
+
+  PASS(rectEqual([v backingAlignedRect: NSMakeRect(4, 5, 6, 7)
+                              options: NSAlignAllEdgesNearest],
+                 4, 5, 6, 7),
+       "an already integral rectangle is unchanged");
+
+  {
+    BOOL raised = NO;
+
+    NS_DURING
+      [v backingAlignedRect: r options: NSAlignMinXInward];
+    NS_HANDLER
+      if ([[localException name] isEqualToString: NSInvalidArgumentException])
+        raised = YES;
+    NS_ENDHANDLER
+    PASS(raised,
+         "an axis without exactly two of min, max and size raises");
+  }
+
+  END_SET("NSView backingAlignedRect")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Implements -[NSView backingAlignedRect:options:]. It delegates the alignment to NSIntegralRectWithOptions: at a backing scale of 1 it calls it directly, and otherwise it scales the rectangle into backing coordinates, aligns there, and scales back.

Depends on libs-base #700, which completes NSIntegralRectWithOptions for all the min/max/size mode combinations. The test checks the windowless (scale 1) case for nearest/inward/outward, per-edge modes, the flipped tie-break, negative origins and an already-integral rectangle, against Apple.

This is the version discussed in #700: it drops the private alignment helper and reuses NSIntegralRectWithOptions.