### PR TITLE
Attach combo box popup and tooltip windows to their owner

### DIFF
--- a/Source/GSToolTips.m
+++ b/Source/GSToolTips.m
@@ -226,6 +226,34 @@ static BOOL   isOpening = NO;
 static NSSize		offset;
 static BOOL		restoreMouseMoved;
 
+static void
+GSSyncToolTipParentWindow(NSWindow *toolTipWindow, NSWindow *ownerWindow)
+{
+  NSWindow *parentWindow = [toolTipWindow parentWindow];
+
+  if (parentWindow != nil && parentWindow != ownerWindow)
+    {
+      [parentWindow removeChildWindow: toolTipWindow];
+      parentWindow = nil;
+    }
+
+  if (ownerWindow != nil && parentWindow != ownerWindow)
+    {
+      [ownerWindow addChildWindow: toolTipWindow ordered: NSWindowAbove];
+    }
+}
+
+static void
+GSDetachToolTipParentWindow(NSWindow *toolTipWindow)
+{
+  NSWindow *parentWindow = [toolTipWindow parentWindow];
+
+  if (parentWindow != nil)
+    {
+      [parentWindow removeChildWindow: toolTipWindow];
+    }
+}
+
 + (void) initialize
 {
   viewsMap = NSCreateMapTable(NSNonOwnedPointerMapKeyCallBacks,
@@ -567,6 +595,7 @@ static BOOL		restoreMouseMoved;
     {
       [window setFrame: NSZeroRect display: NO];
       [window orderOut:self];
+      GSDetachToolTipParentWindow(window);
     }
   if (restoreMouseMoved == YES)
     {
@@ -695,6 +724,7 @@ static BOOL		restoreMouseMoved;
   isOpening = YES;
   [(GSTTView*)([window contentView]) setText: toolTipText];
   [window setFrame: rect display: NO];
+  GSSyncToolTipParentWindow(window, [view window]);
   [window orderFront: nil];
   isOpening = NO;
 
@@ -702,4 +732,3 @@ static BOOL		restoreMouseMoved;
 }
 
 @end
-

--- a/Source/NSComboBoxCell.m
+++ b/Source/NSComboBoxCell.m
@@ -113,6 +113,34 @@ static NSNotificationCenter *nc;
 
 static GSComboWindow *gsWindow = nil;
 
+static void
+GSSyncComboPopupParentWindow(NSWindow *popupWindow, NSWindow *ownerWindow)
+{
+  NSWindow *parentWindow = [popupWindow parentWindow];
+
+  if (parentWindow != nil && parentWindow != ownerWindow)
+    {
+      [parentWindow removeChildWindow: popupWindow];
+      parentWindow = nil;
+    }
+
+  if (ownerWindow != nil && parentWindow != ownerWindow)
+    {
+      [ownerWindow addChildWindow: popupWindow ordered: NSWindowAbove];
+    }
+}
+
+static void
+GSDetachComboPopupParentWindow(NSWindow *popupWindow)
+{
+  NSWindow *parentWindow = [popupWindow parentWindow];
+
+  if (parentWindow != nil)
+    {
+      [parentWindow removeChildWindow: popupWindow];
+    }
+}
+
 @implementation GSComboWindow
 
 + (GSComboWindow *) defaultPopUp
@@ -368,7 +396,8 @@ static GSComboWindow *gsWindow = nil;
   [nc addObserver: self selector: @selector(onWindowEdited:) 
     name: NSWindowDidResizeNotification object: onWindow];
   // End of the code to remove
-  
+
+  GSSyncComboPopupParentWindow(self, onWindow);
   [self orderFront: self];
   [self makeFirstResponder: _tableView];
   [self runLoopWithComboBoxCell: comboBoxCell];
@@ -376,6 +405,7 @@ static GSComboWindow *gsWindow = nil;
   [nc removeObserver: self name: nil object: onWindow];
   
   [self close];
+  GSDetachComboPopupParentWindow(self);
 
   [onWindow makeFirstResponder: [_cell controlView]];
 }


### PR DESCRIPTION
Patch by @danjboyd, from #404.

Under GNOME on Wayland the combo box dropdown and the tooltip window were shown as independent top level windows, so they could appear once and then fail to reappear. This attaches the combo popup window and the shared tooltip window to their owning window as child windows before showing them, and detaches them on dismissal, following the same ownership model as menu windows.

Applied unchanged to current master, builds, and the NSComboBox tests pass. The GNOME/Wayland reopen behaviour was verified by @danjboyd on the environment described in #404; I was not able to reproduce that specific window manager under Weston/Xwayland here, so this carries their fix upstream.

Closes #404.
