### PR TITLE
Fix: retain the default font names for the font roles

### DIFF
--- a/Source/NSFont.m
+++ b/Source/NSFont.m
@@ -289,9 +289,14 @@ static void init_font_roles(void)
 {
   GSFontEnumerator *e = [GSFontEnumerator sharedEnumerator];
 
-  font_roles[RoleSystemFont].defaultFont = [e defaultSystemFontName];
-  font_roles[RoleBoldSystemFont].defaultFont = [e defaultBoldSystemFontName];
-  font_roles[RoleUserFixedPitchFont].defaultFont = [e defaultFixedPitchFontName];
+  /* Retain the returned names: they are kept for the lifetime of the process
+     and used again later (e.g. in keyForFont).  A backend that returns an
+     autoreleased name rather than a string constant would otherwise leave
+     these as dangling pointers once the current autorelease pool drains. */
+  ASSIGN(font_roles[RoleSystemFont].defaultFont, [e defaultSystemFontName]);
+  ASSIGN(font_roles[RoleBoldSystemFont].defaultFont, [e defaultBoldSystemFontName]);
+  ASSIGN(font_roles[RoleUserFixedPitchFont].defaultFont,
+         [e defaultFixedPitchFontName]);
 }
 
 


### PR DESCRIPTION
init_font_roles stored the system, bold-system and fixed-pitch default font names returned by the backend font enumerator without retaining them. These are kept for the lifetime of the process and read again later (e.g. in keyForFont), so they must be owned.

It worked only because the existing backends return string constants. A backend that returns an ordinary autoreleased name leaves the three font_roles[].defaultFont entries dangling once the current autorelease pool drains, and the next font lookup dereferences freed memory — an intermittent crash at pool drain (in -[NSFont dealloc] -> keyForFont).

Retain the names with ASSIGN so the font roles own them.

Surfaced by gnustep/libs-back#172, which changes the fontconfig enumerator to return fontconfig-derived (non-constant) bold and fixed-pitch names. With this change the libs-back cairo tests (glyphmetrics.m, pdfps.m) crash 0/30 instead of intermittently; without it they abort at pool drain.