### PR TITLE
Fix: report and switch the NSColorPanel picker mode

### DIFF
--- a/ColorPickers/GSCMYKColorPicker.m
+++ b/ColorPickers/GSCMYKColorPicker.m
@@ -43,7 +43,7 @@
         return nil;
 
       numFields = 4;
-      currentMode = NSColorPanelCMYKModeMask;
+      currentMode = NSCMYKModeColorPanel;
 
       b = [NSBundle bundleForClass: [self class]];
       r_names[0] = NSLocalizedStringFromTableInBundle(@"Cyan",@"StandardPicker",b,@"");

--- a/ColorPickers/GSGrayColorPicker.m
+++ b/ColorPickers/GSGrayColorPicker.m
@@ -45,7 +45,7 @@
 	return nil;
 
       numFields = 1;
-      currentMode = NSColorPanelGrayModeMask;
+      currentMode = NSGrayModeColorPanel;
       maxValue = 100;
 
       b = [NSBundle bundleForClass: [self class]];

--- a/ColorPickers/GSHSBColorPicker.m
+++ b/ColorPickers/GSHSBColorPicker.m
@@ -43,7 +43,7 @@
         return nil;
 
       numFields = 3;
-      currentMode = NSColorPanelHSBModeMask;
+      currentMode = NSHSBModeColorPanel;
 
       b = [NSBundle bundleForClass: [self class]];
       r_names[0] = NSLocalizedStringFromTableInBundle(@"Hue",@"StandardPicker",b,@"");

--- a/ColorPickers/GSRGBColorPicker.m
+++ b/ColorPickers/GSRGBColorPicker.m
@@ -44,7 +44,7 @@
       b = [NSBundle bundleForClass: [self class]];
 
       numFields = 3;
-      currentMode = NSColorPanelRGBModeMask;
+      currentMode = NSRGBModeColorPanel;
       maxValue = 255;
 
       r_names[0] = NSLocalizedStringFromTableInBundle(@"Red",@"StandardPicker",b,@"");

--- a/ColorPickers/GSStandardColorPicker.m
+++ b/ColorPickers/GSStandardColorPicker.m
@@ -271,7 +271,7 @@
 
 - (BOOL)supportsMode:(int)mode
 {
-  return currentMode == NSRGBModeColorPanel;
+  return currentMode == mode;
 }
 
 - (NSView *)provideNewView:(BOOL)initialRequest

--- a/Tests/gui/NSColorPanel/pickerMode.m
+++ b/Tests/gui/NSColorPanel/pickerMode.m
@@ -1,0 +1,54 @@
+#import "Testing.h"
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSColorPanel.h>
+
+/* NSColorPanel -mode reports the mode set with -setMode: for each of the
+   standard colour-space pickers, not just RGB.  Before the fix the standard
+   picker stored its picker mask in place of the mode and -supportsMode: ignored
+   its argument, so only RGB round-tripped (by coincidence of mask 2 / mode 1).
+   Building the shared panel needs a window server, so the set skips without
+   one. */
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSColorPanel picker mode")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSColorPanel *cp = [NSColorPanel sharedColorPanel];
+
+      [cp setMode: NSGrayModeColorPanel];
+      PASS([cp mode] == NSGrayModeColorPanel,
+        "the picker mode round-trips to gray");
+
+      [cp setMode: NSRGBModeColorPanel];
+      PASS([cp mode] == NSRGBModeColorPanel,
+        "the picker mode round-trips to RGB");
+
+      [cp setMode: NSCMYKModeColorPanel];
+      PASS([cp mode] == NSCMYKModeColorPanel,
+        "the picker mode round-trips to CMYK");
+
+      [cp setMode: NSHSBModeColorPanel];
+      PASS([cp mode] == NSHSBModeColorPanel,
+        "the picker mode round-trips to HSB");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSColorPanel picker mode")
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSColorPanel -mode did not report the mode set with -setMode: for any picker other than RGB (e.g. after -setMode: NSHSBModeColorPanel, -mode still returned NSRGBModeColorPanel).

Root cause, in the standard colour picker (ColorPickers):

- Each GSStandardCSColorPicker subclass (Gray/RGB/CMYK/HSB) stored its picker *mask* (NSColorPanelRGBModeMask = 2, NSColorPanelHSBModeMask = 8, ...) in the currentMode ivar rather than the *mode* value (NSRGBModeColorPanel = 1, NSHSBModeColorPanel = 3, ...). -currentMode, and therefore NSColorPanel -mode, returned a mask.
- GSStandardCSColorPicker -supportsMode: returned `currentMode == NSRGBModeColorPanel`, ignoring its argument, so the container picked a sub-picker based on the accidental relationship between the mask and mode constants (mask 1 == mode 1) rather than the requested mode. Only RGB round-tripped, and it selected the wrong sub-picker.

Each subclass now stores its mode value, and -supportsMode: compares its argument to that mode. NSColorPanel -setMode: then selects the matching sub-picker and -mode reports it for all four standard modes.

Tests/gui/NSColorPanel/pickerMode.m round-trips gray, RGB, CMYK and HSB through -setMode:/-mode; three of the four fail against the previous behaviour. The existing default-mode and RGB assertions still pass.

Closes #758