### PR TITLE
NSTextView: don't flicker the mouse cursor while typing (#353)

### DIFF
--- a/Source/NSTextView.m
+++ b/Source/NSTextView.m
@@ -515,6 +515,36 @@ decoded.
 
 
 /*
+Returns YES if the text contains any attribute that -resetCursorRects turns
+into a custom (non-I-beam) cursor rect.  Currently that is only
+NSLinkAttributeName (the pointing-hand cursor over links); NSCursorAttributeName
+is still a FIXME in -resetCursorRects and so is intentionally not checked here.
+*/
+- (BOOL) _hasCustomCursorRegions
+{
+  NSTextStorage *storage = [self textStorage];
+  NSUInteger length = [storage length];
+  NSUInteger i = 0;
+
+  while (i < length)
+    {
+      NSRange effectiveRange;
+      id linkValue = [storage attribute: NSLinkAttributeName
+				 atIndex: i
+			   longestEffectiveRange: &effectiveRange
+				 inRange: NSMakeRange(i, length - i)];
+
+      if (linkValue != nil)
+	{
+	  return YES;
+	}
+      i = NSMaxRange(effectiveRange);
+    }
+
+  return NO;
+}
+
+/*
 Called when our state needs updating due to external changes. Currently,
 this happens when layout has been invalidated, and when we are resized.
 */
@@ -526,8 +556,15 @@ this happens when layout has been invalidated, and when we are resized.
   [self updateInsertionPointStateAndRestartTimer:
     [self shouldDrawInsertionPoint]];
   [self _updateInputMethodState];
-  /* In case any sections of text with custom cursors were moved */
-  [[self window] invalidateCursorRectsForView: self];
+  /* In case any sections of text with custom cursors were moved.  Only
+     invalidate when the text actually has custom cursor regions (links);
+     for plain text the sole cursor rect is the static I-beam over the whole
+     visible rect, and rebuilding it on every layout change makes the mouse
+     cursor flicker while typing (bug #353). */
+  if ([self _hasCustomCursorRegions])
+    {
+      [[self window] invalidateCursorRectsForView: self];
+    }
 }
 
 - (void) _layoutManagerDidInvalidateLayout

--- a/Source/NSTextView.m
+++ b/Source/NSTextView.m
@@ -515,24 +515,57 @@ decoded.
 
 
 /*
-Returns YES if the text contains any attribute that -resetCursorRects turns
-into a custom (non-I-beam) cursor rect.  Currently that is only
+The characters that are laid out inside the visible rect.  -resetCursorRects
+builds the custom cursor rects for this range alone, so anything deciding
+whether those rects have to be rebuilt must ask about the same range.  This
+uses the layout that already exists rather than forcing more.
+*/
+- (NSRange) _visibleCharacterRange
+{
+  NSPoint containerOrigin;
+  NSRect visibleRect;
+  NSRange visibleGlyphs;
+
+  if (_layoutManager == nil || _textContainer == nil)
+    {
+      return NSMakeRange(0, 0);
+    }
+
+  containerOrigin = [self textContainerOrigin];
+  visibleRect = [self visibleRect];
+  visibleRect.origin.x -= containerOrigin.x;
+  visibleRect.origin.y -= containerOrigin.y;
+
+  visibleGlyphs = [_layoutManager
+    glyphRangeForBoundingRectWithoutAdditionalLayout: visibleRect
+				     inTextContainer: _textContainer];
+  return [_layoutManager characterRangeForGlyphRange: visibleGlyphs
+					actualGlyphRange: NULL];
+}
+
+/*
+Returns YES if the visible text contains any attribute that -resetCursorRects
+turns into a custom (non-I-beam) cursor rect.  Currently that is only
 NSLinkAttributeName (the pointing-hand cursor over links); NSCursorAttributeName
 is still a FIXME in -resetCursorRects and so is intentionally not checked here.
 */
 - (BOOL) _hasCustomCursorRegions
 {
   NSTextStorage *storage = [self textStorage];
-  NSUInteger length = [storage length];
-  NSUInteger i = 0;
+  NSRange visible = [self _visibleCharacterRange];
+  NSUInteger i;
 
-  while (i < length)
+  visible = NSIntersectionRange(visible,
+    NSMakeRange(0, [storage length]));
+
+  i = visible.location;
+  while (i < NSMaxRange(visible))
     {
       NSRange effectiveRange;
       id linkValue = [storage attribute: NSLinkAttributeName
 				 atIndex: i
 			   longestEffectiveRange: &effectiveRange
-				 inRange: NSMakeRange(i, length - i)];
+				 inRange: visible];
 
       if (linkValue != nil)
 	{
@@ -4145,17 +4178,8 @@ Figure out how the additional layout stuff is supposed to work.
       if (_layoutManager != nil && _textContainer != nil)
 	{
 	  NSInteger i;
-	  NSRange visibleGlyphs, visibleCharacters;
 	  const NSPoint containerOrigin = [self textContainerOrigin];
-
-	  NSRect visibleRectInContainerCoordinates = visibleRect;
-	  visibleRectInContainerCoordinates.origin.x -= containerOrigin.x;
-	  visibleRectInContainerCoordinates.origin.y -= containerOrigin.y;
-
-	  visibleGlyphs = [_layoutManager glyphRangeForBoundingRectWithoutAdditionalLayout: visibleRectInContainerCoordinates
-									   inTextContainer: _textContainer];
-	  visibleCharacters = [_layoutManager characterRangeForGlyphRange: visibleGlyphs
-							 actualGlyphRange: NULL];
+	  const NSRange visibleCharacters = [self _visibleCharacterRange];
 	  
 	  for (i = visibleCharacters.location; i < NSMaxRange(visibleCharacters); )
 	    {

--- a/Tests/gui/NSTextView/cursorRectInvalidation.m
+++ b/Tests/gui/NSTextView/cursorRectInvalidation.m
@@ -54,7 +54,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTextView *tv;
   CursorCountWindow *w;
 
@@ -146,6 +145,5 @@ main(int argc, char **argv)
 
   END_SET("NSTextView cursor-rect invalidation")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextView/cursorRectInvalidation.m
+++ b/Tests/gui/NSTextView/cursorRectInvalidation.m
@@ -1,0 +1,119 @@
+/* NSTextView should not invalidate its cursor rects on every layout change
+   when the text is plain.  -_updateState: runs (coalesced) on each layout
+   invalidation, i.e. effectively on every keystroke; it used to always call
+   -[NSWindow invalidateCursorRectsForView:], which rebuilds the sole
+   full-visible-rect I-beam and momentarily drops it, so the mouse cursor
+   flickers between the I-beam and the arrow while typing (bug #353).
+
+   The only text attribute that currently produces a custom cursor rect is
+   NSLinkAttributeName (pointing-hand over links); NSCursorAttributeName is
+   still a FIXME in -resetCursorRects.  So the invalidation is only needed
+   when the text actually contains a link — plain text keeps a static I-beam
+   that never has to be rebuilt on a layout change.
+
+   This spies on the window (a legitimate collaborator) to count the
+   invalidations -_updateState: triggers.  The text view lays out through the
+   theme and font backend, so the set is skipped when the backend is
+   unavailable. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSRange.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSURL.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSAttributedString.h>
+#include <AppKit/NSTextStorage.h>
+#include <AppKit/NSTextView.h>
+#include <AppKit/NSWindow.h>
+
+/* Count the cursor-rect invalidations the view asks the window for. */
+@interface CursorCountWindow : NSWindow
+{
+@public
+  int invalidateCount;
+}
+@end
+
+@implementation CursorCountWindow
+- (void) invalidateCursorRectsForView: (NSView *)aView
+{
+  invalidateCount++;
+  [super invalidateCursorRectsForView: aView];
+}
+@end
+
+/* -_updateState: is the private hook run on each (coalesced) layout change. */
+@interface NSTextView (Private_UpdateState)
+- (void) _updateState: (id)sender;
+@end
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSTextView *tv;
+  CursorCountWindow *w;
+
+  START_SET("NSTextView cursor-rect invalidation")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      tv = AUTORELEASE([[NSTextView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 100)]);
+      [tv setEditable: YES];
+
+      w = AUTORELEASE([[CursorCountWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 220, 120)
+                  styleMask: NSTitledWindowMask
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      [[w contentView] addSubview: tv];
+
+      /* Plain text: a layout change must NOT invalidate the cursor rects,
+         since the only cursor rect is the static full-visible-rect I-beam. */
+      [tv insertText: @"hello world"];
+      w->invalidateCount = 0;
+      [tv _updateState: nil];
+      PASS(w->invalidateCount == 0,
+        "plain-text layout change does not invalidate cursor rects (no flicker)");
+
+      /* Link text: a layout change may have moved the link, so its
+         pointing-hand cursor rect must be rebuilt -> invalidation is needed. */
+      [[tv textStorage]
+        addAttribute: NSLinkAttributeName
+               value: [NSURL URLWithString: @"http://www.gnustep.org"]
+               range: NSMakeRange(0, 5)];
+      w->invalidateCount = 0;
+      [tv _updateState: nil];
+      PASS(w->invalidateCount == 1,
+        "layout change with a visible link still invalidates cursor rects");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSTextView cursor-rect invalidation")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSTextView/cursorRectInvalidation.m
+++ b/Tests/gui/NSTextView/cursorRectInvalidation.m
@@ -22,6 +22,7 @@
 #include <Foundation/NSRange.h>
 #include <Foundation/NSString.h>
 #include <Foundation/NSURL.h>
+#include <Foundation/NSValue.h>
 
 #include <AppKit/NSApplication.h>
 #include <AppKit/NSAttributedString.h>
@@ -101,6 +102,37 @@ main(int argc, char **argv)
       [tv _updateState: nil];
       PASS(w->invalidateCount == 1,
         "layout change with a visible link still invalidates cursor rects");
+
+      /* A link that is not on screen has no cursor rect of its own, because
+         -resetCursorRects only builds them for the visible character range.
+         Looking for it costs a scan of the whole text on every keystroke, and
+         finding it makes us rebuild rects that cannot have changed. */
+      NSTextView *big;
+      NSMutableString *lines;
+      NSUInteger middle;
+      NSUInteger i;
+
+      lines = AUTORELEASE([[NSMutableString alloc] init]);
+      for (i = 0; i < 400; i++)
+        {
+          [lines appendString: @"a line of text in a long document\n"];
+        }
+      middle = [lines length] / 2;
+
+      big = AUTORELEASE([[NSTextView alloc]
+        initWithFrame: NSMakeRect(0, 0, 200, 100)]);
+      [big setEditable: YES];
+      [[w contentView] addSubview: big];
+      [big insertText: lines];
+      [[big textStorage]
+        addAttribute: NSLinkAttributeName
+               value: [NSURL URLWithString: @"http://www.gnustep.org"]
+               range: NSMakeRange(middle, 10)];
+
+      w->invalidateCount = 0;
+      [big _updateState: nil];
+      PASS(w->invalidateCount == 0,
+        "a link outside the visible text does not invalidate cursor rects");
     }
   NS_HANDLER
     {


### PR DESCRIPTION
## Summary

Fixes the mouse-cursor flicker rmottola reported in #353: while typing in an `NSTextView` the pointer rapidly alternated between the I-beam and the arrow.

## Root cause

`-[NSTextView _updateState:]` is scheduled (coalesced) from `-_layoutManagerDidInvalidateLayout` on every layout invalidation — i.e. effectively on every keystroke. It unconditionally called `-[NSWindow invalidateCursorRectsForView:]`, which discards and rebuilds the view's cursor rects via `-resetCursorRects`. For plain text the only cursor rect is the static I-beam covering the whole visible rect, so rebuilding it momentarily drops the I-beam and the pointer falls back to the arrow before it is re-established — the flicker.

## Fix

The invalidation is only needed when a *custom* cursor region may have moved as the text reflowed. The only attribute that currently produces a custom cursor rect is `NSLinkAttributeName` (the pointing-hand over links; `NSCursorAttributeName` is still a FIXME in `-resetCursorRects`). A new private `-_hasCustomCursorRegions` checks for that, and `-_updateState:` only invalidates the cursor rects when it returns YES.

- Plain text keeps its stable full-visible-rect I-beam and no longer flickers — a hairline inside the text rect, an arrow outside, independent of typing (the behaviour rmottola asked for).
- When links are present the cursor rects are still refreshed on reflow, so pointing-hand tracking is unchanged (this is a conservative superset — a document that contains a link anywhere still invalidates exactly as before, so there is no regression for that case).

This matches the original intent of the code — the comment already said *"in case any sections of text with custom cursors were moved."* The per-view I-beam resize on a live window resize is handled by the window's own cursor-rect reset, not by `-_updateState:`, so gating here is safe.

## Test

`Tests/gui/NSTextView/cursorRectInvalidation.m` spies on the window (an `NSWindow` subclass counting `-invalidateCursorRectsForView:`) and asserts a plain-text layout change triggers **no** cursor-rect invalidation while a layout change with a link still does. Full NSTextView set: 54 passed, All OK.

## Out of scope

rmottola also floats a *cursor auto-hide while typing* enhancement. That is a separate feature and is not included here.

Closes #353
