### PR TITLE
Fix: define NSSplitViewControllerAutomaticDimension and default to it

### DIFF
--- a/Headers/AppKit/NSSplitViewController.h
+++ b/Headers/AppKit/NSSplitViewController.h
@@ -36,7 +36,9 @@ extern "C" {
 #endif
 
 @class NSSplitView, NSSplitViewItem, NSArray, NSMutableArray;
-  
+
+APPKIT_EXPORT const CGFloat NSSplitViewControllerAutomaticDimension;
+
 APPKIT_EXPORT_CLASS
 @interface NSSplitViewController : NSViewController
 {

--- a/Source/NSSplitViewController.m
+++ b/Source/NSSplitViewController.m
@@ -33,6 +33,10 @@
 
 #import "GSFastEnumeration.h"
 
+#include <float.h>
+
+const CGFloat NSSplitViewControllerAutomaticDimension = -FLT_MAX;
+
 @implementation NSSplitViewController
 - (instancetype) initWithNibName: (NSString *)nibNameOrNil
                           bundle: (NSBundle *)nibBundleOrNil
@@ -41,6 +45,7 @@
   if (self != nil)
     {
       _splitViewItems = [[NSMutableArray alloc] init];
+      _minimumThicknessForInlineSidebars = NSSplitViewControllerAutomaticDimension;
     }
   return self;
 }
@@ -189,6 +194,7 @@
       return nil;
     }
   _splitViewItems = [[NSMutableArray alloc] init];
+  _minimumThicknessForInlineSidebars = NSSplitViewControllerAutomaticDimension;
   if ([coder allowsKeyedCoding])
     {
       if ([coder containsValueForKey: @"NSSplitView"])

--- a/Tests/gui/NSSplitViewController/config.m
+++ b/Tests/gui/NSSplitViewController/config.m
@@ -2,8 +2,12 @@
 #import <AppKit/NSViewController.h>
 #import <AppKit/NSSplitViewController.h>
 
+#include <float.h>
+
 /* NSSplitViewController state: the minimum thickness for inline sidebars is a
-   plain property that round-trips and does not need a window server. */
+   plain property that round-trips and does not need a window server.  Its
+   default is NSSplitViewControllerAutomaticDimension (-FLT_MAX), matching
+   AppKit. */
 
 int
 main(int argc, const char **argv)
@@ -11,6 +15,12 @@ main(int argc, const char **argv)
   CREATE_AUTORELEASE_POOL(arp);
 
   NSSplitViewController *svc = AUTORELEASE([[NSSplitViewController alloc] init]);
+
+  PASS(NSSplitViewControllerAutomaticDimension == -FLT_MAX,
+    "the automatic dimension constant is -FLT_MAX");
+  PASS([svc minimumThicknessForInlineSidebars]
+       == NSSplitViewControllerAutomaticDimension,
+    "the default minimum inline sidebar thickness is the automatic dimension");
 
   [svc setMinimumThicknessForInlineSidebars: 120.0];
   PASS([svc minimumThicknessForInlineSidebars] == 120.0,


### PR DESCRIPTION
AppKit exports `NSSplitViewControllerAutomaticDimension` and documents it as the default value of `-minimumThicknessForInlineSidebars`; on a macOS runner both the constant and the default read as `-FLT_MAX` (-3.40282e38). GNUstep did not define the constant and defaulted the property to 0.

- Declare `APPKIT_EXPORT const CGFloat NSSplitViewControllerAutomaticDimension;` in NSSplitViewController.h.
- Define it as `-FLT_MAX` in NSSplitViewController.m.
- Initialise `_minimumThicknessForInlineSidebars` to it in both initialisers (nib and coder; the coder keyed branch keeps a decoded value when present).

The other NSSplitViewController work this was waiting on (#706/#707/#708) has merged, so this is now standalone.

Test: Tests/gui/NSSplitViewController/config.m checks the constant value and the default. The default assertion fails against the previous code (default 0); the property round-trip assertions still pass.

Closes #753