### PR TITLE
Fix: let NSSegmentedControl select several segments

### DIFF
--- a/Headers/AppKit/NSSegmentedCell.h
+++ b/Headers/AppKit/NSSegmentedCell.h
@@ -29,13 +29,6 @@
 #import <AppKit/NSActionCell.h>
 #import <AppKit/NSSegmentedControl.h>
 
-// tracking types...
-typedef enum {
-  NSSegmentSwitchTrackingSelectOne = 0,
-  NSSegmentSwitchTrackingSelectAny = 1,
-  NSSegmentSwitchTrackingMomentary = 2 
-} NSSegmentSwitchTracking;
-
 // forward declarations
 @class NSMutableArray;
 @class NSImage;

--- a/Headers/AppKit/NSSegmentedControl.h
+++ b/Headers/AppKit/NSSegmentedControl.h
@@ -38,6 +38,12 @@ typedef enum _NSSegmentStyle {
   NSSegmentStyleCapsule = 5,
   NSSegmentStyleSmallSquare = 6
 } NSSegmentStyle;
+
+typedef enum {
+  NSSegmentSwitchTrackingSelectOne = 0,
+  NSSegmentSwitchTrackingSelectAny = 1,
+  NSSegmentSwitchTrackingMomentary = 2
+} NSSegmentSwitchTracking;
 #endif
 
 APPKIT_EXPORT_CLASS
@@ -51,6 +57,10 @@ APPKIT_EXPORT_CLASS
 - (void) setSelectedSegment: (NSInteger)segment;
 - (NSInteger) selectedSegment;
 - (void) selectSegmentWithTag: (NSInteger)tag;
+
+// Specifying tracking mode...
+- (void) setTrackingMode: (NSSegmentSwitchTracking)mode;
+- (NSSegmentSwitchTracking) trackingMode;
 
 // Working with individual segments...
 - (void) setWidth: (CGFloat)width forSegment: (NSInteger)segment;

--- a/Source/NSSegmentedCell.m
+++ b/Source/NSSegmentedCell.m
@@ -740,7 +740,10 @@
       NSRect frame = [segment frame];
       if(NSPointInRect(lastPoint,frame))
 	{
-	  [self setSelectedSegment: i];
+	  if (_segmentCellFlags._tracking_mode == NSSegmentSwitchTrackingSelectAny)
+	    [self setSelected: ![self isSelectedForSegment: i] forSegment: i];
+	  else
+	    [self setSelectedSegment: i];
 	  break;
 	}
     }

--- a/Source/NSSegmentedControl.m
+++ b/Source/NSSegmentedControl.m
@@ -73,6 +73,16 @@ static Class segmentedControlCellClass;
   [_cell selectSegmentWithTag: tag];
 }
 
+- (void) setTrackingMode: (NSSegmentSwitchTracking)mode
+{
+  [_cell setTrackingMode: mode];
+}
+
+- (NSSegmentSwitchTracking) trackingMode
+{
+  return [_cell trackingMode];
+}
+
 // Working with individual segments...
 - (void) setWidth: (CGFloat)width forSegment: (NSInteger)segment
 {

--- a/Tests/gui/NSSegmentedControl/multiSelect.m
+++ b/Tests/gui/NSSegmentedControl/multiSelect.m
@@ -1,0 +1,89 @@
+/* NSSegmentedControl forwards the tracking mode to its cell, so an application
+   can put it in NSSegmentSwitchTrackingSelectAny and select several segments at
+   once (for example a bold/italic/underline style toggle).  The default is
+   NSSegmentSwitchTrackingSelectOne, where selecting one segment deselects the
+   others.  Checked against AppKit on a macOS runner.  The control uses the theme
+   and font backend, so the set is skipped when the backend is unavailable. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSegmentedControl.h>
+
+static NSSegmentedControl *
+control(NSInteger count)
+{
+  NSSegmentedControl *sc = AUTORELEASE([[NSSegmentedControl alloc]
+    initWithFrame: NSMakeRect(0, 0, 200, 24)]);
+  [sc setSegmentCount: count];
+  return sc;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSSegmentedControl *sc;
+
+  START_SET("NSSegmentedControl multiSelect")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      sc = control(3);
+      PASS([sc trackingMode] == NSSegmentSwitchTrackingSelectOne,
+           "the default tracking mode is select-one");
+
+      /* select-one: a second selection replaces the first */
+      [sc setSelected: YES forSegment: 0];
+      [sc setSelected: YES forSegment: 2];
+      PASS([sc isSelectedForSegment: 0] == NO
+        && [sc isSelectedForSegment: 2] == YES,
+        "select-one keeps a single segment selected");
+      PASS([sc selectedSegment] == 2,
+        "selectedSegment is the one selected segment");
+
+      /* select-any: several segments can be selected together */
+      sc = control(3);
+      [sc setTrackingMode: NSSegmentSwitchTrackingSelectAny];
+      PASS([sc trackingMode] == NSSegmentSwitchTrackingSelectAny,
+        "the control forwards the tracking mode to its cell");
+
+      [sc setSelected: YES forSegment: 0];
+      [sc setSelected: YES forSegment: 1];
+      PASS([sc isSelectedForSegment: 0] == YES
+        && [sc isSelectedForSegment: 1] == YES,
+        "select-any keeps several segments selected");
+
+      [sc setSelected: NO forSegment: 0];
+      PASS([sc isSelectedForSegment: 0] == NO
+        && [sc isSelectedForSegment: 1] == YES,
+        "a segment can be deselected without clearing the others");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSSegmentedControl multiSelect")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSSegmentedControl did not expose the tracking mode: -setTrackingMode:/-trackingMode were implemented on NSSegmentedCell but not forwarded by the control, so `[control setTrackingMode: NSSegmentSwitchTrackingSelectAny]` had no effect and the cell stayed in select-one, deselecting every other segment. Multiple selection (for example a bold/italic/underline style toggle) was therefore not possible through the control.

- Forward -setTrackingMode:/-trackingMode from NSSegmentedControl to its cell.
- In select-any tracking, a click toggles the segment under the mouse instead of always selecting it.
- Move the NSSegmentSwitchTracking enum from NSSegmentedCell.h to NSSegmentedControl.h to match AppKit; NSSegmentedCell.h still sees it through its existing import of the control header.

The cell already keeps several segments selected in select-any mode and one in select-one; the selection semantics (default select-one, selectedSegment being the last selected) were checked against AppKit on a macOS runner. Tests/gui/NSSegmentedControl/multiSelect.m drives the tracking mode and selection through the control API.

Closes #237