### PR TITLE
Fix: ignore paragraph first line head indent in string drawing

### DIFF
--- a/Source/NSStringDrawing.m
+++ b/Source/NSStringDrawing.m
@@ -36,7 +36,9 @@
 #import <Foundation/NSLock.h>
 
 #import "AppKit/NSAffineTransform.h"
+#import "AppKit/NSAttributedString.h"
 #import "AppKit/NSLayoutManager.h"
+#import "AppKit/NSParagraphStyle.h"
 #import "AppKit/NSStringDrawing.h"
 #import "AppKit/NSTextContainer.h"
 #import "AppKit/NSTextStorage.h"
@@ -294,6 +296,44 @@ static cache_t *cache_lookup(BOOL hasSize, NSSize size, BOOL useScreenFonts)
   return c;
 }
 
+/* AppKit ignores a paragraph first line head indent in the convenience string
+   drawing methods: the text is laid out, measured and drawn from the origin,
+   not from the indent. Drop the indent from our private working copy so that
+   -boundingRectWithSize:options: and -drawInRect: agree and match AppKit. */
+static void strip_first_line_indent(NSTextStorage *textStorage)
+{
+  NSUInteger length = [textStorage length];
+  NSUInteger index = 0;
+
+  if (length == 0)
+    {
+      return;
+    }
+
+  [textStorage beginEditing];
+  while (index < length)
+    {
+      NSRange range;
+      NSParagraphStyle *style;
+
+      style = [textStorage attribute: NSParagraphStyleAttributeName
+                             atIndex: index
+                      effectiveRange: &range];
+      if (style != nil && [style firstLineHeadIndent] != 0.0)
+        {
+          NSMutableParagraphStyle *stripped = [style mutableCopy];
+
+          [stripped setFirstLineHeadIndent: 0.0];
+          [textStorage addAttribute: NSParagraphStyleAttributeName
+                              value: stripped
+                              range: range];
+          RELEASE(stripped);
+        }
+      index = NSMaxRange(range);
+    }
+  [textStorage endEditing];
+}
+
 static inline void prepare_string(NSString *string, NSDictionary *attributes)
 {
   cache_t *scratch = cache + NUM_CACHE_ENTRIES;
@@ -308,6 +348,7 @@ static inline void prepare_string(NSString *string, NSDictionary *attributes)
 			  range: NSMakeRange(0, [string length])];
     }
   [scratchTextStorage endEditing];
+  strip_first_line_indent(scratchTextStorage);
 }
 
 static inline void prepare_attributed_string(NSAttributedString *string)
@@ -317,6 +358,7 @@ static inline void prepare_attributed_string(NSAttributedString *string)
 
   [scratchTextStorage replaceCharactersInRange: NSMakeRange(0, [scratchTextStorage length])
                           withAttributedString: string];
+  strip_first_line_indent(scratchTextStorage);
 }
 
 static BOOL use_screen_fonts(void)

--- a/Tests/gui/NSAttributedString/headIndentBounding.m
+++ b/Tests/gui/NSAttributedString/headIndentBounding.m
@@ -1,0 +1,73 @@
+#include "Testing.h"
+
+#include <math.h>
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSDictionary.h>
+#include <Foundation/NSException.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSString.h>
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSAttributedString.h>
+#include <AppKit/NSParagraphStyle.h>
+#include <AppKit/NSStringDrawing.h>
+#include <AppKit/NSFont.h>
+
+/* A paragraph first line head indent must not change the rectangle reported by
+   -boundingRectWithSize:options:. AppKit ignores the head indent for the
+   convenience drawing methods: the origin stays at zero and the width stays the
+   text width, so the reported size matches what -drawInRect: paints. Checked
+   against AppKit on a macOS runner. */
+
+static NSAttributedString *
+noteString(CGFloat indent)
+{
+  NSMutableParagraphStyle *p = [[NSMutableParagraphStyle alloc] init];
+  NSDictionary *attrs;
+
+  [p setFirstLineHeadIndent: indent];
+  attrs = [NSDictionary dictionaryWithObjectsAndKeys:
+             [NSFont systemFontOfSize: 12], NSFontAttributeName,
+             p, NSParagraphStyleAttributeName, nil];
+  RELEASE(p);
+  return AUTORELEASE([[NSAttributedString alloc]
+                       initWithString: @"votre texte en gras"
+                            attributes: attrs]);
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSRect r0, r20;
+
+  START_SET("NSAttributedString head indent bounding rect")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  r0 = [noteString(0.0) boundingRectWithSize: NSMakeSize(336, 9999) options: 0];
+  r20 = [noteString(20.0) boundingRectWithSize: NSMakeSize(336, 9999) options: 0];
+
+  PASS(r20.origin.x == 0.0,
+       "a first line head indent leaves the bounding rect origin at zero");
+
+  PASS(fabs(r20.origin.x - r0.origin.x) < 0.001
+    && fabs(r20.origin.y - r0.origin.y) < 0.001
+    && fabs(r20.size.width - r0.size.width) < 0.001
+    && fabs(r20.size.height - r0.size.height) < 0.001,
+       "a first line head indent does not change the bounding rect");
+
+  END_SET("NSAttributedString head indent bounding rect")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-boundingRectWithSize:options: returned the paragraph first line head indent in its origin while -drawInRect: drew the glyphs at the indent, so the reported width did not cover the drawn text and the tail was clipped. This is the HelpViewer NoteCell case in the issue.

On macOS these convenience methods ignore the head indent: the origin stays at zero and the width stays the text width, so the reported size matches what is drawn. This removes the first line head indent from the private working copy before layout, so -boundingRectWithSize:options: and -drawInRect: agree and match AppKit.

Adds Tests/gui/NSAttributedString/headIndentBounding.m.

Closes #350.
