### PR TITLE
Feature: add NSDraggingImageComponent and build the collection view drag image

### DIFF
--- a/Headers/AppKit/AppKit.h
+++ b/Headers/AppKit/AppKit.h
@@ -85,6 +85,7 @@
 #import <AppKit/NSDataLinkManager.h>
 #import <AppKit/NSDataLinkPanel.h>
 #import <AppKit/NSDragging.h>
+#import <AppKit/NSDraggingItem.h>
 #import <AppKit/NSEPSImageRep.h>
 #import <AppKit/NSEvent.h>
 #import <AppKit/NSFont.h>

--- a/Headers/AppKit/NSDraggingItem.h
+++ b/Headers/AppKit/NSDraggingItem.h
@@ -1,0 +1,78 @@
+/* -*-objc-*-
+   NSDraggingItem.h
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: July 2026
+
+   This file is part of the GNUstep GUI Library.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#ifndef _GNUstep_H_NSDraggingItem
+#define _GNUstep_H_NSDraggingItem
+#import <AppKit/AppKitDefines.h>
+
+#import <Foundation/NSObject.h>
+#import <Foundation/NSGeometry.h>
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_7, GS_API_LATEST)
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+@class NSString;
+
+typedef NSString * NSDraggingImageComponentKey;
+
+/* Keys identifying the standard drag image components. */
+APPKIT_EXPORT NSDraggingImageComponentKey const NSDraggingImageComponentIconKey;
+APPKIT_EXPORT NSDraggingImageComponentKey const NSDraggingImageComponentLabelKey;
+
+APPKIT_EXPORT_CLASS
+@interface NSDraggingImageComponent : NSObject
+{
+  NSDraggingImageComponentKey _key;
+  id _contents;
+  NSRect _frame;
+}
+
++ (instancetype) draggingImageComponentWithKey: (NSDraggingImageComponentKey)key;
+
+- (instancetype) initWithKey: (NSDraggingImageComponentKey)key;
+
+- (NSDraggingImageComponentKey) key;
+- (void) setKey: (NSDraggingImageComponentKey)key;
+
+- (id) contents;
+- (void) setContents: (id)contents;
+
+- (NSRect) frame;
+- (void) setFrame: (NSRect)frame;
+
+@end
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* MAC_OS_X_VERSION_10_7 */
+
+#endif /* _GNUstep_H_NSDraggingItem */

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -111,6 +111,7 @@ NSDictionaryController.m \
 NSDockTile.m \
 NSDocument.m \
 NSDocumentController.m \
+NSDraggingItem.m \
 NSDrawer.m \
 NSEPSImageRep.m \
 NSEvent.m \
@@ -469,6 +470,7 @@ NSDiffableDataSource.h \
 NSDockTile.h \
 NSDocument.h \
 NSDocumentController.h \
+NSDraggingItem.h \
 NSDrawer.h \
 NSEPSImageRep.h \
 NSErrors.h \

--- a/Source/NSCollectionViewItem.m
+++ b/Source/NSCollectionViewItem.m
@@ -29,11 +29,15 @@
 #import <Foundation/NSDictionary.h>
 #import <Foundation/NSKeyedArchiver.h>
 
+#import "AppKit/NSBitmapImageRep.h"
 #import "AppKit/NSCollectionView.h"
 #import "AppKit/NSCollectionViewItem.h"
+#import "AppKit/NSDraggingItem.h"
+#import "AppKit/NSImage.h"
 #import "AppKit/NSImageView.h"
 #import "AppKit/NSKeyValueBinding.h"
 #import "AppKit/NSTextField.h"
+#import "AppKit/NSView.h"
 #import "AppKit/NSDragging.h"
 
 @implementation NSCollectionViewItem
@@ -61,8 +65,36 @@
 
 - (NSArray *) draggingImageComponents
 {
-  // FIXME: We don't have NSDraggingImageComponent
-  return [NSArray array];
+  NSView *view = [self view];
+  NSDraggingImageComponent *component;
+  NSRect bounds;
+  NSImage *image = nil;
+
+  if (view == nil)
+    {
+      return [NSArray array];
+    }
+
+  bounds = [view bounds];
+  component = [NSDraggingImageComponent
+    draggingImageComponentWithKey: NSDraggingImageComponentIconKey];
+  [component setFrame: NSMakeRect(0.0, 0.0, NSWidth(bounds), NSHeight(bounds))];
+
+  if (NSWidth(bounds) > 0.0 && NSHeight(bounds) > 0.0)
+    {
+      NSBitmapImageRep *rep =
+        [view bitmapImageRepForCachingDisplayInRect: bounds];
+
+      if (rep != nil)
+        {
+          [view cacheDisplayInRect: bounds toBitmapImageRep: rep];
+          image = AUTORELEASE([[NSImage alloc] initWithSize: bounds.size]);
+          [image addRepresentation: rep];
+        }
+    }
+  [component setContents: image];
+
+  return [NSArray arrayWithObject: component];
 }
 
 - (void) setSelected: (BOOL)flag

--- a/Source/NSDraggingItem.m
+++ b/Source/NSDraggingItem.m
@@ -1,0 +1,85 @@
+/* Implementation of class NSDraggingImageComponent
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: July 2026
+
+   This file is part of the GNUstep GUI Library.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#import "config.h"
+#import <Foundation/NSString.h>
+#import "AppKit/NSDraggingItem.h"
+
+@implementation NSDraggingImageComponent
+
++ (instancetype) draggingImageComponentWithKey: (NSDraggingImageComponentKey)key
+{
+  return AUTORELEASE([[self alloc] initWithKey: key]);
+}
+
+- (instancetype) initWithKey: (NSDraggingImageComponentKey)key
+{
+  self = [super init];
+  if (self != nil)
+    {
+      ASSIGNCOPY(_key, key);
+    }
+  return self;
+}
+
+- (void) dealloc
+{
+  DESTROY(_key);
+  DESTROY(_contents);
+  [super dealloc];
+}
+
+- (NSDraggingImageComponentKey) key
+{
+  return _key;
+}
+
+- (void) setKey: (NSDraggingImageComponentKey)key
+{
+  ASSIGNCOPY(_key, key);
+}
+
+- (id) contents
+{
+  return _contents;
+}
+
+- (void) setContents: (id)contents
+{
+  ASSIGN(_contents, contents);
+}
+
+- (NSRect) frame
+{
+  return _frame;
+}
+
+- (void) setFrame: (NSRect)frame
+{
+  _frame = frame;
+}
+
+@end

--- a/Source/externs.m
+++ b/Source/externs.m
@@ -37,6 +37,7 @@
 #import "AppKit/NSFontCollection.h"
 #import "AppKit/NSTextFinder.h"
 #import "AppKit/NSCollectionView.h"
+#import "AppKit/NSDraggingItem.h"
 
 // Global strings
 APPKIT_DECLARE APPKIT_DECLARE NSString *NSModalPanelRunLoopMode = @"NSModalPanelRunLoopMode";
@@ -774,6 +775,10 @@ APPKIT_DECLARE NSFontCollectionName const NSFontCollectionRecentlyUsed = @"NSFon
 APPKIT_DECLARE NSFontCollectionMatchingOptionKey const NSFontCollectionIncludeDisabledFontsOption = @"NSFontCollectionIncludeDisabledFontsOption";
 APPKIT_DECLARE NSFontCollectionMatchingOptionKey const NSFontCollectionRemoveDuplicatesOption = @"NSFontCollectionRemoveDuplicatesOption";
 APPKIT_DECLARE NSFontCollectionMatchingOptionKey const NSFontCollectionDisallowAutoActivationOption = @"NSFontCollectionDisallowAutoActivationOption";
+
+// Dragging image components
+APPKIT_DECLARE NSDraggingImageComponentKey const NSDraggingImageComponentIconKey = @"icon";
+APPKIT_DECLARE NSDraggingImageComponentKey const NSDraggingImageComponentLabelKey = @"label";
 
 // Speech recognition...
 APPKIT_DECLARE const NSString *GSSpeechRecognizerDidRecognizeWordNotification = @"GSSpeechRecognizerDidRecognizeWordNotification"; 

--- a/Tests/gui/NSCollectionViewItem/draggingimage.m
+++ b/Tests/gui/NSCollectionViewItem/draggingimage.m
@@ -1,0 +1,74 @@
+/* Coverage for -[NSCollectionViewItem draggingImageComponents]: an item with no
+   view has none, and an item with a view has a single icon component whose frame
+   is the view bounds and whose contents is an image of the view.  The snapshot
+   uses the backend, so the set is skipped when it is unavailable.  The
+   assertions match AppKit (verified on a macOS runner). */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSArray.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSCollectionViewItem.h>
+#include <AppKit/NSDraggingItem.h>
+#include <AppKit/NSImage.h>
+#include <AppKit/NSView.h>
+#include <AppKit/NSWindow.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSCollectionViewItem *item;
+  NSArray *components;
+  NSDraggingImageComponent *component;
+
+  START_SET("NSCollectionViewItem draggingImageComponents")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  item = AUTORELEASE([[NSCollectionViewItem alloc] init]);
+  PASS([[item draggingImageComponents] count] == 0,
+       "an item with no view has no dragging image components");
+
+  NS_DURING
+    {
+      NSWindow *window = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 80, 60)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      NSView *view = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(0, 0, 80, 60)]);
+
+      [window setContentView: view];
+      [item setView: view];
+
+      components = [item draggingImageComponents];
+      PASS([components count] == 1,
+           "an item with a view has one dragging image component");
+      component = [components objectAtIndex: 0];
+      PASS([[component key] isEqualToString: NSDraggingImageComponentIconKey],
+           "the component uses the icon key");
+      PASS(NSEqualRects([component frame], NSMakeRect(0, 0, 80, 60)),
+           "the component frame matches the view bounds");
+      PASS([[component contents] isKindOfClass: [NSImage class]],
+           "the component contents is an image of the view");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("The backend cannot render the view offscreen")
+    else
+      [localException raise];
+  NS_ENDHANDLER
+
+  END_SET("NSCollectionViewItem draggingImageComponents")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSDraggingImageComponent/basic.m
+++ b/Tests/gui/NSDraggingImageComponent/basic.m
@@ -1,0 +1,50 @@
+/* Coverage for NSDraggingImageComponent, which needs no window server: the
+   icon and label key constants, the key a component is created with, the nil
+   contents and zero frame of a new component, and the key, frame and contents
+   round-trips.  Every assertion here matches AppKit (verified on a macOS
+   runner). */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSDraggingItem.h>
+#include <AppKit/NSImage.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSDraggingImageComponent *c;
+  NSImage *image;
+
+  PASS([NSDraggingImageComponentIconKey isEqualToString: @"icon"],
+       "NSDraggingImageComponentIconKey is \"icon\"");
+  PASS([NSDraggingImageComponentLabelKey isEqualToString: @"label"],
+       "NSDraggingImageComponentLabelKey is \"label\"");
+
+  c = [NSDraggingImageComponent
+        draggingImageComponentWithKey: NSDraggingImageComponentIconKey];
+  PASS(c != nil, "+draggingImageComponentWithKey: returns an instance");
+  PASS([[c key] isEqualToString: NSDraggingImageComponentIconKey],
+       "the component keeps the key it was created with");
+  PASS([c contents] == nil, "a new component has no contents");
+  PASS(NSEqualRects([c frame], NSZeroRect), "a new component has a zero frame");
+
+  c = AUTORELEASE([[NSDraggingImageComponent alloc] initWithKey: @"custom"]);
+  PASS([[c key] isEqualToString: @"custom"], "initWithKey: keeps the key");
+
+  [c setKey: NSDraggingImageComponentLabelKey];
+  PASS([[c key] isEqualToString: NSDraggingImageComponentLabelKey],
+       "the key round-trips");
+
+  [c setFrame: NSMakeRect(1, 2, 3, 4)];
+  PASS(NSEqualRects([c frame], NSMakeRect(1, 2, 3, 4)), "the frame round-trips");
+
+  image = AUTORELEASE([[NSImage alloc] initWithSize: NSMakeSize(10, 10)]);
+  [c setContents: image];
+  PASS([c contents] == image, "the contents round-trip");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSDraggingImageComponent did not exist in the tree, so -[NSCollectionViewItem draggingImageComponents] had a FIXME and could only return an empty array.

This adds the class in a new NSDraggingItem.h/.m:
- key, contents and frame properties
- +draggingImageComponentWithKey: and -initWithKey:
- the NSDraggingImageComponentIconKey and NSDraggingImageComponentLabelKey keys (defined in externs.m)

and implements -[NSCollectionViewItem draggingImageComponents] to return a single icon component whose frame is the item view bounds and whose contents is an image of the view. An item with no view returns an empty array.

Checked against AppKit on a macOS runner: the keys are "icon"/"label"; a fresh component has nil contents and a zero frame; the item returns one icon component sized to the view.

Tests: new Tests/gui/NSDraggingImageComponent/basic.m for the class, and Tests/gui/NSCollectionViewItem/draggingimage.m for the item (the view snapshot needs the backend, so that set skips when it is unavailable).

This is the draggingImageComponents half of #756; #823 adds the -highlightState half.

Closes #756
