### PR TITLE
Fix: do not abort when a stored printer has a missing PPD

### DIFF
--- a/Printing/GSLPR/GSLPRPrinter.m
+++ b/Printing/GSLPR/GSLPRPrinter.m
@@ -97,8 +97,20 @@
                         withHost: [printerEntry objectForKey: @"Host"]
                         withNote: [printerEntry objectForKey: @"Note"]];
 
-  [printer parsePPDAtPath: [printerEntry objectForKey: @"PPDPath"]];
-                         
+  /* A stored printer may reference a PPD that no longer exists; an unreadable
+     PPD is a warning here and the printer is returned without it, so the caller
+     uses its defaults. */
+  NS_DURING
+    {
+      [printer parsePPDAtPath: [printerEntry objectForKey: @"PPDPath"]];
+    }
+  NS_HANDLER
+    {
+      NSLog(@"Could not read the PPD for printer %@: %@",
+            name, [localException reason]);
+    }
+  NS_ENDHANDLER
+
   return AUTORELEASE(printer);
 }
 

--- a/Tests/gui/NSPrinter/badPPD.m
+++ b/Tests/gui/NSPrinter/badPPD.m
@@ -1,0 +1,63 @@
+/* A printer stored in the GSLPRPrinters defaults can point at a PPD file that
+   has moved or been removed. Loading it must not raise an uncaught exception
+   (which aborts the application while it is only setting up printing); the
+   printer is returned without the PPD so the caller falls back to its defaults.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSDictionary.h>
+#include <Foundation/NSException.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSUserDefaults.h>
+
+#include <AppKit/NSPrinter.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSPrinter missing PPD")
+
+  NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+  id saved = [ud objectForKey: @"GSLPRPrinters"];
+  NSDictionary *entry;
+  NSDictionary *printers;
+  NSPrinter *printer = nil;
+  BOOL raised = NO;
+
+  entry = [NSDictionary dictionaryWithObjectsAndKeys:
+    @"/does/not/exist/Generic.ppd", @"PPDPath",
+    @"localhost", @"Host",
+    @"Unknown", @"Type",
+    @"test", @"Note",
+    nil];
+  printers = [NSDictionary dictionaryWithObject: entry forKey: @"MissingPPDPrinter"];
+  [ud setObject: printers forKey: @"GSLPRPrinters"];
+
+  NS_DURING
+    {
+      printer = [NSPrinter printerWithName: @"MissingPPDPrinter"];
+    }
+  NS_HANDLER
+    {
+      raised = YES;
+    }
+  NS_ENDHANDLER
+
+  PASS(raised == NO,
+       "loading a printer whose PPD is missing does not raise");
+  PASS(printer != nil,
+       "a printer is still returned when its PPD is missing");
+
+  if (saved != nil)
+    [ud setObject: saved forKey: @"GSLPRPrinters"];
+  else
+    [ud removeObjectForKey: @"GSLPRPrinters"];
+
+  END_SET("NSPrinter missing PPD")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
A printer stored under the `GSLPRPrinters` default can reference a PPD file that has moved or been removed (for example an old install path). GSLPRPrinter loads it with `-parsePPDAtPath:`, which raises `NSPPDParseException` for an unreadable file. Nothing catches it, so the application aborts while only setting up printing, e.g. `+[NSPrintInfo sharedPrintInfo]` -> `+[NSPrintInfo defaultPrinter]` -> `+[GSLPRPrinter printerWithName:]` -> `-parsePPDAtPath:` (as reported in #346 with Ink).

+[GSLPRPrinter printerWithName:] now catches the exception, logs a warning, and returns the printer without the PPD. `-[NSPrintInfo initWithDictionary:]` already falls back to its defaults (A4) when the printer provides no PPD values, so setup completes instead of aborting.

Test: Tests/gui/NSPrinter/badPPD.m sets a `GSLPRPrinters` entry with a non-existent PPD path and loads it; two assertions fail against the previous code (it raises and returns nil). Verified with the GSLPR bundle rebuilt and loaded from the user domain.

Note: GSCUPSPrinter loads a PPD the same way and has the same exposure. I left it out of this change since I could not exercise the CUPS path here; happy to follow up if you would like it covered too.

Addresses the first item in #346 (missing PPD on open should not abort). The print/page-setup path and whether per-app PPD storage is needed are separate items in that issue.