### PR TITLE
Fix: empty the autorelease pool before terminating

### DIFF
--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -3673,6 +3673,11 @@ struct _DelegateWrapper
         DESTROY(pool);
       }
 
+      /* exit() does not unwind the stack, so objects still held by pools
+         created outside this method would otherwise be deallocated from an
+         atexit handler, after parts of the runtime have been torn down.  */
+      [[NSAutoreleasePool currentPool] emptyPool];
+
       /* And finally, stop the program.  */
       exit(0);
     }


### PR DESCRIPTION
This is the part of #344 that was left open: why NSView code runs after the process has exited. Should fix #344 

`-[NSApplication replyToApplicationShouldTerminate:]` ends with `exit()`. Terminate is reached from inside the event loop, so `main`'s autorelease pool is still on the stack, and `exit()` does not unwind it. Anything still in that pool is released by the atexit handler in gnustep-base instead. Other atexit handlers can run before it, so a `-dealloc` reached from there can use a class that has already cleaned itself up, which is how `-[NSView _setNeedsDisplayInRect_real:]` ended up with a nil NSValue.

It is not specific to Solaris. A small application that builds a window and terminates from a timer shows the content view being deallocated after `exit()` has begun on current master on Linux, with the same frames as the backtrace in the issue:

```
-[NSApplication run]
-[NSApplication nextEventMatchingMask:untilDate:inMode:dequeue:]
-[GSDisplayServer(EventOps) getEventMatchingMask:beforeDate:inMode:dequeue:]
-[NSApplication replyToApplicationShouldTerminate:]   NSApplication.m:3677  exit(0)
__run_exit_handlers
handleExit()                                          NSObject+GNUstepBase.m:250
-[NSAutoreleasePool dealloc]                          NSAutoreleasePool.m:684
-[NSAutoreleasePool emptyPool]                        NSAutoreleasePool.m:266
-[NSView dealloc]
```

Emptying the current pool before `exit()` moves that work back into the running program. `-emptyPool` also releases child pools and leaves the pool itself usable, so anything running during exit still has one. With the change the same application deallocates its view before the first atexit handler runs.

The ordering cannot be checked from the test suite, since a test for it has to terminate the process and `gnustep-tests` reports that as a file that aborted without running all its tests. I verified it with a standalone application instead, using an `atexit` handler registered in `main` to mark when exit begins.

This does not remove the need for the nil check already merged in `_setNeedsDisplayInRect_real:`: objects that are autoreleased while the pool is being emptied, or held by pools further out, can still be released during exit. It removes the case that was reported.

Refs #344, rather than closing it, since the NSValue atExit question is separate and lives in gnustep-base.
