### PR TITLE
Use ASSIGNMUTABLECOPY in -_setFontCollectionDictionary:

### DIFF
--- a/Source/NSFontCollection.m
+++ b/Source/NSFontCollection.m
@@ -288,10 +288,7 @@ static NSLock *_fontCollectionLock = nil;
 
 - (void) _setFontCollectionDictionary: (NSMutableDictionary *)dict
 {
-  NSMutableDictionary *d = [dict mutableCopy];
-
-  RELEASE(_fontCollectionDictionary);
-  _fontCollectionDictionary = d;
+  ASSIGNMUTABLECOPY(_fontCollectionDictionary, dict);
 }
 
 - (void) _setQueryDescriptors: (NSArray *)queryDescriptors


### PR DESCRIPTION
Follow-up to #763, which was merged before I could apply the review comment. -_setFontCollectionDictionary: did the mutable copy, release and assign by hand; ASSIGNMUTABLECOPY does the same.