### PR TITLE
Feature: implement the truncating line break modes in the typesetter

### DIFF
--- a/Headers/Additions/GNUstepGUI/GSLayoutManager.h
+++ b/Headers/Additions/GNUstepGUI/GSLayoutManager.h
@@ -323,8 +323,20 @@ invalidation.)
 - (void) setLocation: (NSPoint)location 
 	forStartOfGlyphRange: (NSRange)glyphRange;
 
-- (void) setAttachmentSize: (NSSize)attachmentSize 
+- (void) setAttachmentSize: (NSSize)attachmentSize
 	forGlyphRange: (NSRange)glyphRange; /* not OPENSTEP */
+
+/* Set a truncation glyph (typically an ellipsis) to be drawn at the given
+   point in the line fragment that contains glyphRange, indicating that a line
+   break mode dropped glyphs to fit.  A glyph of 0 clears it.  not OPENSTEP */
+- (void) setTruncationGlyph: (NSGlyph)glyph
+		    atPoint: (NSPoint)location
+		       font: (NSFont *)font
+	      forGlyphRange: (NSRange)glyphRange;
+
+/* The truncation glyph of the line fragment that contains the given glyph, or
+   NSNullGlyph if that fragment is not truncated.  not OPENSTEP */
+- (NSGlyph) truncationGlyphForGlyphAtIndex: (NSUInteger)glyphIndex;
 
 
 - (NSTextContainer *) textContainerForGlyphAtIndex: (NSUInteger)glyphIndex

--- a/Headers/Additions/GNUstepGUI/GSLayoutManager_internal.h
+++ b/Headers/Additions/GNUstepGUI/GSLayoutManager_internal.h
@@ -162,6 +162,15 @@ typedef struct
 
   linefrag_attachment_t *attachments;
   int num_attachments;
+
+  /* Truncation indicator (typically an ellipsis) drawn when a line break mode
+     removes glyphs to fit the fragment.  truncationGlyph is 0 when the fragment
+     is not truncated.  truncationPoint is relative to the fragment rect and
+     truncationFont is not retained (it is held by the text storage during
+     layout, like the glyph run fonts). */
+  NSGlyph truncationGlyph;
+  NSPoint truncationPoint;
+  NSFont *truncationFont;
 } linefrag_t;
 
 typedef struct GSLayoutManager_textcontainer_s

--- a/Source/GSHorizontalTypesetter.m
+++ b/Source/GSHorizontalTypesetter.m
@@ -41,9 +41,14 @@
 #import "AppKit/NSTextAttachment.h"
 #import "AppKit/NSTextContainer.h"
 #import "AppKit/NSTextStorage.h"
+#import "AppKit/NSFont.h"
 #import "GNUstepGUI/GSLayoutManager.h"
 #import "GNUstepGUI/GSHorizontalTypesetter.h"
 
+
+@interface NSFont (GSTypesetterPrivate)
+- (NSGlyph) _defaultGlyphForChar: (unichar)theChar;
+@end
 
 
 /*
@@ -354,6 +359,13 @@ struct GSHorizontalTypesetterLineFragmentStruct
   NSRect rect;
   CGFloat lastUsed;
   unsigned int lastGlyphIndex; /* lastGlyphIndex+1, actually */
+
+  /* Set when a truncating line break mode drops glyphs to fit: the glyph to
+     draw as the truncation indicator (0 if none), its position relative to the
+     line's baseline, and the font to draw it with. */
+  NSGlyph truncationGlyph;
+  NSPoint truncationPoint;
+  NSFont *truncationFont;
 };
 typedef struct GSHorizontalTypesetterLineFragmentStruct LineFragment;
 
@@ -937,8 +949,11 @@ static inline BOOL wantNewLineHeight(CGFloat height, CGFloat *lineHeight, CGFloa
       if (!doesGlyphFitInLineFragment)
         {
           /* It didn't. Try to break the line. */
+          BOOL truncating = NO;
+          int truncationMode = 0; /* 1 = head, 2 = middle */
+
           switch ([currentParagraphStyle lineBreakMode])
-            { /* TODO: implement all modes */
+            {
               default:
               case NSLineBreakByCharWrapping:
                 lineFragment->lastGlyphIndex = *glyphIndex;
@@ -954,14 +969,73 @@ static inline BOOL wantNewLineHeight(CGFloat height, CGFloat *lineHeight, CGFloa
                 break;
 
               case NSLineBreakByTruncatingHead:
+                truncationMode = 1;
+                truncating = YES;
+                /* fall through */
               case NSLineBreakByTruncatingMiddle:
+                if (truncationMode == 0)
+                  {
+                    truncationMode = 2;
+                  }
+                truncating = YES;
+                /* fall through */
               case NSLineBreakByTruncatingTail:
-                /* Pretending that these are clipping is far from prefect,
-                   but it's the closest we've got. */
+                if (truncationMode == 0)
+                  {
+                    /* Fit a truncation glyph (an ellipsis) at the end of the
+                       line, dropping the trailing glyphs it needs room for.
+                       Head and middle reposition the visible glyphs after the
+                       scan below. */
+                    NSFont *efont = glyphCache[(*glyphIndex > firstGlyphIndex)
+                      ? *glyphIndex - 1 : firstGlyphIndex].font;
+                    NSGlyph ellipsis = [efont _defaultGlyphForChar: 0x2026];
+
+                    if (ellipsis != NSNullGlyph)
+                      {
+                        CGFloat ellipsisWidth
+                          = [efont advancementForGlyph: ellipsis].width;
+                        CGFloat maxX = lineFragment->rect.size.width;
+                        int k = (int)*glyphIndex - 1;
+                        int j;
+
+                        while (k >= (int)firstGlyphIndex
+                          && glyphCache[k].position.x + glyphCache[k].size.width
+                             + ellipsisWidth > maxX)
+                          {
+                            k--;
+                          }
+                        for (j = k + 1; j < (int)*glyphIndex; j++)
+                          {
+                            glyphCache[j].dontShow = YES;
+                          }
+                        if (k >= (int)firstGlyphIndex)
+                          {
+                            lineFragment->truncationPoint.x
+                              = glyphCache[k].position.x + glyphCache[k].size.width;
+                          }
+                        else
+                          {
+                            lineFragment->truncationPoint.x
+                              = glyphCache[firstGlyphIndex].position.x;
+                          }
+                        lineFragment->truncationPoint.y = position->y;
+                        lineFragment->truncationGlyph = ellipsis;
+                        lineFragment->truncationFont = efont;
+                        truncating = YES;
+                      }
+                  }
+                /* fall through to hide the overflowing glyphs */
               case NSLineBreakByClipping:
                 /* Scan forward to the next paragraph separator and mark
                    all the glyphs up to there as not visible. */
-                glyphEntry->outsideLineFragment = YES;
+                if (truncating)
+                  {
+                    glyphEntry->dontShow = YES;
+                  }
+                else
+                  {
+                    glyphEntry->outsideLineFragment = YES;
+                  }
                 while (1)
                   {
                     (*glyphIndex)++;
@@ -996,6 +1070,97 @@ static inline BOOL wantNewLineHeight(CGFloat height, CGFloat *lineHeight, CGFloa
 
                 lineFragment->lastGlyphIndex = *glyphIndex + 1;
                 break;
+            }
+
+          /* Head and middle truncation: the scan above cached the whole line
+             and hid its glyphs.  Show a suffix (head) or a prefix and a suffix
+             (middle), place the ellipsis, and reposition the shown suffix. */
+          if (truncationMode != 0
+            && lineFragment->lastGlyphIndex > firstGlyphIndex)
+            {
+              int first = (int)firstGlyphIndex;
+              int last = (int)lineFragment->lastGlyphIndex - 1;
+              NSFont *efont;
+              NSGlyph ellipsis;
+
+              /* Do not count a trailing newline as a visible glyph. */
+              while (last > first && glyphCache[last].glyph == NSControlGlyph)
+                last--;
+
+              efont = glyphCache[last].font;
+              ellipsis = [efont _defaultGlyphForChar: 0x2026];
+
+              if (ellipsis != NSNullGlyph)
+                {
+                  CGFloat E = [efont advancementForGlyph: ellipsis].width;
+                  CGFloat maxX = lineFragment->rect.size.width;
+                  CGFloat lineY = glyphCache[first].position.y;
+                  int p = first - 1;         /* last prefix glyph (middle) */
+                  int s;                     /* first suffix glyph shown */
+                  CGFloat suffixX;
+                  int j;
+
+                  if (truncationMode == 2)
+                    {
+                      /* Middle: keep a prefix that fits in half the room. */
+                      CGFloat pw = 0.0;
+
+                      while (p + 1 <= last
+                        && pw + glyphCache[p + 1].size.width <= (maxX - E) / 2.0)
+                        {
+                          p++;
+                          pw += glyphCache[p].size.width;
+                        }
+                    }
+
+                  /* Suffix: the trailing glyphs that fit in the room left after
+                     the prefix and the ellipsis. */
+                  {
+                    CGFloat room = maxX - E
+                      - ((p >= first)
+                         ? glyphCache[p].position.x + glyphCache[p].size.width
+                         : 0.0);
+                    CGFloat sw = 0.0;
+
+                    s = last + 1;
+                    while (s - 1 > p
+                      && sw + glyphCache[s - 1].size.width <= room)
+                      {
+                        s--;
+                        sw += glyphCache[s].size.width;
+                      }
+                    if (s > last)      /* always show at least the last glyph */
+                      s = last;
+                  }
+
+                  /* Hide everything before the shown suffix that is not part of
+                     the kept prefix. */
+                  for (j = p + 1; j < s; j++)
+                    glyphCache[j].dontShow = YES;
+
+                  /* Reposition and show the suffix after the ellipsis. */
+                  if (p >= first)
+                    suffixX = glyphCache[p].position.x + glyphCache[p].size.width + E;
+                  else
+                    suffixX = E;
+                  for (j = s; j <= last; j++)
+                    {
+                      glyphCache[j].dontShow = NO;
+                      glyphCache[j].position.x = suffixX;
+                      glyphCache[j].position.y = lineY;
+                      glyphCache[j].nominal = NO;
+                      suffixX += glyphCache[j].size.width;
+                    }
+
+                  lineFragment->truncationGlyph = ellipsis;
+                  lineFragment->truncationFont = efont;
+                  lineFragment->truncationPoint.y = lineY;
+                  if (p >= first)
+                    lineFragment->truncationPoint.x
+                      = glyphCache[p].position.x + glyphCache[p].size.width;
+                  else
+                    lineFragment->truncationPoint.x = 0.0;
+                }
             }
 
           /* We force at least one glyph into each line fragment rect. This
@@ -1180,6 +1345,7 @@ static inline BOOL wantNewLineHeight(CGFloat height, CGFloat *lineHeight, CGFloa
                   lineFragments = realloc(lineFragments, sizeof(LineFragment) * lineFragmentCapacity);
                 }
               lineFragments[lineFragmentCount - 1].rect = rect;
+              lineFragments[lineFragmentCount - 1].truncationGlyph = NSNullGlyph;
 
               rect = [currentTextContainer lineFragmentRectForProposedRect: remain
                                                             sweepDirection: NSLineSweepRight
@@ -1280,6 +1446,16 @@ static inline BOOL wantNewLineHeight(CGFloat height, CGFloat *lineHeight, CGFloa
         [currentLayoutManager setLineFragmentRect: lineFragment->rect
                                     forGlyphRange: NSMakeRange(cacheBase + glyphCounter, lineFragment->lastGlyphIndex - glyphCounter)
                                          usedRect: usedRect];
+        if (lineFragment->truncationGlyph != NSNullGlyph)
+          {
+            NSPoint tp = lineFragment->truncationPoint;
+
+            tp.y += baseline;
+            [currentLayoutManager setTruncationGlyph: lineFragment->truncationGlyph
+                                             atPoint: tp
+                                                font: lineFragment->truncationFont
+                                       forGlyphRange: NSMakeRange(cacheBase + glyphCounter, lineFragment->lastGlyphIndex - glyphCounter)];
+          }
         glyphPosition = glyphEntry->position;
         glyphPosition.y += baseline;
         savedGlyphCounter = glyphCounter;

--- a/Source/GSLayoutManager.m
+++ b/Source/GSLayoutManager.m
@@ -2339,6 +2339,51 @@ forStartOfGlyphRange: (NSRange)glyphRange
 }
 
 
+- (void) setTruncationGlyph: (NSGlyph)glyph
+		    atPoint: (NSPoint)location
+		       font: (NSFont *)font
+	      forGlyphRange: (NSRange)glyphRange
+{
+  textcontainer_t *tc;
+  int i;
+  linefrag_t *lf;
+
+  SETUP_STUFF
+
+  for (i = 0, tc = textcontainers; i < num_textcontainers; i++, tc++)
+    {
+      if (tc->pos <= glyphRange.location &&
+	  tc->pos + tc->length >= glyphRange.location + glyphRange.length)
+	break;
+    }
+  if (i == num_textcontainers)
+    {
+      [NSException raise: NSRangeException
+		  format: @"%s: glyph range not consistent with existing layout",
+			  __PRETTY_FUNCTION__];
+      return;
+    }
+
+  for (i = tc->num_linefrags - 1, lf = tc->linefrags + i; i >= 0; i--, lf--)
+    {
+      if (lf->pos <= glyphRange.location &&
+	  lf->pos + lf->length >= glyphRange.location + glyphRange.length)
+	break;
+    }
+  if (i < 0)
+    {
+      [NSException raise: NSRangeException
+		  format: @"%s: glyph range not consistent with existing layout",
+			  __PRETTY_FUNCTION__];
+      return;
+    }
+
+  lf->truncationGlyph = glyph;
+  lf->truncationPoint = location;
+  lf->truncationFont = font;
+}
+
+
 -(void) setAttachmentSize: (NSSize)size
 	    forGlyphRange: (NSRange)glyphRange
 {
@@ -2561,6 +2606,29 @@ forStartOfGlyphRange: (NSRange)glyphRange
 {
   return [self rangeOfNominallySpacedGlyphsContainingIndex: glyphIndex
 	       startLocation: NULL];
+}
+
+
+- (NSGlyph) truncationGlyphForGlyphAtIndex: (NSUInteger)glyphIndex
+{
+  int i;
+  textcontainer_t *tc;
+  linefrag_t *lf;
+
+  [self _doLayoutToGlyph: glyphIndex];
+  for (i = 0, tc = textcontainers; i < num_textcontainers; i++, tc++)
+    if (tc->pos + tc->length > glyphIndex)
+      break;
+  if (i == num_textcontainers)
+    return NSNullGlyph;
+
+  for (i = 0, lf = tc->linefrags; i < tc->num_linefrags; i++, lf++)
+    if (lf->pos + lf->length > glyphIndex)
+      break;
+  if (i == tc->num_linefrags)
+    return NSNullGlyph;
+
+  return lf->truncationGlyph;
 }
 
 

--- a/Source/NSLayoutManager.m
+++ b/Source/NSLayoutManager.m
@@ -1887,6 +1887,40 @@ for (i = 0; i < gbuf_len; i++) printf("   %3i : %04x\n", i, gbuf[i]); */
 
 #undef GBUF_SIZE
 
+  /* Draw any truncation glyph (typically an ellipsis) recorded on the line
+     fragments overlapping the drawn range. */
+  {
+    linefrag_t *tlf;
+    int tli;
+
+    for (tli = 0, tlf = tc->linefrags; tli < tc->num_linefrags; tli++, tlf++)
+      {
+	if (tlf->truncationGlyph != 0
+	  && tlf->pos < NSMaxRange(range)
+	  && tlf->pos + tlf->length > range.location)
+	  {
+	    NSGlyph tg = tlf->truncationGlyph;
+	    NSSize tadv = NSMakeSize(0.0, 0.0);
+	    NSColor *tcolor;
+	    NSPoint tp;
+
+	    tcolor = [_textStorage attribute: NSForegroundColorAttributeName
+				     atIndex: [self characterIndexForGlyphAtIndex: tlf->pos]
+			      effectiveRange: NULL];
+	    if (tcolor == nil)
+	      tcolor = defaultTextColor;
+	    [tcolor set];
+	    [tlf->truncationFont set];
+
+	    tp.x = tlf->rect.origin.x + tlf->truncationPoint.x + containerOrigin.x;
+	    tp.y = tlf->rect.origin.y + tlf->truncationPoint.y + containerOrigin.y;
+	    DPSmoveto(ctxt, tp.x, tp.y);
+	    GSShowGlyphsWithAdvances(ctxt, &tg, &tadv, 1);
+	    DPSnewpath(ctxt);
+	  }
+      }
+  }
+
   // Draw underline where necessary
   // FIXME: Also draw strikeout
   {

--- a/Tests/gui/GSHorizontalTypesetter/truncation.m
+++ b/Tests/gui/GSHorizontalTypesetter/truncation.m
@@ -50,8 +50,6 @@ layoutWithBreakMode(NSLineBreakMode mode)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("GSHorizontalTypesetter truncation")
 
   NS_DURING
@@ -123,6 +121,5 @@ main(int argc, char **argv)
 
   END_SET("GSHorizontalTypesetter truncation")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/GSHorizontalTypesetter/truncation.m
+++ b/Tests/gui/GSHorizontalTypesetter/truncation.m
@@ -1,0 +1,128 @@
+/* GSHorizontalTypesetter implements NSLineBreakByTruncatingTail: text that does
+   not fit the line is laid out on a single line fragment with the trailing
+   glyphs hidden and an ellipsis truncation glyph set on the fragment, rather
+   than being clipped with no indicator.  A non-truncating line break mode sets
+   no truncation glyph.  The typesetter uses the font backend, so the set is
+   skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSDictionary.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSAttributedString.h>
+#include <AppKit/NSFont.h>
+#include <AppKit/NSTextStorage.h>
+#include <AppKit/NSLayoutManager.h>
+#include <AppKit/NSTextContainer.h>
+#include <AppKit/NSParagraphStyle.h>
+#include <AppKit/NSStringDrawing.h>
+
+@interface NSFont (TruncationTest)
+- (NSGlyph) _defaultGlyphForChar: (unichar)theChar;
+@end
+
+/* Lays out a 20-glyph run in a narrow one-line container with the given line
+   break mode and returns the layout manager. */
+static NSLayoutManager *
+layoutWithBreakMode(NSLineBreakMode mode)
+{
+  NSFont *font = [NSFont userFontOfSize: 12.0];
+  NSMutableParagraphStyle *ps = AUTORELEASE([[NSMutableParagraphStyle alloc] init]);
+  [ps setLineBreakMode: mode];
+  NSDictionary *attrs = [NSDictionary dictionaryWithObjectsAndKeys:
+    font, NSFontAttributeName, ps, NSParagraphStyleAttributeName, nil];
+  NSTextStorage *ts = AUTORELEASE([[NSTextStorage alloc]
+    initWithString: @"aaaaaaaaaaaaaaaaaaaa" attributes: attrs]);
+  NSLayoutManager *lm = AUTORELEASE([[NSLayoutManager alloc] init]);
+  [ts addLayoutManager: lm];
+  NSTextContainer *tc = AUTORELEASE([[NSTextContainer alloc]
+    initWithContainerSize: NSMakeSize(50, 1000)]);
+  [tc setLineFragmentPadding: 0.0];
+  [lm addTextContainer: tc];
+  [lm glyphRangeForTextContainer: tc];
+  return lm;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("GSHorizontalTypesetter truncation")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      NSFont *font = [NSFont userFontOfSize: 12.0];
+      NSGlyph ellipsis = [font _defaultGlyphForChar: 0x2026];
+      NSLayoutManager *lm;
+      NSRange r;
+
+      lm = layoutWithBreakMode(NSLineBreakByTruncatingTail);
+
+      PASS([lm numberOfGlyphs] == 20, "all glyphs are generated");
+
+      [lm lineFragmentRectForGlyphAtIndex: 0 effectiveRange: &r];
+      PASS(r.location == 0 && r.length == 20,
+           "truncating tail keeps the whole run in one line fragment");
+
+      PASS([lm notShownAttributeForGlyphAtIndex: 0] == NO,
+           "the first glyph of a truncated line is shown");
+      PASS([lm notShownAttributeForGlyphAtIndex: 19] == YES,
+           "the trailing glyphs of a truncated line are hidden");
+
+      PASS(ellipsis != NSNullGlyph, "the font provides an ellipsis glyph");
+      PASS([lm truncationGlyphForGlyphAtIndex: 0] == ellipsis,
+           "an ellipsis truncation glyph is set on the truncated line");
+
+      lm = layoutWithBreakMode(NSLineBreakByWordWrapping);
+      PASS([lm truncationGlyphForGlyphAtIndex: 0] == NSNullGlyph,
+           "a wrapping line has no truncation glyph");
+
+      /* Head: the leading glyphs are hidden and the trailing ones shown. */
+      lm = layoutWithBreakMode(NSLineBreakByTruncatingHead);
+      PASS([lm notShownAttributeForGlyphAtIndex: 0] == YES,
+           "truncating head hides the leading glyphs");
+      PASS([lm notShownAttributeForGlyphAtIndex: 19] == NO,
+           "truncating head shows the trailing glyphs");
+      PASS([lm truncationGlyphForGlyphAtIndex: 0] == ellipsis,
+           "truncating head sets an ellipsis");
+
+      /* Middle: the first and last glyphs are shown, the middle hidden. */
+      lm = layoutWithBreakMode(NSLineBreakByTruncatingMiddle);
+      PASS([lm notShownAttributeForGlyphAtIndex: 0] == NO,
+           "truncating middle shows the leading glyphs");
+      PASS([lm notShownAttributeForGlyphAtIndex: 19] == NO,
+           "truncating middle shows the trailing glyphs");
+      PASS([lm notShownAttributeForGlyphAtIndex: 10] == YES,
+           "truncating middle hides the middle glyphs");
+      PASS([lm truncationGlyphForGlyphAtIndex: 0] == ellipsis,
+           "truncating middle sets an ellipsis");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available");
+    }
+  NS_ENDHANDLER
+
+  END_SET("GSHorizontalTypesetter truncation")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSLineBreakByTruncatingTail, ...Head and ...Middle all fell through to clipping: the glyphs that did not fit were hidden and no ellipsis was drawn, and head and middle kept the wrong glyphs.

This adds a real truncation indicator. A line fragment can now carry a truncation glyph (an ellipsis) with a position and font:

- GSLayoutManager stores it as transient layout information on the line fragment (in linefrag_t), set by the typesetter through -setTruncationGlyph:atPoint:font:forGlyphRange: and read back with -truncationGlyphForGlyphAtIndex:. Because it is layout information and not written into the glyph store, a re-layout regenerates it correctly and the glyph/character mapping is untouched.
- NSLayoutManager draws the truncation glyph after the fragment's glyphs.
- GSHorizontalTypesetter handles the three modes: tail drops the trailing glyphs and places the ellipsis at the end; head shows a trailing suffix after a leading ellipsis; middle keeps a leading prefix and a trailing suffix with the ellipsis between them. Dropped glyphs are marked not-shown and the shown suffix is repositioned.

The ellipsis glyph comes from the font, and if the font has none the line is clipped as before.

Tests: Tests/gui/GSHorizontalTypesetter/truncation.m checks, for each mode, which glyphs are shown or hidden and that the ellipsis is set. Layout was verified against the full text-layout suites with no regressions, and drawing of all three modes was checked against the X11 backend under Xvfb.

Closes #414
