### PR TITLE
Call the fuller convenience constructor from +sliderWithTarget:action:

### DIFF
--- a/Source/NSSlider.m
+++ b/Source/NSSlider.m
@@ -93,15 +93,11 @@ static Class cellClass;
 + (instancetype) sliderWithTarget: (id)target
                            action: (SEL)action
 {
-  NSSlider *slider = AUTORELEASE([[self alloc]
-    initWithFrame: NSMakeRect(0, 0, 100, 20)]);
-
-  [slider setMinValue: 0.0];
-  [slider setMaxValue: 1.0];
-  [slider setDoubleValue: 0.0];
-  [slider setTarget: target];
-  [slider setAction: action];
-  return slider;
+  return [self sliderWithValue: 0.0
+                      minValue: 0.0
+                      maxValue: 1.0
+                        target: target
+                        action: action];
 }
 
 + (instancetype) sliderWithValue: (double)value


### PR DESCRIPTION
Follow-up to #771, which was merged before I could apply the review comment. +sliderWithTarget:action: duplicated the setup; it now calls +sliderWithValue:minValue:maxValue:target:action: with the default range.