### PR TITLE
Fix: keep NSStackView arranged subviews in the subview list

### DIFF
--- a/Source/NSStackView.m
+++ b/Source/NSStackView.m
@@ -413,10 +413,11 @@
 
 - (void) setArrangedSubviews: (NSArray *)arrangedSubviews
 {
-  ASSIGN(_arrangedSubviews, arrangedSubviews);
-  _distribution = NSStackViewDistributionFill;
-
   [self _removeAllSubviews];
+
+  RELEASE(_arrangedSubviews);
+  _arrangedSubviews = [[NSMutableArray alloc] initWithArray: arrangedSubviews];
+  _distribution = NSStackViewDistributionFill;
 
   _beginningContainer = nil;
   _middleContainer = nil;
@@ -428,7 +429,7 @@
 
 - (NSArray *) arrangedSubviews
 {
-  return [self subviews];
+  return AUTORELEASE([_arrangedSubviews copy]);
 }
 
 - (void) setDetachedViews: (NSArray *)detachedViews
@@ -474,17 +475,20 @@
   self = [self initWithFrame: NSZeroRect];
   if (self != nil)
     {
-      [_arrangedSubviews addObjectsFromArray: views];
-      ASSIGNCOPY(_views, views);
-
-      [self _refreshView];
+      FOR_IN(NSView*, v, views)
+        {
+          [self addArrangedSubview: v];
+        }
+      END_FOR_IN(views);
     }
   return self;
 }
 
 - (void) dealloc
 {
-  RELEASE(_arrangedSubviews);
+  /* Cleared, not released: -[super dealloc] removes the subviews and reaches
+     -willRemoveSubview:, which reads _arrangedSubviews. */
+  DESTROY(_arrangedSubviews);
   RELEASE(_detachedViews);
   RELEASE(_views);
   RELEASE(_customSpacingMap);
@@ -521,18 +525,55 @@
 
 - (void) addArrangedSubview: (NSView *)v
 {
+  if (v == nil)
+    {
+      return;
+    }
+
+  [_arrangedSubviews removeObject: v];
   [_arrangedSubviews addObject: v];
+  if ([v superview] != self)
+    {
+      [self addSubview: v];
+    }
   [self _refreshView];
 }
 
 - (void) insertArrangedSubview: (NSView *)v atIndex: (NSInteger)idx
 {
+  if (v == nil)
+    {
+      return;
+    }
+
+  [_arrangedSubviews removeObject: v];
+  if (idx > (NSInteger)[_arrangedSubviews count])
+    {
+      idx = [_arrangedSubviews count];
+    }
   [_arrangedSubviews insertObject: v atIndex: idx];
+  if ([v superview] != self)
+    {
+      [self addSubview: v];
+    }
+  [self _refreshView];
 }
 
 - (void) removeArrangedSubview: (NSView *)v
 {
+  if (![_arrangedSubviews containsObject: v])
+    {
+      return;
+    }
+
   [_arrangedSubviews removeObject: v];
+  [self _refreshView];
+}
+
+- (void) willRemoveSubview: (NSView *)subview
+{
+  [_arrangedSubviews removeObject: subview];
+  [super willRemoveSubview: subview];
 }
 
 // Custom priorities

--- a/Tests/gui/NSStackView/membership.m
+++ b/Tests/gui/NSStackView/membership.m
@@ -1,0 +1,94 @@
+/* Coverage for the NSStackView arranged-subview membership model, which does
+   not depend on the constraint-based layout: -addArrangedSubview: leaves the
+   view in both -arrangedSubviews and -subviews, -insertArrangedSubview:atIndex:
+   orders the arranged list while the subview stays appended, re-adding a view
+   does not duplicate it, -removeArrangedSubview: drops it from the arranged list
+   but keeps it as a subview, a plain -addSubview: is not arranged, and
+   -removeFromSuperview drops it from both.  Every assertion matches AppKit
+   (checked on a macOS runner). */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSStackView.h>
+#include <AppKit/NSView.h>
+
+int main()
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSStackView *sv;
+  NSView *a, *b, *c, *d;
+
+  START_SET("NSStackView membership")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      sv = AUTORELEASE([[NSStackView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+      a = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 20, 20)]);
+      b = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 20, 20)]);
+      c = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 20, 20)]);
+      d = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 20, 20)]);
+
+      PASS([[sv arrangedSubviews] count] == 0 && [[sv subviews] count] == 0,
+           "a new stack view has no arranged subviews or subviews");
+
+      [sv addArrangedSubview: a];
+      PASS([[sv arrangedSubviews] count] == 1 && [[sv subviews] count] == 1,
+           "addArrangedSubview: adds to arrangedSubviews and subviews");
+      PASS([[sv arrangedSubviews] containsObject: a]
+           && [[sv subviews] containsObject: a],
+           "the added view is in both lists");
+
+      [sv addArrangedSubview: b];
+      [sv insertArrangedSubview: c atIndex: 0];
+      PASS([[sv arrangedSubviews] count] == 3,
+           "insertArrangedSubview: adds the view");
+      PASS([[sv arrangedSubviews] objectAtIndex: 0] == c
+           && [[sv arrangedSubviews] objectAtIndex: 1] == a
+           && [[sv arrangedSubviews] objectAtIndex: 2] == b,
+           "insertArrangedSubview:atIndex: orders the arranged list");
+
+      [sv addArrangedSubview: a];
+      PASS([[sv arrangedSubviews] count] == 3,
+           "re-adding an arranged view does not duplicate it");
+
+      [sv removeArrangedSubview: a];
+      PASS(![[sv arrangedSubviews] containsObject: a],
+           "removeArrangedSubview: drops the view from arrangedSubviews");
+      PASS([[sv subviews] containsObject: a],
+           "removeArrangedSubview: keeps the view as a subview");
+
+      [sv addSubview: d];
+      PASS(![[sv arrangedSubviews] containsObject: d]
+           && [[sv subviews] containsObject: d],
+           "a plain addSubview: is a subview but not arranged");
+
+      [b removeFromSuperview];
+      PASS(![[sv arrangedSubviews] containsObject: b]
+           && ![[sv subviews] containsObject: b],
+           "removeFromSuperview drops the view from both lists");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+    else
+      [localException raise];
+  NS_ENDHANDLER
+
+  END_SET("NSStackView membership")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-addArrangedSubview: only appended to the internal arranged list and never made the view a subview, while -arrangedSubviews returned -subviews, so an added view was reported by neither and the count came out wrong. -insertArrangedSubview:atIndex: also skipped the refresh, and -setArrangedSubviews: retained the passed array directly, so a later -addArrangedSubview: could mutate a possibly immutable array.

-arrangedSubviews now returns the arranged list, and the mutators keep it and the subviews in step to match AppKit (checked on a macOS runner):

- addArrangedSubview:/insertArrangedSubview:atIndex: make the view a subview and deduplicate it; insert orders the arranged list while the subview stays appended
- removeArrangedSubview: drops it from the arranged list but leaves it as a subview
- removeFromSuperview drops it from both, through -willRemoveSubview:
- a plain -addSubview: is a subview but not arranged

New Tests/gui/NSStackView/membership.m covers this.

This is the arranged-subview half of #628. The layout half (the custom -_layoutViewsWithOrientation: pass that grows the frame instead of building constraints) needs the constraint solver in #643, so the geometry the arranged views get is unchanged here and the issue stays open for that part.
