### PR TITLE
Fix: NSStringDrawing - drop the head indent from the attributes for plain strings

### DIFF
--- a/Source/NSStringDrawing.m
+++ b/Source/NSStringDrawing.m
@@ -344,11 +344,33 @@ static inline void prepare_string(NSString *string, NSDictionary *attributes)
                                     withString: string];
   if ([string length])
     {
-      [scratchTextStorage setAttributes: attributes
-			  range: NSMakeRange(0, [string length])];
+      NSParagraphStyle *style = [attributes objectForKey:
+                                   NSParagraphStyleAttributeName];
+
+      /* AppKit ignores a paragraph first line head indent in these
+         convenience methods (see strip_first_line_indent).  The whole string
+         shares one attributes dictionary here, so dropping the indent from a
+         copy before it is applied avoids rewriting the laid out text. */
+      if (style != nil && [style firstLineHeadIndent] != 0.0)
+        {
+          NSMutableParagraphStyle *stripped = [style mutableCopy];
+          NSMutableDictionary *noIndent = [attributes mutableCopy];
+
+          [stripped setFirstLineHeadIndent: 0.0];
+          [noIndent setObject: stripped
+                       forKey: NSParagraphStyleAttributeName];
+          [scratchTextStorage setAttributes: noIndent
+                                      range: NSMakeRange(0, [string length])];
+          RELEASE(stripped);
+          RELEASE(noIndent);
+        }
+      else
+        {
+          [scratchTextStorage setAttributes: attributes
+                                      range: NSMakeRange(0, [string length])];
+        }
     }
   [scratchTextStorage endEditing];
-  strip_first_line_indent(scratchTextStorage);
 }
 
 static inline void prepare_attributed_string(NSAttributedString *string)


### PR DESCRIPTION
Follow-up to #820. In the review there, @fredkiefer noted that for the plain string path it would be faster to drop the head indent from the attributes rather than rewrite the laid out text.

`prepare_string` applies a single attributes dictionary to the whole string, so this drops the first line head indent from a copy of that dictionary before it is applied, instead of calling `strip_first_line_indent` afterwards. The attributed string path still uses `strip_first_line_indent`, where the paragraph runs can vary.

No behaviour change: the plain string `boundingRectWithSize:options:attributes:` still reports origin x 0 with a head indent, and the NSAttributedString tests (including `headIndentBounding`) pass.
