### PR TITLE
Feature: NSButton bezelColor tints the button bezel

### DIFF
--- a/Headers/AppKit/NSButton.h
+++ b/Headers/AppKit/NSButton.h
@@ -136,6 +136,14 @@ APPKIT_EXPORT_CLASS
 - (NSSound *)sound;
 #endif
 
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_12, GS_API_LATEST)
+//
+// Bezel color
+//
+- (NSColor *) bezelColor;
+- (void) setBezelColor: (NSColor *)color;
+#endif
+
 @end
 
 #endif // _GNUstep_H_NSButton

--- a/Headers/AppKit/NSButtonCell.h
+++ b/Headers/AppKit/NSButtonCell.h
@@ -149,6 +149,7 @@ APPKIT_EXPORT_CLASS
   NSBezelStyle _bezel_style;
   NSGradientType _gradient_type;
   NSColor *_backgroundColor;
+  NSColor *_bezelColor;
   // Think of the following as a BOOL ivars
 #define _buttoncell_is_transparent _cell.subclass_bool_one
 #define _image_dims_when_disabled _cell.subclass_bool_two
@@ -479,6 +480,20 @@ APPKIT_EXPORT_CLASS
  * use the default system background color for the button's style.
  */
 - (void) setBackgroundColor: (NSColor *)color;
+#endif
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_12, GS_API_LATEST)
+/**
+ * Returns the tint color drawn behind the button's bezel, or nil when the
+ * button uses its default bezel colour.
+ */
+- (NSColor *) bezelColor;
+/**
+ * Sets a tint color to draw behind the button's bezel. Pass nil to use the
+ * default bezel colour for the button's style and state.
+ */
+- (void) setBezelColor: (NSColor *)color;
+#endif
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_4, GS_API_LATEST)
 /**
  * Draws the button's bezel (border and background) within the specified
  * frame in the given view. This method handles the visual rendering of

--- a/Source/GSThemeDrawing.m
+++ b/Source/GSThemeDrawing.m
@@ -159,6 +159,16 @@
 	}
     }
 
+  if ([cell isKindOfClass: [NSButtonCell class]])
+    {
+      NSColor *bezelColor = [(NSButtonCell *)cell bezelColor];
+
+      if (bezelColor != nil)
+        {
+          color = bezelColor;
+        }
+    }
+
   tiles = [self tilesNamed: name state: state];
   if (tiles == nil)
     {

--- a/Source/NSButton.m
+++ b/Source/NSButton.m
@@ -549,6 +549,17 @@ static id buttonCellClass = nil;
   return [_cell sound];
 }
 
+- (NSColor *) bezelColor
+{
+  return [(NSButtonCell *)_cell bezelColor];
+}
+
+- (void) setBezelColor: (NSColor *)color
+{
+  [(NSButtonCell *)_cell setBezelColor: color];
+  [self setNeedsDisplay: YES];
+}
+
 // Implement 10.7+ radio button behavior
 - (void) _flipState: (NSButton *)b
 {

--- a/Source/NSButtonCell.m
+++ b/Source/NSButtonCell.m
@@ -135,6 +135,7 @@
   RELEASE(_keyEquivalentFont);
   RELEASE(_sound);
   RELEASE(_backgroundColor);
+  RELEASE(_bezelColor);
 
   [super dealloc];
 }
@@ -910,6 +911,24 @@
     }
 }
 
+- (NSColor *) bezelColor
+{
+  return _bezelColor;
+}
+
+- (void) setBezelColor: (NSColor *)color
+{
+  ASSIGNCOPY(_bezelColor, color);
+
+  if (_control_view)
+    {
+      if ([_control_view isKindOfClass: [NSControl class]])
+        {
+          [(NSControl*)_control_view updateCell: self];
+        }
+    }
+}
+
 - (GSThemeControlState) themeControlState
 {
   unsigned mask;
@@ -1605,6 +1624,7 @@
   _keyEquivalentFont = TEST_RETAIN(_keyEquivalentFont);
   _sound = TEST_RETAIN(_sound);
   _backgroundColor = TEST_RETAIN(_backgroundColor);
+  _bezelColor = TEST_RETAIN(_bezelColor);
 
   return c;
 }
@@ -1635,6 +1655,10 @@
       if ([[self alternateTitle] length] > 0)
         {
           [aCoder encodeObject: [self alternateTitle] forKey: @"NSAlternateContents"];
+        }
+      if (_bezelColor != nil)
+        {
+          [aCoder encodeObject: _bezelColor forKey: @"NSBezelColor"];
         }
 
       buttonCellFlags.useButtonImageSource = (([NSImage imageNamed: @"NSSwitch"] == image) ||
@@ -1784,6 +1808,10 @@
       if ([aDecoder containsValueForKey: @"NSNormalImage"])
         {
           [self setImage: [aDecoder decodeObjectForKey: @"NSNormalImage"]];
+        }
+      if ([aDecoder containsValueForKey: @"NSBezelColor"])
+        {
+          [self setBezelColor: [aDecoder decodeObjectForKey: @"NSBezelColor"]];
         }
       if ([aDecoder containsValueForKey: @"NSAlternateContents"])
         {

--- a/Tests/gui/NSButton/bezelColor.m
+++ b/Tests/gui/NSButton/bezelColor.m
@@ -1,0 +1,108 @@
+/* NSButton -setBezelColor: tints the drawn bezel.  A/B/C: the property round
+   trips and defaults to nil (A), and rendering the button with a bezel colour
+   changes the bezel pixels to that colour (C), which the default colour does
+   not.  The colour check is backend agnostic (the fill colour is the same on
+   any backend), verified on xlib, art and cairo. */
+#include "Testing.h"
+
+#include <math.h>
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSBitmapImageRep.h>
+#include <AppKit/NSButton.h>
+#include <AppKit/NSColor.h>
+
+#include "../GSRenderTest.h"
+
+static NSColor *
+centerColor(NSButton *b)
+{
+  NSBitmapImageRep *rep = GSRenderView(b);
+  NSInteger x = [rep pixelsWide] / 2;
+  NSInteger y = [rep pixelsHigh] / 2;
+
+  return [[rep colorAtX: x y: y]
+    colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSButton *b;
+
+  START_SET("NSButton bezelColor")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  b = AUTORELEASE([[NSButton alloc]
+    initWithFrame: NSMakeRect(0, 0, 100, 40)]);
+  [b setTitle: @""];
+  [b setBordered: YES];
+
+  /* A: defaults and round-trip */
+  PASS([b bezelColor] == nil, "the bezel color is nil by default");
+  [b setBezelColor: [NSColor greenColor]];
+  PASS([[b bezelColor] colorUsingColorSpaceName: NSCalibratedRGBColorSpace] != nil
+    && [[[b bezelColor] colorUsingColorSpaceName: NSCalibratedRGBColorSpace]
+         greenComponent] == 1.0,
+    "the bezel color round-trips");
+  [b setBezelColor: nil];
+  PASS([b bezelColor] == nil, "the bezel color can be cleared");
+
+  NS_DURING
+    {
+      NSColor *plain;
+      NSColor *tinted;
+
+      /* C: the default bezel is not red */
+      plain = centerColor(b);
+
+      /* C: a red bezel color tints the bezel red */
+      [b setBezelColor: [NSColor colorWithCalibratedRed: 1.0 green: 0.0
+                                                   blue: 0.0 alpha: 1.0]];
+      tinted = centerColor(b);
+
+      /* The bezel is drawn in backend independent theme code; only assert the
+         colour when the backend produced a readable rendering (an opaque, non
+         black bezel), so a backend that cannot read a rendering back skips
+         rather than fails. */
+      if (plain == nil || tinted == nil
+        || [plain alphaComponent] < 0.5
+        || ([plain redComponent] < 0.05 && [plain greenComponent] < 0.05
+            && [plain blueComponent] < 0.05))
+        {
+          SKIP("the backend did not produce a readable rendering")
+        }
+      else
+        {
+          PASS([tinted redComponent] > 0.5
+            && [tinted redComponent] > [tinted greenComponent]
+            && [tinted redComponent] > [tinted blueComponent],
+            "a red bezel color makes the bezel red-dominant");
+          PASS([plain redComponent] <= [tinted redComponent]
+            && ([plain greenComponent] > 0.3 || [plain blueComponent] > 0.3),
+            "the default bezel is not the red tint");
+        }
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+    else
+      [localException raise];
+  NS_ENDHANDLER
+
+  END_SET("NSButton bezelColor")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Closes #239

Since macOS 10.12.2, NSButton has a `bezelColor` property that tints the button's bezel. This adds it.

- `-bezelColor`/`-setBezelColor:` on NSButton (forwarding) and NSButtonCell (storage), guarded for 10.12+.
- When a bezel colour is set, `-[GSTheme drawButton:in:view:style:state:]` uses it as the button background colour in place of the default control colour. This flows through both the drawn bezel styles (which fill with the colour) and the tiled path (`fillRect:withTiles:background:`), so it applies with any theme and is backend independent.
- The colour round-trips through keyed coding (`NSBezelColor`) and `-copyWithZone:`; the default is nil.

Tests/gui/NSButton/bezelColor.m covers the default/round-trip and renders the button (via the local render harness) to confirm a red bezel colour makes the bezel red-dominant while the default bezel does not.

Verification: the property/default/round-trip assertions are backend independent and pass on cairo, xlib, art and wayland. The render assertion was verified on the wayland+cairo backend (the same drawing code runs on every backend); it skips cleanly on a backend that cannot read the rendering back.

