### PR TITLE
NSMenu/NSMenuView: fix horizontal menu switch in external Menu.app mode (libs-back#76)

### DIFF
--- a/Source/NSMenu.m
+++ b/Source/NSMenu.m
@@ -2040,8 +2040,15 @@ static BOOL menuBarVisible = YES;
         {
           [[self window] setTitle: [[NSProcessInfo processInfo] processName]];
           [[self window] setLevel: NSMainMenuWindowLevel];
-          [self _setGeometry];
+          /* sizeToFit must run first so that [_aWindow frame].size.height
+           * is non-zero when _setGeometry uses it to place the bar at the
+           * top of the screen.  Without this ordering, external Menu.app
+           * mode (which never calls -display) leaves the window frame at
+           * {0,0,w,h} instead of the correct top-of-screen position,
+           * breaking the NSMouseInRect re-entry check in
+           * _trackWithEvent:startingMenuView: (step 3a). */
           [self sizeToFit];
+          [self _setGeometry];
 
           if ([NSApp isActive])
             {

--- a/Source/NSMenuView.m
+++ b/Source/NSMenuView.m
@@ -1790,24 +1790,36 @@ static float menuBarHeight = 0.0;
                   // If the user moves the mouse into the main window
                   // horizontal menu, start tracking again.
                   NSWindow *mainWindow = [mainWindowMenuView window];
-                  NSPoint locationInMainWindow = [mainWindow 
-                    convertScreenToBase: locationInScreenCoordinates];
-		  if ([mainWindowMenuView 
-                        hitTest: locationInMainWindow] != nil)
-		    {
-                      int index = [mainWindowMenuView indexOfItemAtPoint: 
-                        [mainWindowMenuView 
-                          convertPoint: locationInMainWindow
-                              fromView: nil]];
-                      if (index != -1 &&
-                          index != [mainWindowMenuView highlightedItemIndex])
-                        {
-		          [self setHighlightedItemIndex: -1];
-		          return [mainWindowMenuView
-                                   _trackWithEvent: original
-                                   startingMenuView: mainWindowMenuView];
-                        }
-		    }
+                  /* Guard against the embedded menu view having been
+                   * removed from its host window (e.g. when external
+                   * Menu.app mode calls updateAllWindowsWithMenu:nil
+                   * while tracking is already in progress).  Without
+                   * this check, [nil convertScreenToBase:] returns
+                   * NSZeroPoint and hitTest: may yield a false positive,
+                   * causing spurious re-entry into menu-bar tracking. */
+                  if (mainWindow != nil
+                      && NSMouseInRect (locationInScreenCoordinates,
+                                        [mainWindow frame], NO))
+                    {
+                      NSPoint locationInMainWindow = [mainWindow
+                        convertScreenToBase: locationInScreenCoordinates];
+		      if ([mainWindowMenuView
+                            hitTest: locationInMainWindow] != nil)
+		        {
+                          int index = [mainWindowMenuView indexOfItemAtPoint:
+                            [mainWindowMenuView
+                              convertPoint: locationInMainWindow
+                                  fromView: nil]];
+                          if (index != -1 &&
+                              index != [mainWindowMenuView highlightedItemIndex])
+                            {
+		              [self setHighlightedItemIndex: -1];
+		              return [mainWindowMenuView
+                                       _trackWithEvent: original
+                                       startingMenuView: mainWindowMenuView];
+                            }
+		        }
+                    }
 		}
             }
 
@@ -1955,11 +1967,15 @@ static float menuBarHeight = 0.0;
   [nc postNotificationName: NSMenuDidBeginTrackingNotification
                     object: [self menu]];
  
-  if (NSInterfaceStyleForKey(@"NSMenuInterfaceStyle", self) ==
-      NSWindows95InterfaceStyle &&
-      ![[self menu] isTransient] &&
-      ![[self menu] _ownedByPopUp])
+  if ([self isHorizontal] == YES
+      && ![[self menu] isTransient]
+      && ![[self menu] _ownedByPopUp])
     {
+      /* Keep the root horizontal menu view available while tracking any
+       * attached submenu so moving back over the bar can switch directly to
+       * another top-level menu without requiring a second click.  This is
+       * needed for both in-window menus and the hidden menu-bar window used
+       * by external Menu.app mode. */
       mainWindowMenuView = self;
     }
 


### PR DESCRIPTION
## Summary

Fixes gnustep/libs-back#76 — in horizontal menu bars, moving from an open dropdown to another top-level title should close the first menu and open the other without a second click. This failed in **external Menu.app mode** (e.g. Gershwin's global menu bar).

The patch is **@probonopd's** (posted in gnustep/libs-back#76); this PR applies it with attribution, plus a root-cause writeup and a regression check.

## Root cause

The horizontal menu-bar window's Y origin is computed in `-[NSMenu _setGeometry]` as `screenHeight − windowHeight`. In `-[NSMenu setMain:]`, `_setGeometry` ran **before** `sizeToFit`, so on the first pass it read height 0 and left the bar at the **bottom** of the screen (`y = 0`).

On a normal foreground app this is invisible: `-[NSMenu display]` later re-runs `_setGeometry` via the `origin.y <= 0` self-heal (`NSMenu.m` ~1830), by which point the height is correct. **External Menu.app mode never calls `-display`**, so the bar stays mispositioned and the `NSMouseInRect(pointerLocation, [mainWindow frame])` re-entry check in `-_trackWithEvent:startingMenuView:` (step 3a) never matches — the pointer is at the top of the screen, the bar frame is at the bottom.

## Changes

- **`NSMenu.m`** — run `sizeToFit` before `_setGeometry` in `setMain:` so the bar is positioned correctly on the first pass, independent of `-display`. (Load-bearing fix.)
- **`NSMenuView.m`** — gate the `mainWindowMenuView` assignment on `-isHorizontal` rather than `NSWindows95InterfaceStyle`, so Macintosh-style bars re-enter tracking too.
- **`NSMenuView.m`** — guard the bar re-entry check with `NSMouseInRect` against the main-window frame, avoiding a false positive when the embedded view was removed during external-mode teardown.

## Verification

I instrumented `NSMenu`/`NSMenuView` and confirmed the mechanism directly (details in gnustep/libs-back#76):

- Normal foreground app: `_setGeometry` sees the correct height; bar at top; switch works — before and after this change (no regression).
- Forcing height 0 reproduces the mispositioned bar (`y = 0`); the reorder positions it correctly on the first pass.
- Live check under Xephyr + WindowMaker (Macintosh interface style): clicking a title, moving into its submenu, then sliding to another title opens the second menu with the bar correctly at the top.

I couldn't stand up Gershwin's external global bar locally to end-to-end confirm that specific configuration, but the code path is unambiguous and matches @probonopd's report and reproduction.

Fixes: gnustep/libs-back#76

