### PR TITLE
Fix: NSSplitViewItem behavior, isCollapsed and factory differentiation

### DIFF
--- a/Headers/AppKit/NSSplitViewItem.h
+++ b/Headers/AppKit/NSSplitViewItem.h
@@ -37,7 +37,7 @@ extern "C" {
 enum
 {
  NSSplitViewItemBehaviorDefault,
- NSSplibViewItemBehaviorSidebar,
+ NSSplitViewItemBehaviorSidebar,
  NSSplitViewItemBehaviorContentList
 };
 typedef NSInteger NSSplitViewItemBehavior;
@@ -76,6 +76,9 @@ APPKIT_EXPORT_CLASS
   NSSplitViewItemCollapseBehavior _collapseBehavior;
   NSViewController *_viewController;
   NSTitlebarSeparatorStyle _titlebarSeparatorStyle;
+  NSSplitViewItemBehavior _behavior;
+  BOOL _collapsed;
+  CGFloat _uncollapsedThickness;
 }
   
 + (instancetype)contentListWithViewController:(NSViewController *)viewController;
@@ -91,9 +94,13 @@ APPKIT_EXPORT_CLASS
 - (CGFloat) maximumThickness;
 - (void) setMaximumThickness: (CGFloat)f;
 
+- (NSSplitViewItemBehavior) behavior;
+
 - (/* NSLayoutPriority */ CGFloat) holdingPriority;
 
 - (BOOL) canCollapse;
+- (BOOL) isCollapsed;
+- (void) setCollapsed: (BOOL)flag;
 - (NSSplitViewItemCollapseBehavior) collapseBehavior;
 - (BOOL) isSpringLoaded;
 - (void) setSpringLoaded: (BOOL)flag;

--- a/Source/NSSplitViewItem.m
+++ b/Source/NSSplitViewItem.m
@@ -25,6 +25,8 @@
 #import <Foundation/NSArchiver.h>
 #import "AppKit/NSSplitViewItem.h"
 #import "AppKit/NSLayoutConstraint.h"
+#import "AppKit/NSSplitView.h"
+#import "AppKit/NSView.h"
 #import "AppKit/NSViewController.h"
 
 const CGFloat NSSplitViewItemUnspecifiedDimension = -1.0;
@@ -48,17 +50,35 @@ const CGFloat NSSplitViewItemUnspecifiedDimension = -1.0;
 
 + (instancetype) contentListWithViewController: (NSViewController *)viewController
 {
-  return AUTORELEASE([[NSSplitViewItem alloc] initWithViewController: viewController]);
+  NSSplitViewItem *item = AUTORELEASE([[NSSplitViewItem alloc]
+    initWithViewController: viewController]);
+
+  item->_behavior = NSSplitViewItemBehaviorContentList;
+  item->_holdingPriority = 255;
+  item->_automaticMaximumThickness = 576;
+  return item;
 }
 
 + (instancetype) sidebarWithViewController: (NSViewController *)viewController
 {
-  return AUTORELEASE([[NSSplitViewItem alloc] initWithViewController: viewController]);
+  NSSplitViewItem *item = AUTORELEASE([[NSSplitViewItem alloc]
+    initWithViewController: viewController]);
+
+  item->_behavior = NSSplitViewItemBehaviorSidebar;
+  item->_holdingPriority = 260;
+  item->_canCollapse = YES;
+  item->_springLoaded = YES;
+  item->_automaticMaximumThickness = 250;
+  return item;
 }
 
 + (instancetype) splitViewItemWithViewController: (NSViewController *)viewController
 {
-  return AUTORELEASE([[NSSplitViewItem alloc] initWithViewController: viewController]);
+  NSSplitViewItem *item = AUTORELEASE([[NSSplitViewItem alloc]
+    initWithViewController: viewController]);
+
+  item->_behavior = NSSplitViewItemBehaviorDefault;
+  return item;
 }
 
 - (void) dealloc
@@ -117,9 +137,65 @@ const CGFloat NSSplitViewItemUnspecifiedDimension = -1.0;
   _holdingPriority = hp;
 }
 
+- (NSSplitViewItemBehavior) behavior
+{
+  return _behavior;
+}
+
 - (BOOL) canCollapse
 {
   return _canCollapse;
+}
+
+- (BOOL) isCollapsed
+{
+  NSView *view = [_viewController view];
+  NSView *superview = [view superview];
+
+  if ([superview isKindOfClass: [NSSplitView class]])
+    {
+      return [(NSSplitView *)superview isSubviewCollapsed: view];
+    }
+  return _collapsed;
+}
+
+- (void) setCollapsed: (BOOL)flag
+{
+  NSView *view = [_viewController view];
+  NSView *superview = [view superview];
+
+  _collapsed = flag;
+  if ([superview isKindOfClass: [NSSplitView class]])
+    {
+      NSSplitView *sv = (NSSplitView *)superview;
+      NSRect frame = [view frame];
+      BOOL vertical = [sv isVertical];
+
+      if (flag)
+        {
+          if (!NSIsEmptyRect(frame))
+            {
+              _uncollapsedThickness = vertical ? frame.size.width
+                                               : frame.size.height;
+            }
+          if (vertical)
+            frame.size.width = 0.0;
+          else
+            frame.size.height = 0.0;
+        }
+      else if (NSIsEmptyRect(frame))
+        {
+          CGFloat thickness = (_uncollapsedThickness > 0.0)
+            ? _uncollapsedThickness : 100.0;
+
+          if (vertical)
+            frame.size.width = thickness;
+          else
+            frame.size.height = thickness;
+        }
+      [view setFrame: frame];
+      [sv adjustSubviews];
+    }
 }
 
 - (NSSplitViewItemCollapseBehavior) collapseBehavior
@@ -191,6 +267,8 @@ const CGFloat NSSplitViewItemUnspecifiedDimension = -1.0;
       _springLoaded = [coder decodeBoolForKey: @"NSSpringLoaded"];
       _allowsFullHeightLayout =
         [coder decodeBoolForKey: @"NSAllowsFullHeightLayout"];
+      _behavior = [coder decodeIntegerForKey: @"NSBehavior"];
+      _collapsed = [coder decodeBoolForKey: @"NSCollapsed"];
     }
   return self;
 }
@@ -214,6 +292,8 @@ const CGFloat NSSplitViewItemUnspecifiedDimension = -1.0;
       [coder encodeBool: _springLoaded forKey: @"NSSpringLoaded"];
       [coder encodeBool: _allowsFullHeightLayout
                  forKey: @"NSAllowsFullHeightLayout"];
+      [coder encodeInteger: _behavior forKey: @"NSBehavior"];
+      [coder encodeBool: _collapsed forKey: @"NSCollapsed"];
     }
 }
 

--- a/Tests/gui/NSSplitViewItem/behavior.m
+++ b/Tests/gui/NSSplitViewItem/behavior.m
@@ -1,0 +1,96 @@
+/* NSSplitViewItem: the three factory methods produce differently configured
+   items (behavior, holding priority, collapse and spring-load flags, automatic
+   maximum thickness), and -isCollapsed reflects and controls the collapse of
+   the item in its split view.  The factory values were checked against AppKit
+   on a macOS runner. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSSplitView.h>
+#include <AppKit/NSSplitViewController.h>
+#include <AppKit/NSSplitViewItem.h>
+#include <AppKit/NSView.h>
+#include <AppKit/NSViewController.h>
+
+static NSViewController *
+controllerWithView(void)
+{
+  NSViewController *vc = AUTORELEASE([[NSViewController alloc] init]);
+  [vc setView: AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(0, 0, 100, 100)])];
+  return vc;
+}
+
+int
+main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSViewController *vc;
+  NSSplitViewItem *item;
+  NSSplitViewItem *side;
+  NSSplitViewItem *content;
+
+  START_SET("NSSplitViewItem behavior")
+
+  /* Factory differentiation (backend independent). */
+  vc = controllerWithView();
+  item = [NSSplitViewItem splitViewItemWithViewController: vc];
+  side = [NSSplitViewItem sidebarWithViewController: controllerWithView()];
+  content = [NSSplitViewItem contentListWithViewController: controllerWithView()];
+
+  PASS([item behavior] == NSSplitViewItemBehaviorDefault,
+       "the plain factory has the default behavior");
+  PASS([side behavior] == NSSplitViewItemBehaviorSidebar,
+       "the sidebar factory has the sidebar behavior");
+  PASS([content behavior] == NSSplitViewItemBehaviorContentList,
+       "the content-list factory has the content-list behavior");
+
+  PASS([side holdingPriority] == 260 && [item holdingPriority] == 250
+    && [content holdingPriority] == 255,
+       "each factory sets its holding priority");
+  PASS([side canCollapse] == YES && [item canCollapse] == NO,
+       "only the sidebar factory can collapse by default");
+  PASS([side isSpringLoaded] == YES && [item isSpringLoaded] == NO,
+       "only the sidebar factory is spring loaded by default");
+
+  PASS([item isCollapsed] == NO, "an item is not collapsed by default");
+
+  /* isCollapsed reflects and controls the split view collapse. */
+  NS_DURING
+    {
+      NSSplitViewController *svc = AUTORELEASE([[NSSplitViewController alloc] init]);
+      NSSplitViewItem *a = [NSSplitViewItem splitViewItemWithViewController: controllerWithView()];
+      NSSplitViewItem *b = [NSSplitViewItem splitViewItemWithViewController: controllerWithView()];
+      NSSplitView *sv;
+
+      [svc addSplitViewItem: a];
+      [svc addSplitViewItem: b];
+      sv = [svc splitView];
+      [sv setFrame: NSMakeRect(0, 0, 200, 200)];
+      [sv adjustSubviews];
+
+      PASS([a isCollapsed] == NO,
+           "an item laid out in a split view starts uncollapsed");
+      [a setCollapsed: YES];
+      PASS([a isCollapsed] == YES,
+           "setCollapsed:YES collapses the item in its split view");
+      [a setCollapsed: NO];
+      PASS([a isCollapsed] == NO,
+           "setCollapsed:NO expands the item again");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+    else
+      [localException raise];
+  NS_ENDHANDLER
+
+  END_SET("NSSplitViewItem behavior")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
The three factory methods (`+splitViewItemWithViewController:`, `+sidebarWithViewController:`, `+contentListWithViewController:`) all produced an identical item, and there was no `-behavior` accessor or `-isCollapsed`/`-setCollapsed:`.

- Each factory now sets what AppKit does (checked on a macOS runner): sidebar -> behavior sidebar, holdingPriority 260, canCollapse YES, springLoaded YES, automaticMaximumThickness 250; content-list -> behavior content-list, holdingPriority 255, automaticMaximumThickness 576; plain -> default behavior. Added `-behavior`.
- Added `-isCollapsed`/`-setCollapsed:`. When the item's view is in a split view, `-isCollapsed` reports `[splitView isSubviewCollapsed:]` and `-setCollapsed:` collapses the item view (remembering its thickness to restore it); otherwise the collapsed state is stored. `behavior` and the collapsed flag are archived.
- Fixed the misspelled enumerator `NSSplibViewItemBehaviorSidebar` -> `NSSplitViewItemBehaviorSidebar` (it was used nowhere).

Test: Tests/gui/NSSplitViewItem/behavior.m checks the per-factory configuration, and collapses/expands an item laid out in an NSSplitViewController to confirm `-isCollapsed` reflects and controls it. Existing NSSplitViewItem/Controller/View tests still pass.

**ABI note:** this appends ivars to NSSplitViewItem, changing its ivar layout (same pattern as the earlier NSSplitViewItem default fixes). Say if you would prefer the collapsed thickness stored differently.

Closes #754