### PR TITLE
Fix: store the layout manager hyphenation factor and non-contiguous layout flag

### DIFF
--- a/Headers/AppKit/NSLayoutManager.h
+++ b/Headers/AppKit/NSLayoutManager.h
@@ -70,6 +70,10 @@ APPKIT_EXPORT_CLASS
   NSMutableDictionary *_typingAttributes;
 
   NSMutableAttributedString *_temporaryAttributes;
+
+@protected
+  float _hyphenationFactor;
+  BOOL _allowsNonContiguousLayout;
 }
 
 /* TODO */

--- a/Source/NSLayoutManager.m
+++ b/Source/NSLayoutManager.m
@@ -1334,11 +1334,12 @@ has the same y origin and height as the line frag rect it is in.
 
 - (BOOL) allowsNonContiguousLayout
 {
-  return NO;
+  return _allowsNonContiguousLayout;
 }
 
 - (void) setAllowsNonContiguousLayout: (BOOL)flag
 {
+  _allowsNonContiguousLayout = flag;
 }
 
 - (BOOL) hasNonContiguousLayout
@@ -2302,19 +2303,14 @@ static void GSDrawPatternLine(NSPoint start, NSPoint end, NSInteger pattern, CGF
 }
 
 
-/*
-TODO: Add a general typesetterAttributes dictionary. Implement the
-hyphenation factor methods by setting/getting an attribute in this
-dictionary.
-*/
 -(float) hyphenationFactor
 {
-  return 0.0;
+  return _hyphenationFactor;
 }
 
 -(void) setHyphenationFactor: (float)factor
 {
-  NSLog(@"Warning: (NSLayoutManager) %s not implemented", __PRETTY_FUNCTION__);
+  _hyphenationFactor = factor;
 }
 
 

--- a/Tests/gui/NSLayoutManager/config.m
+++ b/Tests/gui/NSLayoutManager/config.m
@@ -3,8 +3,7 @@
    flags, hyphenation factor, non-contiguous layout flag and first text view of
    a new layout manager; the flag and delegate round-trips; adding a text
    container; and the link established by adding the layout manager to a text
-   storage.  Every assertion here matches AppKit (verified on a macOS runner)
-   and passes on unmodified GNUstep. */
+   storage.  Every assertion here matches AppKit (verified on a macOS runner). */
 #include "Testing.h"
 
 #include <Foundation/NSAutoreleasePool.h>
@@ -47,6 +46,14 @@ int main()
   [lm setShowsControlCharacters: YES];
   PASS([lm showsControlCharacters] == YES,
        "showsControlCharacters round-trips");
+
+  [lm setHyphenationFactor: 0.75];
+  PASS([lm hyphenationFactor] == 0.75f, "hyphenationFactor round-trips");
+  [lm setAllowsNonContiguousLayout: YES];
+  PASS([lm allowsNonContiguousLayout] == YES,
+       "allowsNonContiguousLayout round-trips");
+  PASS([lm hasNonContiguousLayout] == NO,
+       "hasNonContiguousLayout stays NO with no non-contiguous layout done");
 
   delegate = AUTORELEASE([[NSObject alloc] init]);
   [lm setDelegate: delegate];


### PR DESCRIPTION
setHyphenationFactor: logged a warning and discarded the value, and setAllowsNonContiguousLayout: did nothing, so -hyphenationFactor and -allowsNonContiguousLayout always returned the defaults regardless of what was set.

Both values are now kept in ivars so they round-trip, matching AppKit (checked on a macOS runner: the factor stores the set value and allowsNonContiguousLayout stores the flag). hasNonContiguousLayout still returns NO, since the layout is produced contiguously; on macOS it likewise stays NO after setAllowsNonContiguousLayout:YES until non-contiguous layout is actually performed.

The existing NSLayoutManager/config.m test gains the set round-trips.

Closes #755
