### PR TITLE
Fix: store the NSCollectionViewItem highlight state

### DIFF
--- a/Headers/AppKit/NSCollectionViewItem.h
+++ b/Headers/AppKit/NSCollectionViewItem.h
@@ -32,6 +32,7 @@
 
 #import <Foundation/NSArray.h>
 #import <AppKit/NSViewController.h>
+#import <AppKit/NSCollectionView.h>
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
 
@@ -56,6 +57,7 @@ APPKIT_EXPORT_CLASS
   IBOutlet NSTextField *textField;
   IBOutlet NSImageView *imageView;
   BOOL _isSelected;
+  NSInteger _highlightState;
 }
 
 /**
@@ -92,6 +94,22 @@ APPKIT_EXPORT_CLASS
  * differently in user interactions and operations.
  */
 - (BOOL)isSelected;
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)
+/**
+ * Returns the current highlight state of the item, used to draw a
+ * highlight while it participates in selection, deselection or as a
+ * drop target. The default is NSCollectionViewItemHighlightNone. The
+ * highlight state is independent of the selection state.
+ */
+- (NSCollectionViewItemHighlightState)highlightState;
+/**
+ * Sets the current highlight state of the item. This changes how the
+ * item is drawn while the collection view tracks selection or a drag,
+ * and does not change the selection state.
+ */
+- (void)setHighlightState:(NSCollectionViewItemHighlightState)highlightState;
+#endif
 
 /**
  * Returns the text field outlet that displays textual content for this

--- a/Source/NSCollectionViewItem.m
+++ b/Source/NSCollectionViewItem.m
@@ -47,6 +47,16 @@
   return _isSelected;
 }
 
+- (NSCollectionViewItemHighlightState) highlightState
+{
+  return _highlightState;
+}
+
+- (void) setHighlightState: (NSCollectionViewItemHighlightState)state
+{
+  _highlightState = state;
+}
+
 - (void) dealloc
 {
   DESTROY(textField);

--- a/Tests/gui/NSCollectionViewItem/config.m
+++ b/Tests/gui/NSCollectionViewItem/config.m
@@ -1,7 +1,7 @@
-/* Coverage for NSCollectionViewItem: the selection flag, the text field and
-   image view outlets, the represented object and the collection view of an item
-   that is not in a collection.  Every assertion here matches AppKit (verified on
-   a macOS runner) and passes on unmodified GNUstep. */
+/* Coverage for NSCollectionViewItem: the selection flag, the highlight state,
+   the text field and image view outlets, the represented object and the
+   collection view of an item that is not in a collection.  Every assertion here
+   matches AppKit (verified on a macOS runner). */
 #include "Testing.h"
 
 #include <Foundation/NSAutoreleasePool.h>
@@ -33,6 +33,8 @@ int main()
   item = AUTORELEASE([[NSCollectionViewItem alloc] init]);
 
   PASS([item isSelected] == NO, "default isSelected is NO");
+  PASS([item highlightState] == NSCollectionViewItemHighlightNone,
+       "default highlightState is None");
   PASS([item textField] == nil, "default textField is nil");
   PASS([item imageView] == nil, "default imageView is nil");
   PASS([item representedObject] == nil, "default representedObject is nil");
@@ -43,6 +45,20 @@ int main()
   PASS([item isSelected] == YES, "setSelected: YES round-trips");
   [item setSelected: NO];
   PASS([item isSelected] == NO, "setSelected: NO round-trips");
+
+  [item setHighlightState: NSCollectionViewItemHighlightForSelection];
+  PASS([item highlightState] == NSCollectionViewItemHighlightForSelection,
+       "setHighlightState: round-trips");
+  PASS([item isSelected] == NO,
+       "setting the highlight state does not change the selection");
+  [item setHighlightState: NSCollectionViewItemHighlightAsDropTarget];
+  PASS([item highlightState] == NSCollectionViewItemHighlightAsDropTarget,
+       "the drop-target highlight state round-trips");
+  [item setSelected: YES];
+  PASS([item highlightState] == NSCollectionViewItemHighlightAsDropTarget,
+       "selecting the item does not change the highlight state");
+  [item setSelected: NO];
+  [item setHighlightState: NSCollectionViewItemHighlightNone];
 
   tf = AUTORELEASE([[NSTextField alloc]
     initWithFrame: NSMakeRect(0, 0, 100, 20)]);


### PR DESCRIPTION
NSCollectionViewItem did not implement -highlightState, so an item could not report the highlight the collection view assigns it during selection tracking or a drag (the enum NSCollectionViewItemHighlightState already exists in NSCollectionView.h).

Add -highlightState/-setHighlightState: backed by an ivar. Checked on a macOS runner: the default is NSCollectionViewItemHighlightNone, any of the four states round-trips, and the highlight state is independent of the selection state (setting one does not change the other).

The -draggingImageComponents FIXME is left as is; it still returns an empty array because there is no NSDraggingImageComponent class yet.

The existing NSCollectionViewItem/config.m test gains the highlight-state coverage.

This is the -highlightState half of #756. The -draggingImageComponents half is left for when NSDraggingImageComponent exists, so I have not marked the issue closed here.
