### PR TITLE
Fix: send NSViewController layout methods

### DIFF
--- a/Headers/AppKit/NSViewController.h
+++ b/Headers/AppKit/NSViewController.h
@@ -104,6 +104,9 @@ APPKIT_EXPORT_CLASS
 - (void) viewDidAppear;
 - (void) viewWillDisappear;
 - (void) viewDidDisappear;
+- (void) updateViewConstraints;
+- (void) viewWillLayout;
+- (void) viewDidLayout;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_10, GS_API_LATEST)
 - (void) dismissViewController: (NSViewController *)viewController;

--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -5253,20 +5253,25 @@ static NSView* findByTag(NSView *view, NSInteger aTag, NSUInteger *level)
 
 - (void) layout
 {
+  NSViewController *vc = [NSViewController _viewControllerForView: self];
+  GSAutoLayoutEngine *engine;
+
+  [vc viewWillLayout];
+
   _needsLayout = NO;
 
-  GSAutoLayoutEngine *engine = [self _layoutEngine];
-  if (!engine)
+  engine = [self _layoutEngine];
+  if (engine)
     {
-      return;
+      NSArray *subviews = [self subviews];
+      FOR_IN (NSView *, subview, subviews)
+        NSRect subviewAlignmentRect =
+            [engine alignmentRectForView: subview];
+        [subview setFrame: subviewAlignmentRect];
+      END_FOR_IN (subviews);
     }
 
-  NSArray *subviews = [self subviews];
-  FOR_IN (NSView *, subview, subviews)
-    NSRect subviewAlignmentRect =
-        [engine alignmentRectForView: subview];
-    [subview setFrame: subviewAlignmentRect];
-  END_FOR_IN (subviews);
+  [vc viewDidLayout];
 }
 
 - (void) layoutSubtreeIfNeeded
@@ -5440,7 +5445,16 @@ static NSView* findByTag(NSView *view, NSInteger aTag, NSUInteger *level)
 
   if ([self needsUpdateConstraints])
     {
-      [self updateConstraints];
+      NSViewController *vc = [NSViewController _viewControllerForView: self];
+
+      if (vc != nil)
+        {
+          [vc updateViewConstraints];
+        }
+      else
+        {
+          [self updateConstraints];
+        }
     }
 }
 

--- a/Source/NSViewController.m
+++ b/Source/NSViewController.m
@@ -140,6 +140,19 @@ static void *viewControllerAssociationKey = &viewControllerAssociationKey;
 {
 }
 
+- (void) updateViewConstraints
+{
+  [[self view] updateConstraints];
+}
+
+- (void) viewWillLayout
+{
+}
+
+- (void) viewDidLayout
+{
+}
+
 - (void)setRepresentedObject:(id)representedObject
 {
   ASSIGN(_representedObject, representedObject);

--- a/Tests/gui/NSViewController/layout.m
+++ b/Tests/gui/NSViewController/layout.m
@@ -1,0 +1,93 @@
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSViewController.h>
+#import <AppKit/NSWindow.h>
+
+/* -[NSViewController viewWillLayout]/-viewDidLayout and -updateViewConstraints
+   were declared but never sent (gnustep/libs-gui issue #149).  The view now
+   brackets its -layout with the controller's will/did layout and routes
+   -updateConstraints through the controller's -updateViewConstraints. */
+
+@interface LayoutVC : NSViewController
+{
+@public
+  int willLayout;
+  int didLayout;
+  int updateConstraints;
+}
+@end
+
+@implementation LayoutVC
+- (void) loadView
+{
+  [self setView: AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(0, 0, 50, 50)])];
+}
+- (void) viewWillLayout { [super viewWillLayout]; willLayout++; }
+- (void) viewDidLayout { [super viewDidLayout]; didLayout++; }
+- (void) updateViewConstraints { updateConstraints++; [super updateViewConstraints]; }
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  LayoutVC *vc;
+  NSView *view;
+
+  START_SET("NSViewController layout")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      vc = AUTORELEASE([[LayoutVC alloc] initWithNibName: nil bundle: nil]);
+      view = [vc view];
+
+      NSWindow *w = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 200, 200)
+                  styleMask: NSTitledWindowMask
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      [[w contentView] addSubview: view];
+
+      /* Laying out the controller's view brackets it with will/did layout. */
+      vc->willLayout = 0;
+      vc->didLayout = 0;
+      [view layout];
+      PASS(vc->willLayout == 1 && vc->didLayout == 1,
+        "the view's -layout sends viewWillLayout and viewDidLayout");
+
+      /* It happens on each layout pass. */
+      [view layout];
+      PASS(vc->willLayout == 2 && vc->didLayout == 2,
+        "the layout methods are sent on each layout");
+
+      /* Updating the view's constraints routes through updateViewConstraints. */
+      vc->updateConstraints = 0;
+      [view setNeedsUpdateConstraints: YES];
+      [view updateConstraintsForSubtreeIfNeeded];
+      PASS(vc->updateConstraints == 1,
+        "updating the view's constraints sends updateViewConstraints");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+    else
+      [localException raise];
+  NS_ENDHANDLER
+
+  END_SET("NSViewController layout")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
viewWillLayout, viewDidLayout and updateViewConstraints were declared on NSViewController but never sent, so a view controller was not told about its layout passes (issue #149). This completes the life-cycle methods alongside the earlier appearance and viewDidLoad work.

The view now brackets its -layout with the controller's -viewWillLayout and -viewDidLayout, and -updateConstraintsForSubtreeIfNeeded routes a controller's view through -updateViewConstraints, whose default asks the view to update its constraints. Views without a controller are unaffected.

Tests/gui/NSViewController/layout.m verifies the three methods are sent. The existing NSViewController tests and the layout/constraint suites (NSLayoutConstraint, NSLayoutGuide, NSLayoutAnchor, NSStackView, NSView, NSGridView) pass unchanged.

Closes #149