### PR TITLE
Fix: autohidesScrollers respects hasHorizontal/VerticalScroller

### DIFF
--- a/Headers/AppKit/NSScrollView.h
+++ b/Headers/AppKit/NSScrollView.h
@@ -79,6 +79,8 @@ APPKIT_EXPORT_CLASS
   NSScrollElasticity _vertScrollElasticity;
   NSScrollerStyle _scrollerStyle;
   NSScrollerKnobStyle _scrollerKnobStyle;
+  BOOL _hasHorizScrollerRequested;
+  BOOL _hasVertScrollerRequested;
 }
 
 /* Calculating layout */

--- a/Source/NSScrollView.m
+++ b/Source/NSScrollView.m
@@ -107,6 +107,8 @@ typedef struct _scrollViewFlags
 - (void) _synchronizeHeaderAndCornerView;
 - (void) _themeDidActivate: (NSNotification*)notification;
 - (void) _autohideScrollers;
+- (void) _setHasHorizScroller: (BOOL)flag;
+- (void) _setHasVertScroller: (BOOL)flag;
 @end
 
 @implementation NSScrollView
@@ -317,6 +319,12 @@ static CGFloat scrollerWidth;
 
 - (void) setHasHorizontalScroller: (BOOL)flag
 {
+  _hasHorizScrollerRequested = flag;
+  [self _setHasHorizScroller: flag];
+}
+
+- (void) _setHasHorizScroller: (BOOL)flag
+{
   if (_hasHorizScroller == flag)
     return;
 
@@ -357,6 +365,12 @@ static CGFloat scrollerWidth;
 }
 
 - (void) setHasVerticalScroller: (BOOL)flag
+{
+  _hasVertScrollerRequested = flag;
+  [self _setHasVertScroller: flag];
+}
+
+- (void) _setHasVertScroller: (BOOL)flag
 {
   if (_hasVertScroller == flag)
     return;
@@ -866,23 +880,30 @@ static CGFloat scrollerWidth;
   availWidth = clipSize.width + (_hasVertScroller ? footprint : 0.0);
   availHeight = clipSize.height + (_hasHorizScroller ? footprint : 0.0);
 
-  needsVert = documentSize.height > availHeight;
-  needsHoriz = documentSize.width > availWidth;
+  /* Only an axis that the client asked to scroll may get a scroller. Gating
+     each axis by its requested flag also keeps a disabled axis out of the
+     coupling below, so it does not reserve space for a scroller that will not
+     appear. */
+  needsVert = _hasVertScrollerRequested && (documentSize.height > availHeight);
+  needsHoriz = _hasHorizScrollerRequested && (documentSize.width > availWidth);
   if (needsVert)
     {
-      needsHoriz = documentSize.width > (availWidth - footprint);
+      needsHoriz = _hasHorizScrollerRequested
+        && (documentSize.width > (availWidth - footprint));
     }
   if (needsHoriz)
     {
-      needsVert = documentSize.height > (availHeight - footprint);
+      needsVert = _hasVertScrollerRequested
+        && (documentSize.height > (availHeight - footprint));
     }
   if (needsVert)
     {
-      needsHoriz = documentSize.width > (availWidth - footprint);
+      needsHoriz = _hasHorizScrollerRequested
+        && (documentSize.width > (availWidth - footprint));
     }
 
-  [self setHasVerticalScroller: needsVert];
-  [self setHasHorizontalScroller: needsHoriz];
+  [self _setHasVertScroller: needsVert];
+  [self _setHasHorizScroller: needsHoriz];
 }
 
 - (void) reflectScrolledClipView: (NSClipView *)aClipView
@@ -1708,6 +1729,8 @@ GSOppositeEdge(NSRectEdge edge)
           _borderType = flags & 3;
           _hasVertScroller = (flags & 16) == 16;
           _hasHorizScroller = (flags & 32) == 32;
+          _hasVertScrollerRequested = _hasVertScroller;
+          _hasHorizScrollerRequested = _hasHorizScroller;
           _autohidesScrollers = (flags & 512) == 512;
         }
 
@@ -1771,13 +1794,15 @@ GSOppositeEdge(NSRectEdge edge)
       [aDecoder decodeValueOfObjCType: @encode(float) at: &_vPageScroll];
       
       [aDecoder decodeValueOfObjCType: @encode(BOOL) at: &_hasHorizScroller];
+      _hasHorizScrollerRequested = _hasHorizScroller;
       if (_hasHorizScroller)
         [aDecoder decodeValueOfObjCType: @encode(id) at: &_horizScroller];
-      
+
       [aDecoder decodeValueOfObjCType: @encode(BOOL) at: &_hasVertScroller];
+      _hasVertScrollerRequested = _hasVertScroller;
       if (_hasVertScroller)
         [aDecoder decodeValueOfObjCType: @encode(id) at: &_vertScroller];
-      
+
       [aDecoder decodeValueOfObjCType: @encode(BOOL) at: &_hasHorizRuler];
       if (_hasHorizRuler)
         [aDecoder decodeValueOfObjCType: @encode(id) at: &_horizRuler];

--- a/Tests/gui/NSScrollView/autohidesScrollers.m
+++ b/Tests/gui/NSScrollView/autohidesScrollers.m
@@ -6,13 +6,17 @@
 #import <AppKit/NSScrollView.h>
 #import <AppKit/NSView.h>
 
-/* Lay out an autohiding scroll view whose document is a given size and
-   return whether each scroller ended up visible.  With the pre-#234 code a
-   document sized so that showing one scroller forces the other on (and vice
-   versa) makes -reflectScrolledClipView: and -tile recurse without bound and
-   the process crashes, so simply returning from here is the regression check. */
+/* Lay out an autohiding scroll view whose document is a given size, with each
+   axis configured to want a scroller or not, and return whether each scroller
+   ended up shown.  With the pre-#234 code a document sized so that showing one
+   scroller forces the other (and vice versa) makes -reflectScrolledClipView:
+   and -tile recurse without bound and the process crashes, so simply returning
+   from here is that regression check.  Autohiding only ever shows a scroller on
+   an axis the client asked to have one (#236): an axis set to NO stays without
+   a scroller even when its content overflows. */
 static void
-layoutScrollView(NSSize frame, NSSize document, BOOL *hasVert, BOOL *hasHoriz)
+layoutScrollView(NSSize frame, NSSize document, BOOL wantHoriz, BOOL wantVert,
+                 BOOL *hasVert, BOOL *hasHoriz)
 {
   NSScrollView *sv = AUTORELEASE([[NSScrollView alloc]
     initWithFrame: NSMakeRect(0, 0, frame.width, frame.height)]);
@@ -21,8 +25,8 @@ layoutScrollView(NSSize frame, NSSize document, BOOL *hasVert, BOOL *hasHoriz)
 
   [sv setBorderType: NSNoBorder];
   [sv setDocumentView: doc];
-  [sv setHasVerticalScroller: YES];
-  [sv setHasHorizontalScroller: NO];
+  [sv setHasVerticalScroller: wantVert];
+  [sv setHasHorizontalScroller: wantHoriz];
   [sv setAutohidesScrollers: YES];
 
   [doc setFrameSize: document];
@@ -54,27 +58,43 @@ main(int argc, const char **argv)
 
       /* The size that used to trigger the runaway recursion (bug #234): the
          document is within a scroller width of the frame on both axes, so the
-         two scrollers keep flipping each other's visibility.  Reaching the
-         next line at all means the recursion is now bounded. */
-      layoutScrollView(frame, NSMakeSize(792, 595), &hasVert, &hasHoriz);
+         two scrollers keep flipping each other's visibility.  Reaching the next
+         line at all means the recursion is now bounded. */
+      layoutScrollView(frame, NSMakeSize(792, 595), YES, YES, &hasVert, &hasHoriz);
       PASS(1, "autohidesScrollers does not recurse for a critical document size");
 
       /* A document that fits needs neither scroller. */
-      layoutScrollView(frame, NSMakeSize(400, 300), &hasVert, &hasHoriz);
+      layoutScrollView(frame, NSMakeSize(400, 300), YES, YES, &hasVert, &hasHoriz);
       PASS(hasVert == NO && hasHoriz == NO,
         "no scrollers are shown when the document fits");
 
       /* A document taller than the frame needs a vertical scroller; that
-         scroller then narrows the clip view enough that the horizontal
-         scroller is needed too. */
-      layoutScrollView(frame, NSMakeSize(792, 640), &hasVert, &hasHoriz);
+         scroller then narrows the clip view enough that the horizontal scroller
+         is needed too. */
+      layoutScrollView(frame, NSMakeSize(792, 640), YES, YES, &hasVert, &hasHoriz);
       PASS(hasVert == YES && hasHoriz == YES,
         "a scroller that narrows the clip view brings in the other scroller");
 
       /* Symmetrically for a document wider than the frame. */
-      layoutScrollView(frame, NSMakeSize(840, 595), &hasVert, &hasHoriz);
+      layoutScrollView(frame, NSMakeSize(840, 595), YES, YES, &hasVert, &hasHoriz);
       PASS(hasVert == YES && hasHoriz == YES,
         "a wide document brings in both scrollers");
+
+      /* #236: a horizontal scroller the client did not ask for is not shown
+         even when the document is wider than the frame. */
+      layoutScrollView(frame, NSMakeSize(900, 500), NO, YES, &hasVert, &hasHoriz);
+      PASS(hasHoriz == NO,
+        "a disabled horizontal scroller stays hidden for a wide document");
+      PASS(hasVert == NO,
+        "the vertical scroller is not needed once the horizontal one cannot show");
+
+      /* #236: symmetrically, a disabled vertical scroller stays hidden for a
+         tall document. */
+      layoutScrollView(frame, NSMakeSize(500, 900), YES, NO, &hasVert, &hasHoriz);
+      PASS(hasVert == NO,
+        "a disabled vertical scroller stays hidden for a tall document");
+      PASS(hasHoriz == NO,
+        "the horizontal scroller is not needed once the vertical one cannot show");
     }
   NS_HANDLER
     if ([[localException name] isEqualToString: NSInternalInconsistencyException]


### PR DESCRIPTION
With `autohidesScrollers` set to YES, an axis configured to have no scroller (`setHasHorizontalScroller: NO`) still got one when its content overflowed, because `-_autohideScrollers` decided visibility purely from the content size. NSScrollView tracked a single flag per axis (`_hasHorizScroller`/`_hasVertScroller`) that served as both the configured setting and the current visibility, so the autohide pass overwrote the client setting.

This tracks the configured setting separately (`_hasHorizScrollerRequested`/`_hasVertScrollerRequested`), set from the public setters and when decoding, and gates the autohide pass by it: a scroller is only shown on an axis the client asked to scroll. The public setters keep their behaviour through an internal visibility setter that the autohide pass now uses, so it no longer disturbs the configured setting.

**ABI note:** this appends two BOOL ivars to NSScrollView, changing its ivar layout, in the same way as other recent state fixes. The library is built as a whole and the ivars are at the end of the block. Say if you would rather handle the state another way.

Test: Tests/gui/NSScrollView/autohidesScrollers.m is extended (it previously asserted the buggy behaviour, that a disabled scroller was shown). Two new assertions fail against the previous code: a horizontal scroller set to NO stays hidden for a wide document, and symmetrically for a disabled vertical scroller. The recursion regression from #234 and the two-axis coupling cases still pass.

Behaviour was checked against AppKit on a macOS runner. Note one further AppKit difference I did **not** change here: `-hasHorizontalScroller` on macOS returns the configured value, and autohide instead hides the scroller (`-[NSScroller isHidden]`) while keeping the property YES; GNUstep's getter returns the current visibility. Matching that would also touch the theme drawing (GSThemeDrawing reads the getter to lay out the scroller area), so I left the getter as-is and kept this change to the reported bug. Happy to follow up on the getter semantics if you want it.

Closes #236