### PR TITLE
Fix: keep the paragraph head indent when drawing wrapped strings

### DIFF
--- a/Source/NSStringDrawing.m
+++ b/Source/NSStringDrawing.m
@@ -296,44 +296,6 @@ static cache_t *cache_lookup(BOOL hasSize, NSSize size, BOOL useScreenFonts)
   return c;
 }
 
-/* AppKit ignores a paragraph first line head indent in the convenience string
-   drawing methods: the text is laid out, measured and drawn from the origin,
-   not from the indent. Drop the indent from our private working copy so that
-   -boundingRectWithSize:options: and -drawInRect: agree and match AppKit. */
-static void strip_first_line_indent(NSTextStorage *textStorage)
-{
-  NSUInteger length = [textStorage length];
-  NSUInteger index = 0;
-
-  if (length == 0)
-    {
-      return;
-    }
-
-  [textStorage beginEditing];
-  while (index < length)
-    {
-      NSRange range;
-      NSParagraphStyle *style;
-
-      style = [textStorage attribute: NSParagraphStyleAttributeName
-                             atIndex: index
-                      effectiveRange: &range];
-      if (style != nil && [style firstLineHeadIndent] != 0.0)
-        {
-          NSMutableParagraphStyle *stripped = [style mutableCopy];
-
-          [stripped setFirstLineHeadIndent: 0.0];
-          [textStorage addAttribute: NSParagraphStyleAttributeName
-                              value: stripped
-                              range: range];
-          RELEASE(stripped);
-        }
-      index = NSMaxRange(range);
-    }
-  [textStorage endEditing];
-}
-
 static inline void prepare_string(NSString *string, NSDictionary *attributes)
 {
   cache_t *scratch = cache + NUM_CACHE_ENTRIES;
@@ -344,31 +306,8 @@ static inline void prepare_string(NSString *string, NSDictionary *attributes)
                                     withString: string];
   if ([string length])
     {
-      NSParagraphStyle *style = [attributes objectForKey:
-                                   NSParagraphStyleAttributeName];
-
-      /* AppKit ignores a paragraph first line head indent in these
-         convenience methods (see strip_first_line_indent).  The whole string
-         shares one attributes dictionary here, so dropping the indent from a
-         copy before it is applied avoids rewriting the laid out text. */
-      if (style != nil && [style firstLineHeadIndent] != 0.0)
-        {
-          NSMutableParagraphStyle *stripped = [style mutableCopy];
-          NSMutableDictionary *noIndent = [attributes mutableCopy];
-
-          [stripped setFirstLineHeadIndent: 0.0];
-          [noIndent setObject: stripped
-                       forKey: NSParagraphStyleAttributeName];
-          [scratchTextStorage setAttributes: noIndent
-                                      range: NSMakeRange(0, [string length])];
-          RELEASE(stripped);
-          RELEASE(noIndent);
-        }
-      else
-        {
-          [scratchTextStorage setAttributes: attributes
-                                      range: NSMakeRange(0, [string length])];
-        }
+      [scratchTextStorage setAttributes: attributes
+                                  range: NSMakeRange(0, [string length])];
     }
   [scratchTextStorage endEditing];
 }
@@ -380,7 +319,6 @@ static inline void prepare_attributed_string(NSAttributedString *string)
 
   [scratchTextStorage replaceCharactersInRange: NSMakeRange(0, [scratchTextStorage length])
                           withAttributedString: string];
-  strip_first_line_indent(scratchTextStorage);
 }
 
 static BOOL use_screen_fonts(void)
@@ -577,6 +515,11 @@ static void draw_in_rect(cache_t *c, NSRect rect)
       prepare_attributed_string(self);
       c = cache_lookup(hasSize, size, YES);
       result = c->usedRect;
+      /* A paragraph head indent shifts the laid out glyphs to the right, so it
+         appears in the used rect origin.  AppKit does not fold that offset into
+         the rectangle reported by the convenience methods: the origin stays at
+         zero (the indent still moves the drawn glyphs, see draw_in_rect).  */
+      result.origin.x = 0.0;
     }
   NS_HANDLER
     {

--- a/Tests/gui/NSAttributedString/headIndentDrawing.m
+++ b/Tests/gui/NSAttributedString/headIndentDrawing.m
@@ -1,0 +1,157 @@
+#import "Testing.h"
+#import "../GSRenderTest.h"
+#import <math.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSColor.h>
+#import <AppKit/NSFont.h>
+#import <AppKit/NSStringDrawing.h>
+#import <AppKit/NSAttributedString.h>
+#import <AppKit/NSParagraphStyle.h>
+
+/* A paragraph head indent shifts the drawn glyphs to the right on every line
+   of the paragraph, first line and wrapped continuation lines alike, so the
+   paragraph reads as one block with a common left edge (this matches AppKit).
+   Render a wrapped, indented string and check that the first and second drawn
+   lines start at the same column, and that the block is actually indented.
+   Needs a window server, so it skips cleanly without one. */
+
+#define INDENT 24.0
+
+@interface HeadIndentView : NSView
+@end
+
+@implementation HeadIndentView
+- (BOOL) isFlipped
+{
+  return YES;
+}
+- (void) drawRect: (NSRect)r
+{
+  NSMutableParagraphStyle *p = [[NSMutableParagraphStyle alloc] init];
+  NSDictionary *attrs;
+  NSAttributedString *s;
+
+  [[NSColor whiteColor] setFill];
+  NSRectFill([self bounds]);
+
+  [p setFirstLineHeadIndent: INDENT];
+  [p setHeadIndent: INDENT];
+  [p setLineBreakMode: NSLineBreakByWordWrapping];
+  attrs = [NSDictionary dictionaryWithObjectsAndKeys:
+             [NSFont systemFontOfSize: 12], NSFontAttributeName,
+             [NSColor blackColor], NSForegroundColorAttributeName,
+             p, NSParagraphStyleAttributeName, nil];
+  RELEASE(p);
+  s = AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"The quick brown fox jumps over the lazy dog"
+         attributes: attrs]);
+  [s drawInRect: [self bounds]];
+}
+@end
+
+/* Leftmost column carrying drawn (dark, opaque) content within a row band. */
+static int
+leftmostContent(NSBitmapImageRep *rep, int y0, int y1)
+{
+  NSInteger W = [rep pixelsWide];
+  int x, y;
+
+  for (x = 0; x < W; x++)
+    for (y = y0; y <= y1; y++)
+      {
+        CGFloat cr, cg, cb, ca;
+        [[[rep colorAtX: x y: y]
+          colorUsingColorSpaceName: NSDeviceRGBColorSpace]
+          getRed: &cr green: &cg blue: &cb alpha: &ca];
+        if (isnan(cr) || ca < 0.5)
+          continue;
+        if ((cr + cg + cb) / 3.0 < 0.5)
+          return x;
+      }
+  return -1;
+}
+
+/* Row has any dark, opaque content. */
+static BOOL
+rowHasContent(NSBitmapImageRep *rep, int y)
+{
+  NSInteger W = [rep pixelsWide];
+  int x, n = 0;
+
+  for (x = 0; x < W; x++)
+    {
+      CGFloat cr, cg, cb, ca;
+      [[[rep colorAtX: x y: y]
+        colorUsingColorSpaceName: NSDeviceRGBColorSpace]
+        getRed: &cr green: &cg blue: &cb alpha: &ca];
+      if (isnan(cr) || ca < 0.5)
+        continue;
+      if ((cr + cg + cb) / 3.0 < 0.5)
+        n++;
+    }
+  return (n > 2);
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSAttributedString head indent drawing")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      HeadIndentView *v = AUTORELEASE([[HeadIndentView alloc]
+        initWithFrame: NSMakeRect(0, 0, 150, 80)]);
+      NSBitmapImageRep *rep = GSRenderView(v);
+      NSInteger H, y;
+      int bands[8][2], nb = 0, inLine = 0, y0 = 0;
+      int l1, l2;
+
+      GSSavePNG(rep, @"headindentdrawing");
+      H = [rep pixelsHigh];
+
+      /* group content rows into line bands */
+      for (y = 0; y < H; y++)
+        {
+          BOOL c = rowHasContent(rep, (int)y);
+          if (c && !inLine) { inLine = 1; y0 = (int)y; }
+          else if (!c && inLine)
+            {
+              inLine = 0;
+              if ((int)y - y0 >= 2 && nb < 8)
+                { bands[nb][0] = y0; bands[nb][1] = (int)y - 1; nb++; }
+            }
+        }
+      if (inLine && nb < 8) { bands[nb][0] = y0; bands[nb][1] = (int)H - 1; nb++; }
+
+      PASS(nb >= 2, "the indented string wraps to at least two drawn lines");
+
+      if (nb >= 2)
+        {
+          l1 = leftmostContent(rep, bands[0][0], bands[0][1]);
+          l2 = leftmostContent(rep, bands[1][0], bands[1][1]);
+
+          PASS(l1 >= 0 && l2 >= 0, "both lines drew content");
+          PASS(l1 >= 0 && l2 >= 0 && abs(l1 - l2) <= 2,
+            "the wrapped continuation line starts at the same column as the first line");
+          PASS(l1 >= (int)(INDENT) - 6,
+            "the paragraph is drawn at the head indent, not flush to the edge");
+        }
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSAttributedString head indent drawing")
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSAttributedString/headIndentWrapped.m
+++ b/Tests/gui/NSAttributedString/headIndentWrapped.m
@@ -1,0 +1,82 @@
+#include "Testing.h"
+#include <math.h>
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSDictionary.h>
+#include <Foundation/NSException.h>
+#include <Foundation/NSGeometry.h>
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSAttributedString.h>
+#include <AppKit/NSParagraphStyle.h>
+#include <AppKit/NSStringDrawing.h>
+#include <AppKit/NSFont.h>
+
+/* A paragraph head indent shifts every line of the paragraph, so a wrapped
+   string laid out in a container of width W with indent I wraps in the same
+   column as the un-indented string laid out in a container of width W - I.  The
+   convenience bounding rect keeps its origin at zero (the indent is not folded
+   into the reported origin), while the reported size reflects that narrower
+   column.  Checked against AppKit on a macOS runner. */
+
+#define INDENT 24.0
+#define WIDTH  150.0
+
+static NSAttributedString *
+para(CGFloat indent)
+{
+  NSMutableParagraphStyle *p = [[NSMutableParagraphStyle alloc] init];
+  NSDictionary *attrs;
+
+  [p setFirstLineHeadIndent: indent];
+  [p setHeadIndent: indent];
+  [p setLineBreakMode: NSLineBreakByWordWrapping];
+  attrs = [NSDictionary dictionaryWithObjectsAndKeys:
+             [NSFont systemFontOfSize: 12], NSFontAttributeName,
+             p, NSParagraphStyleAttributeName, nil];
+  RELEASE(p);
+  return AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"The quick brown fox jumps over the lazy dog"
+         attributes: attrs]);
+}
+
+static NSRect
+bounds(NSAttributedString *s, CGFloat w)
+{
+  return [s boundingRectWithSize: NSMakeSize(w, 1000.0)
+                        options: NSStringDrawingUsesLineFragmentOrigin];
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSRect indented, narrowed, full;
+
+  START_SET("NSAttributedString wrapped head indent")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  indented = bounds(para(INDENT), WIDTH);
+  narrowed = bounds(para(0.0), WIDTH - INDENT);
+  full = bounds(para(0.0), WIDTH);
+
+  PASS(indented.origin.x == 0.0,
+    "a head indent leaves the wrapped bounding rect origin at zero");
+
+  PASS(fabs(indented.size.width - narrowed.size.width) < 0.5
+    && fabs(indented.size.height - narrowed.size.height) < 0.5,
+    "an indented paragraph wraps like the same text in a container narrowed "
+    "by the indent (the indent applies to every line, not just the first)");
+
+  PASS(indented.size.height >= full.size.height,
+    "indenting every line wraps to at least as many lines as the plain text");
+
+  END_SET("NSAttributedString wrapped head indent")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Closes #831. Follow-up to #350 and #820.

#820 made a single line with a paragraph head indent match AppKit, but a wrapped paragraph did not: the first line was drawn flush while the continuation lines kept the head indent, so the block was misaligned (visible in the GNUstep screenshot on #350).

This keeps the head indent in the laid out text, so every line is drawn at the indent, one aligned block as AppKit does. The indent offset is cleared from the origin reported by -boundingRectWithSize:options: instead of stripping the indent before layout. The reported origin stays at zero, so the single line result from #820 is unchanged.

Checked against AppKit with -drawWithRect:options: and -boundingRectWithSize:options:: every line is drawn at the indent, the reported origin stays at zero, and the indent narrows the wrapped column rather than being folded into the origin.

Tests. NSAttributedString/headIndentWrapped.m checks that an indented wrapped paragraph reports the same size as the same text in a container narrowed by the indent (the indent applies to every line) and keeps the bounding rect origin at zero. NSAttributedString/headIndentDrawing.m renders a wrapped indented paragraph and checks that the first and second lines start at the same column and that the block is drawn at the indent; it skips without a window server.
