### PR TITLE
Fix: reload the theme when the preference change notification arrives

### DIFF
--- a/Source/GSTheme.m
+++ b/Source/GSTheme.m
@@ -518,11 +518,11 @@ typedef	struct {
 {
   NSUserDefaults	*defaults;
 
-  NSLog(@"System preference changing");
   defaults = [NSUserDefaults standardUserDefaults];
   [defaults synchronize];
-  NSLog(@"System preference changed; default theme is %@",
+  NSDebugMLLog(@"GSTheme", @"default theme is now %@",
     [defaults objectForKey: @"GSTheme"]);
+  [self defaultsDidChange: nil];
 }
 
 + (void) setTheme: (GSTheme*)theme


### PR DESCRIPTION
This addresses the slow, incomplete propagation part of #431.

+preferenceDidChange: is the handler for the distributed GSThemePreferenceDidChangeNotification that SystemPreferences posts when the user changes the theme. It only synchronized the defaults and did nothing else, so a running application did not actually switch theme until the local NSUserDefaultsDidChangeNotification happened to fire. That is what made the change take up to half a minute to show up in other applications, and it never showed up at all for an application still on the default theme (whose local defaults observer is not registered, since +setTheme: only registers it when the theme actually changes).

The handler now calls +defaultsDidChange: after synchronizing, so the new theme is loaded and activated as soon as the notification arrives. +defaultsDidChange: already compares against the current theme name, so it is a no-op when nothing changed, and calling it directly does not depend on the local observer being present.

The two unconditional NSLog calls in the handler are moved to the GSTheme debug channel (visible with --GNU-Debug=GSTheme), which is how this was diagnosed in the issue.

The image caching part was already handled in b6eed598, and the colour path in -[NSColor themeDidActivate:] already fills any colour the new theme does not override from the default system colours, so a switch reverts non-overridden colours.

I have not added a test: exercising this needs a second theme bundle and a second process posting the distributed notification, and it mutates the global active theme and the on-disk GSTheme default, which is not suitable for the headless suite. cc @rmottola 

Refs #431
