### PR TITLE
Fix: only guess the mounted path file where it is used

### DIFF
--- a/Source/NSWorkspace.m
+++ b/Source/NSWorkspace.m
@@ -68,14 +68,16 @@
  * FIXME We won't get here on Solaris at all because it defines the
  * mntent struct in sys/mnttab.h instead of sys/mntent.h.
  */
+#if defined(HAVE_GETMNTENT) && defined (MNT_MEMB)
 # ifdef _PATH_MOUNTED
 #  define MOUNTED_PATH _PATH_MOUNTED
 # elif defined(MOUNTED)
 #  define MOUNTED_PATH MOUNTED
 # else
-#  define MNTTAB "/etc/mtab"
-#  warning "Mounted path file for you OS guessed to /etc/mtab";
+#  define MOUNTED_PATH "/etc/mtab"
+#  warning "Mounted path file for your OS guessed to /etc/mtab"
 # endif
+#endif
 
 #import <Foundation/NSBundle.h>
 #import <Foundation/NSData.h>


### PR DESCRIPTION
`MOUNTED_PATH` is only read by the `getmntent` code in `-[NSWorkspace getInfoForPath:...]` and `-mountedLocalVolumePaths`, both compiled under `HAVE_GETMNTENT && MNT_MEMB`. The block that defines it was outside that condition, so a system that reads the mount table through a syscall still warned about a guessed `/etc/mtab` while never using the path. `<mntent.h>`, which provides `_PATH_MOUNTED` and `MOUNTED`, is itself only included under the same condition, so outside it the guess was always the branch taken. That is the FreeBSD case in the issue, where `getmntinfo` is used.

The fallback also defined `MNTTAB`, which nothing reads, rather than `MOUNTED_PATH`, which the `setmntent` calls read. A system with `getmntent` but without `_PATH_MOUNTED` or `MOUNTED` therefore did not compile at all.

I checked the block by extracting it and compiling it against a use of `MOUNTED_PATH` guarded the same way as the real ones:

| configuration | before | after |
| --- | --- | --- |
| `getmntent`, `_PATH_MOUNTED` present | compiles, no warning | compiles, no warning |
| `getmntent`, no `_PATH_MOUNTED` or `MOUNTED` | does not compile | compiles, warns |
| no `getmntent`, syscall platform | compiles, warns | compiles, no warning |

The warning text had "you OS" and a trailing semicolon inside the string; both are corrected.

Unrelated to this change, and left alone: the last resort branch of `-mountedLocalVolumePaths`, which parses the mount table by hand when neither `getmntinfo` nor `getmntent` is available, tests `[parts count] >= 2` and then reads `objectAtIndex: 2`.

Closes #333.
