### PR TITLE
Fix: do not abort when a CUPS printer PPD is unreadable

### DIFF
--- a/Printing/GSCUPS/GSCUPSPrinter.m
+++ b/Printing/GSCUPS/GSCUPSPrinter.m
@@ -109,7 +109,18 @@ static BOOL didWarn;
 		      withHost: @"Unknown"
 		      withNote: @"Automatically Generated"];
 
-      [printer parsePPDAtPath: ppdPath];
+      /* An unreadable fallback PPD is a warning here and the printer is
+         returned without it, so the caller uses its defaults. */
+      NS_DURING
+        {
+          [printer parsePPDAtPath: ppdPath];
+        }
+      NS_HANDLER
+        {
+          NSLog(@"Could not read the fallback PPD %@: %@",
+                ppdPath, [localException reason]);
+        }
+      NS_ENDHANDLER
 
       return AUTORELEASE(printer);
     }
@@ -124,7 +135,19 @@ static BOOL didWarn;
 
   if( ppdFile )
     {
-      [printer parsePPDAtPath: [NSString stringWithCString: ppdFile]];
+      /* The PPD CUPS provides may be unreadable; an unreadable PPD is a warning
+         here and the printer is returned without it, so the caller uses its
+         defaults rather than aborting. */
+      NS_DURING
+        {
+          [printer parsePPDAtPath: [NSString stringWithCString: ppdFile]];
+        }
+      NS_HANDLER
+        {
+          NSLog(@"Could not read the PPD for printer %@: %@",
+                name, [localException reason]);
+        }
+      NS_ENDHANDLER
       unlink( ppdFile );
     }
   else


### PR DESCRIPTION
Companion to #788 for the CUPS printing backend. GSCUPSPrinter loads a PPD with `-parsePPDAtPath:` in two places: the fallback (dummy) printer, and a real CUPS printer via the file returned by `cupsGetPPD`. As with GSLPR, an unreadable PPD makes `-parsePPDAtPath:` raise `NSPPDParseException`, and with nothing catching it the application aborts while only setting up printing.

Both calls now catch the exception, log a warning, and return the printer without the PPD, so `NSPrintInfo` falls back to its defaults.

Testing note: this mirrors the GSLPR change in #788, which has an automated test (Tests/gui/NSPrinter/badPPD.m). I could not add an equivalent automated test for the CUPS path here: it is driven by `cupsGetPPD` against a live CUPS printer, and the fallback path is guarded by an `NSAssert`, so neither is reachable without a configured CUPS printer. I verified the change compiles against libcups and the logic is identical to the tested GSLPR fix. Happy to adjust if you have a preferred way to exercise the CUPS path in CI.

Relates to #346 (missing/unreadable PPD should not abort).