### PR TITLE
Fix: report each exposed binding once

### DIFF
--- a/Source/NSKeyValueBinding.m
+++ b/Source/NSKeyValueBinding.m
@@ -64,7 +64,18 @@
       tmp = [GSKeyValueBinding exposedBindingsForClass: class];
       if (tmp != nil)
         {
-          [exposedBindings addObjectsFromArray: tmp];
+          NSUInteger i;
+
+          /* A class may expose a binding its superclass also exposes.  */
+          for (i = 0; i < [tmp count]; i++)
+            {
+              id name = [tmp objectAtIndex: i];
+
+              if ([exposedBindings containsObject: name] == NO)
+                {
+                  [exposedBindings addObject: name];
+                }
+            }
         }
   
       class = [class superclass];

--- a/Tests/gui/NSOutlineView/exposedBindings.m
+++ b/Tests/gui/NSOutlineView/exposedBindings.m
@@ -8,6 +8,7 @@
 #include "Testing.h"
 
 #include <Foundation/NSArray.h>
+#include <Foundation/NSAutoreleasePool.h>
 #include <Foundation/NSSet.h>
 #include <Foundation/NSString.h>
 
@@ -33,6 +34,7 @@ occurrences(NSArray *array, NSString *name)
 
 int main()
 {
+  CREATE_AUTORELEASE_POOL(arp);
   NSOutlineView	*ov;
   NSArray	*exposed;
 
@@ -61,6 +63,8 @@ int main()
        "no binding is reported more than once");
 
   END_SET("NSOutlineView exposed bindings are not repeated")
+
+  DESTROY(arp);
 
   return 0;
 }

--- a/Tests/gui/NSOutlineView/exposedBindings.m
+++ b/Tests/gui/NSOutlineView/exposedBindings.m
@@ -1,0 +1,66 @@
+/* -exposedBindings collects the bindings exposed by the class and by each of
+   its superclasses, so a class that exposes a binding its superclass already
+   exposes used to have that name reported twice.  AppKit reports each name
+   once (verified on a macOS runner).  NSOutlineView is the case in tree: it
+   exposes content, selectionIndexes and sortDescriptors, and NSTableView
+   exposes the same three.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSArray.h>
+#include <Foundation/NSSet.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSKeyValueBinding.h>
+#include <AppKit/NSOutlineView.h>
+
+static unsigned
+occurrences(NSArray *array, NSString *name)
+{
+  unsigned	count = 0;
+  unsigned	i;
+
+  for (i = 0; i < [array count]; i++)
+    {
+      if ([[array objectAtIndex: i] isEqual: name])
+	{
+	  count++;
+	}
+    }
+  return count;
+}
+
+int main()
+{
+  NSOutlineView	*ov;
+  NSArray	*exposed;
+
+  START_SET("NSOutlineView exposed bindings are not repeated")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  ov = AUTORELEASE([[NSOutlineView alloc]
+    initWithFrame: NSMakeRect(0, 0, 300, 200)]);
+  exposed = [ov exposedBindings];
+
+  PASS(occurrences(exposed, NSContentBinding) == 1,
+       "the content binding is reported once");
+  PASS(occurrences(exposed, NSSelectionIndexesBinding) == 1,
+       "the selection indexes binding is reported once");
+  PASS(occurrences(exposed, NSSortDescriptorsBinding) == 1,
+       "the sort descriptors binding is reported once");
+  PASS(occurrences(exposed, NSContentArrayBinding) == 1,
+       "a binding exposed by only one class in the chain is still reported");
+  PASS([exposed count] == [[NSSet setWithArray: exposed] count],
+       "no binding is reported more than once");
+
+  END_SET("NSOutlineView exposed bindings are not repeated")
+
+  return 0;
+}


### PR DESCRIPTION
`-exposedBindings` walks the class and each of its superclasses and collects the bindings each one exposes, appending every list to the result. A binding exposed by both a class and one of its superclasses is therefore reported twice.

`NSOutlineView` exposes `content`, `selectionIndexes` and `sortDescriptors`, and `NSTableView` exposes the same three, so `-[NSOutlineView exposedBindings]` reported each of those names twice. AppKit reports every name once, checked on a macOS runner.

The fix skips a name already collected rather than appending it again, so the set of exposed bindings is unchanged and only the repetition goes away. `-bind:toObject:withKeyPath:options:` tests the list with `containsObject:`, so it behaves exactly as before.

`Tests/gui/NSOutlineView/exposedBindings.m` asserts that each of the three shared names appears once, that a binding exposed by only one class in the chain is still reported, and that the whole list has no repeats. Four of its five assertions fail before the change and all pass after. No regression across the outline view, table view, browser, tree controller, array and object controller, collection view, text field, button, slider and popup button tests.

Found while writing binding coverage for #329. Two further divergences from AppKit came out of the same comparison and are **not** touched here, since neither is a cosmetic change:

- `NSTreeController` exposes a `content` binding that AppKit does not expose. Removing it is not a drive-by: `-bind:toObject:withKeyPath:options:` only binds names that appear in `-exposedBindings`, so dropping it would silently turn `bind:` with `NSContentBinding` into a no-op.
- `NSOutlineView` exposes `selectionIndexes`, where AppKit exposes `selectionIndexPaths` and no `selectionIndexes` at all. Matching that means implementing the index path binding rather than renaming the exposed one.

Refs #329.
