### PR TITLE
Fix: load NSDataAsset from the bundle and report a missing asset

### DIFF
--- a/Source/NSDataAsset.m
+++ b/Source/NSDataAsset.m
@@ -22,30 +22,192 @@
    Boston, MA 02110 USA.
 */
 
+#import <Foundation/NSArray.h>
 #import <Foundation/NSBundle.h>
-#import <Foundation/NSString.h>
 #import <Foundation/NSData.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSEnumerator.h>
+#import <Foundation/NSJSONSerialization.h>
+#import <Foundation/NSPathUtilities.h>
+#import <Foundation/NSString.h>
 #import <AppKit/NSDataAsset.h>
+
+@interface NSDataAsset (Private)
+- (BOOL) _loadData;
+@end
+
+/* A best-effort type identifier from a file extension.  Only the common,
+   standard uniform type identifiers are mapped; an unknown extension gives
+   nil. */
+static NSString *
+typeIdentifierForExtension(NSString *ext)
+{
+  static NSDictionary *map = nil;
+
+  if (ext == nil || [ext length] == 0)
+    {
+      return nil;
+    }
+  if (map == nil)
+    {
+      map = [[NSDictionary alloc] initWithObjectsAndKeys:
+        @"public.json", @"json",
+        @"public.xml", @"xml",
+        @"public.plain-text", @"txt",
+        @"public.html", @"html",
+        @"public.comma-separated-values-text", @"csv",
+        @"com.apple.property-list", @"plist",
+        @"public.png", @"png",
+        @"public.jpeg", @"jpeg",
+        @"public.jpeg", @"jpg",
+        @"com.compuserve.gif", @"gif",
+        @"com.adobe.pdf", @"pdf",
+        @"public.data", @"data",
+        nil];
+    }
+  return [map objectForKey: [ext lowercaseString]];
+}
 
 @implementation NSDataAsset
 
 // Initializing the Data Asset
 - (instancetype) initWithName: (NSDataAssetName)name
 {
-  return [self initWithName: name bundle: nil];
+  return [self initWithName: name bundle: [NSBundle mainBundle]];
 }
 
 - (instancetype) initWithName: (NSDataAssetName)name bundle: (NSBundle *)bundle
 {
   self = [super init];
-  if (self != nil)
+  if (self == nil)
     {
-      ASSIGNCOPY(_name, name);
-      ASSIGN(_bundle, bundle);
-      _data = nil;
-      _typeIdentifier = nil;
+      return nil;
     }
+
+  if (name == nil)
+    {
+      DESTROY(self);
+      return nil;
+    }
+  if (bundle == nil)
+    {
+      bundle = [NSBundle mainBundle];
+    }
+
+  ASSIGNCOPY(_name, name);
+  ASSIGN(_bundle, bundle);
+  _data = nil;
+  _typeIdentifier = nil;
+
+  if (![self _loadData])
+    {
+      DESTROY(self);
+      return nil;
+    }
+
   return self;
+}
+
+- (BOOL) _loadData
+{
+  NSString *datasetPath;
+  NSString *resourcePath;
+
+  // An Apple .dataset directory: read Contents.json for the data file.
+  datasetPath = [_bundle pathForResource: _name ofType: @"dataset"];
+  if (datasetPath != nil)
+    {
+      NSString *contentsPath;
+      NSData *contentsData;
+      id contents;
+
+      contentsPath = [datasetPath
+        stringByAppendingPathComponent: @"Contents.json"];
+      contentsData = [NSData dataWithContentsOfFile: contentsPath];
+      contents = (contentsData != nil)
+        ? [NSJSONSerialization JSONObjectWithData: contentsData
+                                          options: 0
+                                            error: NULL]
+        : nil;
+      if ([contents isKindOfClass: [NSDictionary class]])
+        {
+          NSArray *entries = [(NSDictionary *)contents objectForKey: @"data"];
+
+          if ([entries isKindOfClass: [NSArray class]])
+            {
+              NSEnumerator *en = [entries objectEnumerator];
+              NSDictionary *entry;
+              NSString *filename = nil;
+
+              while ((entry = [en nextObject]) != nil)
+                {
+                  NSString *entryFile;
+
+                  if (![entry isKindOfClass: [NSDictionary class]])
+                    continue;
+                  entryFile = [entry objectForKey: @"filename"];
+                  if (entryFile == nil)
+                    continue;
+                  if (filename == nil)
+                    filename = entryFile;
+                  if ([[entry objectForKey: @"idiom"]
+                        isEqualToString: @"universal"])
+                    {
+                      filename = entryFile;
+                      break;
+                    }
+                }
+
+              if (filename != nil)
+                {
+                  NSString *dataPath;
+                  NSData *data;
+
+                  dataPath = [datasetPath
+                    stringByAppendingPathComponent: filename];
+                  data = [NSData dataWithContentsOfFile: dataPath];
+                  if (data != nil)
+                    {
+                      ASSIGN(_data, data);
+                      ASSIGN(_typeIdentifier,
+                        typeIdentifierForExtension([filename pathExtension]));
+                      return YES;
+                    }
+                }
+            }
+        }
+    }
+
+  // A plain named resource in the bundle.
+  resourcePath = [_bundle pathForResource: _name ofType: nil];
+  if (resourcePath == nil)
+    {
+      NSArray *types = [NSArray arrayWithObjects:
+        @"data", @"json", @"plist", @"xml", @"txt", nil];
+      NSEnumerator *en = [types objectEnumerator];
+      NSString *type;
+
+      while ((type = [en nextObject]) != nil)
+        {
+          resourcePath = [_bundle pathForResource: _name ofType: type];
+          if (resourcePath != nil)
+            break;
+        }
+    }
+  if (resourcePath != nil)
+    {
+      NSData *data = [NSData dataWithContentsOfFile: resourcePath];
+
+      if (data != nil)
+        {
+          ASSIGN(_data, data);
+          ASSIGN(_typeIdentifier,
+            typeIdentifierForExtension([resourcePath pathExtension]));
+          return YES;
+        }
+    }
+
+  return NO;
 }
 
 - (void) dealloc

--- a/Tests/gui/NSDataAsset/loading.m
+++ b/Tests/gui/NSDataAsset/loading.m
@@ -1,0 +1,93 @@
+/* NSDataAsset loads a named data asset from a bundle, from either an Apple
+   .dataset directory or a plain named resource, and returns nil when the asset
+   is not found.  AppKit returns nil for a missing asset (checked on a macOS
+   runner); the loading itself is exercised against a temporary bundle built
+   here. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSBundle.h>
+#include <Foundation/NSData.h>
+#include <Foundation/NSFileManager.h>
+#include <Foundation/NSPathUtilities.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSDataAsset.h>
+
+static NSData *
+bytes(NSString *s)
+{
+  return [s dataUsingEncoding: NSUTF8StringEncoding];
+}
+
+/* Build a bundle with a Blob.dataset directory and a Plain.json resource,
+   returning its path. */
+static NSString *
+buildBundle(void)
+{
+  NSFileManager *fm = [NSFileManager defaultManager];
+  NSString *root = [NSTemporaryDirectory()
+    stringByAppendingPathComponent: @"NSDataAssetTest.bundle"];
+  NSString *res = [root stringByAppendingPathComponent: @"Resources"];
+  NSString *dataset = [res stringByAppendingPathComponent: @"Blob.dataset"];
+
+  [fm removeItemAtPath: root error: NULL];
+  [fm createDirectoryAtPath: dataset
+    withIntermediateDirectories: YES
+                 attributes: nil
+                      error: NULL];
+
+  [bytes(@"{\"info\":{\"version\":1,\"author\":\"test\"},"
+         @"\"data\":[{\"idiom\":\"universal\",\"filename\":\"payload.bin\"}]}")
+    writeToFile: [dataset stringByAppendingPathComponent: @"Contents.json"]
+     atomically: YES];
+  [bytes(@"hello dataset")
+    writeToFile: [dataset stringByAppendingPathComponent: @"payload.bin"]
+     atomically: YES];
+  [bytes(@"{\"k\":1}")
+    writeToFile: [res stringByAppendingPathComponent: @"Plain.json"]
+     atomically: YES];
+
+  return root;
+}
+
+int
+main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSString *root;
+  NSBundle *bundle;
+  NSDataAsset *a;
+
+  START_SET("NSDataAsset loading")
+
+  root = buildBundle();
+  bundle = [NSBundle bundleWithPath: root];
+  PASS(bundle != nil, "built a temporary bundle to load from");
+
+  a = AUTORELEASE([[NSDataAsset alloc] initWithName: @"Blob" bundle: bundle]);
+  PASS(a != nil, "an asset packaged as a .dataset loads");
+  PASS([[a data] isEqualToData: bytes(@"hello dataset")],
+       "the .dataset payload is the asset data");
+  PASS([[a name] isEqualToString: @"Blob"], "the asset keeps its name");
+
+  a = AUTORELEASE([[NSDataAsset alloc] initWithName: @"Plain" bundle: bundle]);
+  PASS(a != nil, "an asset stored as a plain resource loads");
+  PASS([[a data] isEqualToData: bytes(@"{\"k\":1}")],
+       "the plain resource is the asset data");
+  PASS([[a typeIdentifier] isEqualToString: @"public.json"],
+       "the type identifier is derived from the resource extension");
+
+  a = AUTORELEASE([[NSDataAsset alloc] initWithName: @"Missing" bundle: bundle]);
+  PASS(a == nil, "a missing asset returns nil");
+
+  a = AUTORELEASE([[NSDataAsset alloc] initWithName: @"NoSuchAsset"]);
+  PASS(a == nil, "a missing asset in the main bundle returns nil");
+
+  [[NSFileManager defaultManager] removeItemAtPath: root error: NULL];
+
+  END_SET("NSDataAsset loading")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSDataAsset kept its name and bundle but never read anything, so -data and -typeIdentifier were nil for every asset, and -initWithName:(bundle:) returned an object even for an asset that does not exist (AppKit returns nil, checked on a macOS runner).

The initialiser now loads the named asset from the bundle:

- an Apple .dataset directory (<name>.dataset), reading its Contents.json to find the data file, or
- a plain named resource in the bundle.

The type identifier is derived from the data file's extension for the common uniform types. The initialiser returns nil when the asset cannot be found or no name is given; a nil bundle uses the main bundle.

Since there is no compiled asset catalog on GNUstep, the loading is exercised in Tests/gui/NSDataAsset/loading.m against a temporary bundle built with both a .dataset directory and a plain resource; five of its assertions fail against the previous implementation. The .dataset layout follows Apple's source format so an .xcassets shipped as bundle resources resolves; the plain-resource path covers the simpler GNUstep case.

Closes #582