### PR TITLE
Fix: report an unbounded visibleRect for a view with no window

### DIFF
--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -111,12 +111,28 @@ NSView *viewIsPrinting = nil;
 const CGFloat NSViewNoInstrinsicMetric = -1;
 const CGFloat NSViewNoIntrinsicMetric = -1;
 
+/* Largest representable CGFloat.  Defined here so the library does not pull in
+   CoreFoundation for it; gated so it does not clash where CoreFoundation is
+   present. */
+#ifndef CGFLOAT_MAX
+#  include <float.h>
+#  if defined(__LP64__) && __LP64__
+#    define CGFLOAT_MAX DBL_MAX
+#  else
+#    define CGFLOAT_MAX FLT_MAX
+#  endif
+#endif
+
 /* Private NSViewController hooks used to drive a controller's appearance
    transitions when its view moves between windows. */
 @interface NSViewController (GSViewAppearance)
 + (NSViewController *) _viewControllerForView: (NSView *)aView;
 - (void) _viewWillMoveToWindow: (NSWindow *)newWindow;
 - (void) _viewDidMoveToWindow;
+@end
+
+@interface NSView (GSPrivateVisibleRect)
+- (NSRect) _geometricVisibleRect;
 @end
 
 /**
@@ -363,9 +379,9 @@ GSSetDragTypes(NSView* obj, NSArray *types)
 
 	  if (_super_view != nil)
 	    {
-	      superviewsVisibleRect = [self convertRect: [_super_view visibleRect]
+	      superviewsVisibleRect = [self convertRect: [_super_view _geometricVisibleRect]
 					       fromView: _super_view];
-	      
+
 	      _visibleRect = NSIntersectionRect(superviewsVisibleRect, _bounds);
 	    }
 	  else
@@ -2439,7 +2455,7 @@ static void autoresize(CGFloat oldContainerSize,
 
 - (void) lockFocus
 {
-  [self lockFocusInRect: [self visibleRect]];
+  [self lockFocusInRect: [self _geometricVisibleRect]];
 }
 
 - (void) unlockFocus
@@ -2456,7 +2472,7 @@ static void autoresize(CGFloat oldContainerSize,
 {
   if ([self canDraw])
     {
-      [self _lockFocusInContext: context inRect: [self visibleRect]];
+      [self _lockFocusInContext: context inRect: [self _geometricVisibleRect]];
       return YES;
     }
   else
@@ -2510,14 +2526,14 @@ static void autoresize(CGFloat oldContainerSize,
 
 - (void) display
 {
-  [self displayRect: [self visibleRect]];
+  [self displayRect: [self _geometricVisibleRect]];
 }
 
 - (void) displayIfNeeded
 {
   if (_rFlags.needs_display == YES)
     {
-      [self displayIfNeededInRect: [self visibleRect]];
+      [self displayIfNeededInRect: [self _geometricVisibleRect]];
     }
 }
 
@@ -2525,7 +2541,7 @@ static void autoresize(CGFloat oldContainerSize,
 {
   if (_rFlags.needs_display == YES)
     {
-      [self displayIfNeededInRectIgnoringOpacity: [self visibleRect]];
+      [self displayIfNeededInRectIgnoringOpacity: [self _geometricVisibleRect]];
     }
 }
 
@@ -2650,7 +2666,7 @@ static void autoresize(CGFloat oldContainerSize,
   if (context == wContext)
     {
       NSRect neededRect;
-      NSRect visibleRect = [self visibleRect];
+      NSRect visibleRect = [self _geometricVisibleRect];
 
       flush = YES;
       [_window disableFlushWindow];
@@ -2763,7 +2779,10 @@ static void autoresize(CGFloat oldContainerSize,
 - (void) drawRect: (NSRect)rect
 {}
 
-- (NSRect) visibleRect
+/* The visible rectangle clipped to the superview chain, in the receiver's
+   coordinates.  Used for the coordinate and drawing machinery, which needs a
+   bounded rectangle even when the view has no window. */
+- (NSRect) _geometricVisibleRect
 {
   if ([self isHiddenOrHasHiddenAncestor])
     {
@@ -2775,6 +2794,19 @@ static void autoresize(CGFloat oldContainerSize,
       [self _rebuildCoordinates];
     }
   return _visibleRect;
+}
+
+- (NSRect) visibleRect
+{
+  if (_window == nil && ![self isHiddenOrHasHiddenAncestor])
+    {
+      /* AppKit reports an unbounded visible rectangle for a view that is not
+         in a window. */
+      return NSMakeRect(-CGFLOAT_MAX / 2, -CGFLOAT_MAX / 2,
+                        CGFLOAT_MAX, CGFLOAT_MAX);
+    }
+
+  return [self _geometricVisibleRect];
 }
 
 - (BOOL) wantsDefaultClipping

--- a/Tests/gui/NSView/visibleClip.m
+++ b/Tests/gui/NSView/visibleClip.m
@@ -20,10 +20,8 @@ int main(int argc, const char **argv)
       SKIP("It looks like GNUstep backend is not yet installed")
   NS_ENDHANDLER
 
-  /* -[NSView visibleRect] on a view with no window returns the view's own
-     bounds in GNUstep, rather than AppKit's unbounded sentinel rect for a
-     view with no clip context at all. Confirmed divergence, not asserted
-     here (see Divergences). */
+  /* -[NSView visibleRect] on a view with no window returns AppKit's unbounded
+     rect; that is exercised in visibleRectNoWindow.m. */
 
   {
     NSScrollView *sv = AUTORELEASE([[NSScrollView alloc] initWithFrame: NSMakeRect(0, 0, 100, 100)]);

--- a/Tests/gui/NSView/visibleRectNoWindow.m
+++ b/Tests/gui/NSView/visibleRectNoWindow.m
@@ -1,0 +1,45 @@
+#import "Testing.h"
+#import <Foundation/NSGeometry.h>
+#import <AppKit/NSView.h>
+
+/* -[NSView visibleRect] on a view with no window reports an unbounded
+   rectangle, matching AppKit (checked on a macOS runner: origin
+   {-CGFLOAT_MAX/2, -CGFLOAT_MAX/2}, size {CGFLOAT_MAX, CGFLOAT_MAX}).  A hidden
+   view still reports NSZeroRect.  This needs no window server. */
+
+static const CGFloat huge = 1.0e30;
+
+static BOOL
+isUnbounded(NSRect r)
+{
+  return (r.size.width > huge) && (r.size.height > huge)
+    && (r.origin.x < -huge) && (r.origin.y < -huge);
+}
+
+int main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSView *v, *sup, *child, *hidden;
+
+  v = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 100, 80)]);
+  PASS(isUnbounded([v visibleRect]),
+       "a windowless view has an unbounded visibleRect");
+  PASS(NSContainsRect([v visibleRect], [v bounds]),
+       "the unbounded visibleRect contains the view bounds");
+
+  sup = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 200, 200)]);
+  child = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(10, 10, 50, 50)]);
+  [sup addSubview: child];
+  PASS(isUnbounded([child visibleRect]),
+       "a windowless view inside a windowless superview is also unbounded");
+  PASS(isUnbounded([sup visibleRect]),
+       "the windowless superview is unbounded too");
+
+  hidden = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 100, 80)]);
+  [hidden setHidden: YES];
+  PASS(NSEqualRects([hidden visibleRect], NSZeroRect),
+       "a hidden windowless view has a zero visibleRect");
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-[NSView visibleRect] returned the view's own bounds for a view that is not in a window, where AppKit reports an unbounded rectangle. This returns that rectangle for a windowless, non-hidden view to match (checked on a macOS runner: origin {-CGFLOAT_MAX/2, -CGFLOAT_MAX/2}, size {CGFLOAT_MAX, CGFLOAT_MAX}, for the view and for a windowless view nested in a windowless superview). A hidden view still reports NSZeroRect.

The coordinate and drawing machinery needs a bounded rectangle even without a window - the superview intersection in -_rebuildCoordinates would otherwise convert an unbounded rectangle and overflow - so that code, along with the lock-focus and display entry points, now uses a new private -_geometricVisibleRect that keeps the previous clipped-bounds behaviour. Only the public accessor changes, so a view in a window is unaffected (the full NSView/NSScrollView/NSClipView/NSSplitView/NSTableView/NSTextView suites pass unchanged).

CGFLOAT_MAX is defined locally and gated with #ifndef so the library does not depend on CoreFoundation for it.

New Tests/gui/NSView/visibleRectNoWindow.m covers the windowless cases.

Closes #613
