### PR TITLE
Use CREATE_AUTORELEASE_POOL in the NSSplitViewItem memory test

### DIFF
--- a/Tests/gui/NSSplitViewItem/memory.m
+++ b/Tests/gui/NSSplitViewItem/memory.m
@@ -24,13 +24,12 @@ static BOOL vcDeallocated;
 int main()
 {
   CREATE_AUTORELEASE_POOL(arp);
-  NSAutoreleasePool *pool;
   NSSplitViewItem *item;
   ProbeViewController *vc;
 
   /* Keep the only reference to the item so that releasing it below runs its
      deallocation. */
-  pool = [NSAutoreleasePool new];
+  CREATE_AUTORELEASE_POOL(pool);
   item = RETAIN([NSSplitViewItem splitViewItemWithViewController: nil]);
   RELEASE(pool);
 


### PR DESCRIPTION
Follow-up to #725: create the inner pool in the NSSplitViewItem memory test with CREATE_AUTORELEASE_POOL, as elsewhere.