### PR TITLE
Fix: reassign a window to a valid screen when its monitor is removed

### DIFF
--- a/Source/NSWindow.m
+++ b/Source/NSWindow.m
@@ -2857,6 +2857,7 @@ titleWithRepresentedFilename(NSString *representedFilename)
   NSRect       newFrame;
   NSEnumerator *e;
   NSScreen     *scr;
+  NSScreen     *newScreen = nil;
 
   // We need to get new screen from renewed screen list because
   // [NSScreen mainScreen] returns NSScreen object of key window and that object
@@ -2866,9 +2867,20 @@ titleWithRepresentedFilename(NSString *representedFilename)
     {
       if ([scr screenNumber] == screenNumber)
         {
-          ASSIGN(_screen, scr);
+          newScreen = scr;
           break;
         }
+    }
+  // The screen the window was on may have been removed (e.g. a monitor was
+  // disconnected). Fall back to the first available screen so the window is
+  // not left anchored to a screen that no longer exists.
+  if (newScreen == nil)
+    {
+      newScreen = [[NSScreen screens] firstObject];
+    }
+  if (newScreen != nil)
+    {
+      ASSIGN(_screen, newScreen);
     }
 
   // Do not adjust frame for mini and appicon windows - it's a WM's job.


### PR DESCRIPTION
When a monitor is disconnected, -applicationDidChangeScreenParameters: could leave a window's _screen pointing at a screen that is no longer in [NSScreen screens]. The window then stayed anchored to that removed screen, and the following frame adjustment used its stale geometry, so windows and menus could be moved offscreen.

This falls back to the first available screen when the window's previous screen is gone, so the window is placed on a screen that still exists.

Part of the multi-monitor problems reported in gnustep/libs-back#67, alongside the screenList change already in libs-back and the NSCachedImageRep change already committed here. It follows the fix @sheffler tested on a two-monitor setup; the commit is authored to him.

I don't have a multi-monitor setup to reproduce the hot-plug here, so this is verified by inspection and a clean build. The screen list is provided by the display server, so this path isn't exercised by a unit test.
