### PR TITLE
Fix: default an NSProgressIndicator to threaded animation

### DIFF
--- a/Source/NSProgressIndicator.m
+++ b/Source/NSProgressIndicator.m
@@ -65,7 +65,7 @@
   _controlSize = NSRegularControlSize;
   [self setStyle: NSProgressIndicatorBarStyle];
   //_isVertical = NO;
-  //_usesThreadedAnimation = NO;
+  _usesThreadedAnimation = YES;
 
   return self;
 }

--- a/Tests/gui/NSProgressIndicator/progress.m
+++ b/Tests/gui/NSProgressIndicator/progress.m
@@ -51,6 +51,8 @@ main(int argc, char **argv)
            "the default control size is regular");
       PASS([pi style] == NSProgressIndicatorBarStyle,
            "the default style is the bar style");
+      PASS([pi usesThreadedAnimation] == YES,
+           "an indicator uses threaded animation by default");
 
       /* Setter round-trips. */
       [pi setIndeterminate: NO];


### PR DESCRIPTION
Fixes #658. A new NSProgressIndicator now uses threaded animation by default, matching AppKit, which changed the default of this property from NO to YES in Big Sur.