### PR TITLE
Return the configured value from -hasHorizontalScroller/-hasVerticalScroller

### DIFF
--- a/Source/NSScrollView.m
+++ b/Source/NSScrollView.m
@@ -1462,7 +1462,7 @@ GSOppositeEdge(NSRectEdge edge)
  */
 - (BOOL) hasHorizontalScroller
 {
-  return _hasHorizScroller;
+  return _hasHorizScrollerRequested;
 }
 
 /** <p>Returns whether the NSScrollView has a vertical ruler</p>
@@ -1478,7 +1478,7 @@ GSOppositeEdge(NSRectEdge edge)
  */
 - (BOOL) hasVerticalScroller
 {
-  return _hasVertScroller;
+  return _hasVertScrollerRequested;
 }
 
 /**<p>Returns the size of the NSScrollView's content view</p>

--- a/Tests/gui/NSScrollView/autohidesScrollers.m
+++ b/Tests/gui/NSScrollView/autohidesScrollers.m
@@ -34,8 +34,11 @@ layoutScrollView(NSSize frame, NSSize document, BOOL wantHoriz, BOOL wantVert,
   [sv setFrame: NSMakeRect(0, 0, frame.width, frame.height)];
   [sv tile];
 
-  *hasVert = [sv hasVerticalScroller];
-  *hasHoriz = [sv hasHorizontalScroller];
+  /* -hasVerticalScroller/-hasHorizontalScroller report the configured setting,
+     not the current autohidden visibility, so check whether each scroller is
+     actually shown by whether it is in the view hierarchy. */
+  *hasVert = ([[sv verticalScroller] superview] != nil);
+  *hasHoriz = ([[sv horizontalScroller] superview] != nil);
 }
 
 int
@@ -67,6 +70,25 @@ main(int argc, const char **argv)
       layoutScrollView(frame, NSMakeSize(400, 300), YES, YES, &hasVert, &hasHoriz);
       PASS(hasVert == NO && hasHoriz == NO,
         "no scrollers are shown when the document fits");
+
+      /* The getter reports the configured setting, not the autohidden
+         visibility, as on macOS. */
+      {
+        NSScrollView *sv = AUTORELEASE([[NSScrollView alloc]
+          initWithFrame: NSMakeRect(0, 0, frame.width, frame.height)]);
+        NSView *doc = AUTORELEASE([[NSView alloc]
+          initWithFrame: NSMakeRect(0, 0, 400, 300)]);
+        [sv setBorderType: NSNoBorder];
+        [sv setDocumentView: doc];
+        [sv setHasVerticalScroller: YES];
+        [sv setAutohidesScrollers: YES];
+        [sv reflectScrolledClipView: [sv contentView]];
+        [sv tile];
+        PASS([sv hasVerticalScroller] == YES,
+          "hasVerticalScroller reports the configured value when autohidden");
+        PASS([[sv verticalScroller] superview] == nil,
+          "the configured scroller is hidden for a document that fits");
+      }
 
       /* A document taller than the frame needs a vertical scroller; that
          scroller then narrows the clip view enough that the horizontal scroller


### PR DESCRIPTION
Follow-up to #790. As on macOS, -hasHorizontalScroller and -hasVerticalScroller now report the configured setting rather than the current autohidden visibility, returning the requested flags that #790 added. The autohidesScrollers test checked the getters for visibility, so it now checks whether each scroller is in the view hierarchy instead, and gains a case that the getter still reports the configured value while the scroller is autohidden.