### PR TITLE
Feature: grow the typesetter glyph cache geometrically rather than in fixed steps

### DIFF
--- a/Source/GSHorizontalTypesetter.m
+++ b/Source/GSHorizontalTypesetter.m
@@ -96,7 +96,7 @@ cache fairly aggressively without having to worry about memory consumption.
   return shared;
 }
 
-#define CACHE_INITIAL 192
+#define CACHE_INITIAL 512
 #define CACHE_STEP 192
 
 
@@ -224,7 +224,18 @@ typedef struct GSHorizontalTypesetterGlyphCacheStruct GlyphCacheEntry;
 
   if (cacheSize < newLength)
     {
-      cacheSize = newLength;
+      /* Grow the allocation geometrically but gently (half again, rather than
+         to exactly the requested length or by doubling) so that laying out a
+         long run reallocates only a handful of times, starting from a
+         reasonably large initial block. */
+      if (cacheSize < CACHE_INITIAL)
+        {
+          cacheSize = CACHE_INITIAL;
+        }
+      while (cacheSize < newLength)
+        {
+          cacheSize += cacheSize / 2;
+        }
       glyphCache = realloc(glyphCache, sizeof(GlyphCacheEntry) * cacheSize);
     }
 

--- a/Tests/gui/GSHorizontalTypesetter/longRun.m
+++ b/Tests/gui/GSHorizontalTypesetter/longRun.m
@@ -1,0 +1,87 @@
+/* GSHorizontalTypesetter lays out a run that is much longer than the initial
+   glyph cache, so the cache grows several times while laying it out.  This
+   exercises that growth and checks that every glyph is still laid out and the
+   run flows onto multiple lines.  The typesetter uses the font backend, so the
+   set is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSDictionary.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSAttributedString.h>
+#include <AppKit/NSFont.h>
+#include <AppKit/NSTextStorage.h>
+#include <AppKit/NSLayoutManager.h>
+#include <AppKit/NSTextContainer.h>
+#include <AppKit/NSStringDrawing.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("GSHorizontalTypesetter longRun")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      const NSUInteger length = 3000;
+      NSFont *font = [NSFont userFontOfSize: 12.0];
+      NSDictionary *attrs = [NSDictionary dictionaryWithObjectsAndKeys:
+        font, NSFontAttributeName, nil];
+      NSString *s = [@"" stringByPaddingToLength: length
+                                      withString: @"a b c d "
+                                 startingAtIndex: 0];
+      NSTextStorage *ts = AUTORELEASE([[NSTextStorage alloc]
+        initWithString: s attributes: attrs]);
+      NSLayoutManager *lm = AUTORELEASE([[NSLayoutManager alloc] init]);
+      [ts addLayoutManager: lm];
+      NSTextContainer *tc = AUTORELEASE([[NSTextContainer alloc]
+        initWithContainerSize: NSMakeSize(300, 1.0e6)]);
+      [tc setLineFragmentPadding: 0.0];
+      [lm addTextContainer: tc];
+
+      NSRange gr = [lm glyphRangeForTextContainer: tc];
+
+      PASS([lm numberOfGlyphs] == length,
+           "every glyph of a long run is generated");
+      PASS(gr.location == 0 && gr.length == length,
+           "the whole long run is laid out in the container");
+
+      NSRange first, last;
+      NSRect firstFrag = [lm lineFragmentRectForGlyphAtIndex: 0
+                                             effectiveRange: &first];
+      NSRect lastFrag = [lm lineFragmentRectForGlyphAtIndex: length - 1
+                                            effectiveRange: &last];
+      PASS(NSMinY(lastFrag) > NSMinY(firstFrag),
+           "the run wraps onto later lines below the first");
+      PASS(last.location + last.length == length,
+           "the last line fragment reaches the end of the run");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available");
+    }
+  NS_ENDHANDLER
+
+  END_SET("GSHorizontalTypesetter longRun")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
-_cacheGlyphsUpToLength: grew the glyph cache to exactly the requested length, and the callers extend it in CACHE_STEP (192) glyph increments, so laying out a long run reallocated the cache roughly every 192 glyphs.

Following the suggestion on the issue to prefer a larger initial cache with a slower rate of growth (rather than the simple doubling first proposed), this starts from a larger initial block and grows the allocation by half again each time it is too small, so a long run reallocates only a handful of times. The cache still fills in CACHE_STEP increments and the resulting layout is unchanged.

New Tests/gui/GSHorizontalTypesetter/longRun.m lays out a run much longer than the initial cache so the growth path runs several times, and checks every glyph is still laid out and the run flows onto later lines.

Closes #408
