### PR TITLE
Fix and test cases for NSAttributedString rangeOfTextBlock and rangeOfTextTable lockups

### DIFF
--- a/Source/NSAttributedString.m
+++ b/Source/NSAttributedString.m
@@ -1151,7 +1151,7 @@ documentAttributes: (NSDictionary **)dict
           NSRange newEffRange;
           NSUInteger len = [self length];
 
-          while ((effRange.location > 0) && style && textBlocks)
+          while (effRange.location > 0)
             {
               style = [self attribute: NSParagraphStyleAttributeName
                             atIndex: effRange.location - 1
@@ -1159,16 +1159,18 @@ documentAttributes: (NSDictionary **)dict
               if (style != nil)
                 {
                   textBlocks = [style textBlocks];
-                  
+
                   if ((textBlocks != nil) && [textBlocks containsObject: block])
                     {
                       effRange.location = newEffRange.location;
                       effRange.length += newEffRange.length;
+                      continue;
                     }
                 }
+              break;
             }
 
-          while (NSMaxRange(effRange) < len && style && textBlocks) 
+          while (NSMaxRange(effRange) < len)
             {
               style = [self attribute: NSParagraphStyleAttributeName
                             atIndex: NSMaxRange(effRange)
@@ -1176,12 +1178,14 @@ documentAttributes: (NSDictionary **)dict
               if (style != nil)
                 {
                   textBlocks = [style textBlocks];
-                  
+
                   if ((textBlocks != nil) && [textBlocks containsObject: block])
                     {
                       effRange.length += newEffRange.length;
+                      continue;
                     }
                 }
+              break;
             }
 
           return effRange;
@@ -1283,7 +1287,7 @@ BOOL containsTable(NSArray *textBlocks, NSTextTable *table)
 	  NSRange newEffRange;
 	  NSUInteger len = [self length];
 	  
-	  while ((effRange.location > 0) && style && textBlocks)
+	  while (effRange.location > 0)
 	    {
 	      style = [self attribute: NSParagraphStyleAttributeName
 			      atIndex: effRange.location - 1
@@ -1291,16 +1295,18 @@ BOOL containsTable(NSArray *textBlocks, NSTextTable *table)
 	      if (style != nil)
 		{
 		  textBlocks = [style textBlocks];
-		  
+
 		  if ((textBlocks != nil) && containsTable(textBlocks, table))
                     {
                       effRange.location = newEffRange.location;
                       effRange.length += newEffRange.length;
+                      continue;
                     }
                 }
+              break;
             }
 
-          while (NSMaxRange(effRange) < len && style && textBlocks) 
+          while (NSMaxRange(effRange) < len)
             {
               style = [self attribute: NSParagraphStyleAttributeName
                             atIndex: NSMaxRange(effRange)
@@ -1308,12 +1314,14 @@ BOOL containsTable(NSArray *textBlocks, NSTextTable *table)
               if (style != nil)
                 {
                   textBlocks = [style textBlocks];
-                  
+
                   if ((textBlocks != nil) && containsTable(textBlocks, table))
                     {
                       effRange.length += newEffRange.length;
+                      continue;
                     }
                 }
+              break;
             }
 
           return effRange;

--- a/Source/NSParagraphStyle.m
+++ b/Source/NSParagraphStyle.m
@@ -639,11 +639,16 @@ static NSParagraphStyle	*defaultStyle = nil;
   C(_lineHeightMultiple);
   C(_tighteningFactorForTruncation);
   C(_headerLevel);
+  C(_baseDirection);
 #undef C
 
-#define C(x) if (![x isEqualToArray: other->x]) return NO;
+/* _textBlocks is nil rather than an empty array in a style that has none,
+   so compare the pointers before sending isEqualToArray:.
+ */
+#define C(x) if ((x != other->x) && ![x isEqualToArray: other->x]) return NO;
   C(_tabStops);
   C(_textLists);
+  C(_textBlocks);
 #undef C
 
   return YES;

--- a/Tests/gui/NSAttributedString/NSAttributedString_rangeOfTextBlock.m
+++ b/Tests/gui/NSAttributedString/NSAttributedString_rangeOfTextBlock.m
@@ -1,0 +1,171 @@
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <AppKit/NSAttributedString.h>
+#include <AppKit/NSParagraphStyle.h>
+#include <AppKit/NSTextTable.h>
+
+int main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSAttributedString rangeOfTextBlock:atIndex: category method");
+
+  NSTextBlock *block1 = AUTORELEASE([[NSTextBlock alloc] init]);
+  NSTextBlock *block2 = AUTORELEASE([[NSTextBlock alloc] init]);
+  NSTextBlock *block3 = AUTORELEASE([[NSTextBlock alloc] init]);
+
+  NSMutableParagraphStyle *style1 = AUTORELEASE(
+    [[NSParagraphStyle defaultParagraphStyle] mutableCopy]);
+  NSMutableParagraphStyle *style2 = AUTORELEASE(
+    [[NSParagraphStyle defaultParagraphStyle] mutableCopy]);
+  NSMutableParagraphStyle *style3 = AUTORELEASE(
+    [[NSParagraphStyle defaultParagraphStyle] mutableCopy]);
+  NSMutableParagraphStyle *style4 = AUTORELEASE(
+    [[NSParagraphStyle defaultParagraphStyle] mutableCopy]);
+
+  [style2 setTextBlocks: [NSArray arrayWithObject: block1]];
+  [style3 setTextBlocks: [NSArray arrayWithObjects: block1, block2, nil]];
+  [style4 setTextBlocks: [NSArray arrayWithObject: block3]];
+
+  NSMutableAttributedString *storage = AUTORELEASE(
+    [[NSMutableAttributedString alloc] init]);
+
+  NSUInteger pos1 = [storage length];
+  [storage appendAttributedString: AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"before\n"
+    attributes: [NSDictionary dictionaryWithObject: style1 forKey: NSParagraphStyleAttributeName]])];
+
+  NSUInteger pos2 = [storage length];
+  [storage appendAttributedString: AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"block 1\n"
+    attributes: [NSDictionary dictionaryWithObject: style2 forKey: NSParagraphStyleAttributeName]])];
+
+  NSUInteger pos3 = [storage length];
+  [storage appendAttributedString: AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"nested\n"
+    attributes: [NSDictionary dictionaryWithObject: style3 forKey: NSParagraphStyleAttributeName]])];
+
+  NSUInteger pos4 = [storage length];
+  [storage appendAttributedString: AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"block 1\n"
+    attributes: [NSDictionary dictionaryWithObject: style2 forKey: NSParagraphStyleAttributeName]])];
+
+  NSUInteger pos5 = [storage length];
+  [storage appendAttributedString: AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"block 3\n"
+    attributes: [NSDictionary dictionaryWithObject: style4 forKey: NSParagraphStyleAttributeName]])];
+
+  NSUInteger pos6 = [storage length];
+  [storage appendAttributedString: AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"ending\n"
+    attributes: [NSDictionary dictionaryWithObject: style1 forKey: NSParagraphStyleAttributeName]])];
+
+  NSRange expected, actual;
+
+  expected = NSMakeRange(pos3, pos4 - pos3);
+  actual = [storage rangeOfTextBlock: block2 atIndex: pos3 + 1];
+  PASS(NSEqualRanges(expected, actual), "Found correct range of nested block");
+
+  expected = NSMakeRange(pos2, pos5 - pos2);
+  actual = [storage rangeOfTextBlock: block1 atIndex: pos3 + 1];
+  PASS(NSEqualRanges(expected, actual), "Found correct range of enclosing block");
+
+  expected = NSMakeRange(pos2, pos5 - pos2);
+  actual = [storage rangeOfTextBlock: block1 atIndex: pos2 + 1];
+  PASS(NSEqualRanges(expected, actual), "Found correct range including nested block");
+
+  expected = NSMakeRange(pos5, pos6 - pos5);
+  actual = [storage rangeOfTextBlock: block3 atIndex: pos5 + 1];
+  PASS(NSEqualRanges(expected, actual), "Found correct range of an adjacent block");
+
+  actual = [storage rangeOfTextBlock: block1 atIndex: pos5];
+  PASS(actual.location == NSNotFound, "Returned not found for location in different block");
+
+  actual = [storage rangeOfTextBlock: block1 atIndex: pos1];
+  PASS(actual.location == NSNotFound, "Returned not found for location not in any block");
+
+  END_SET("NSAttributedString rangeOfTextBlock:atIndex: category method");
+
+  START_SET("NSAttributedString rangeOfTextTable:atIndex: category method");
+
+  NSRange tableExpected, tableActual;
+
+  NSTextTable *table1 = AUTORELEASE([[NSTextTable alloc] init]);
+  NSTextTable *table2 = AUTORELEASE([[NSTextTable alloc] init]);
+
+  NSTextTableBlock *cell1 = AUTORELEASE([[NSTextTableBlock alloc]
+    initWithTable: table1 startingRow: 0 rowSpan: 1
+    startingColumn: 0 columnSpan: 1]);
+  NSTextTableBlock *cell2 = AUTORELEASE([[NSTextTableBlock alloc]
+    initWithTable: table1 startingRow: 1 rowSpan: 1
+    startingColumn: 0 columnSpan: 1]);
+  NSTextTableBlock *cell3 = AUTORELEASE([[NSTextTableBlock alloc]
+    initWithTable: table2 startingRow: 0 rowSpan: 1
+    startingColumn: 0 columnSpan: 1]);
+
+  NSMutableParagraphStyle *plain = AUTORELEASE(
+    [[NSParagraphStyle defaultParagraphStyle] mutableCopy]);
+  NSMutableParagraphStyle *cellStyle1 = AUTORELEASE(
+    [[NSParagraphStyle defaultParagraphStyle] mutableCopy]);
+  NSMutableParagraphStyle *cellStyle2 = AUTORELEASE(
+    [[NSParagraphStyle defaultParagraphStyle] mutableCopy]);
+  NSMutableParagraphStyle *cellStyle3 = AUTORELEASE(
+    [[NSParagraphStyle defaultParagraphStyle] mutableCopy]);
+
+  [cellStyle1 setTextBlocks: [NSArray arrayWithObject: cell1]];
+  [cellStyle2 setTextBlocks: [NSArray arrayWithObject: cell2]];
+  [cellStyle3 setTextBlocks: [NSArray arrayWithObject: cell3]];
+
+  NSMutableAttributedString *tableStorage = AUTORELEASE(
+    [[NSMutableAttributedString alloc] init]);
+
+  NSUInteger tpos1 = [tableStorage length];
+  [tableStorage appendAttributedString: AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"before\n"
+    attributes: [NSDictionary dictionaryWithObject: plain forKey: NSParagraphStyleAttributeName]])];
+
+  NSUInteger tpos2 = [tableStorage length];
+  [tableStorage appendAttributedString: AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"cell 1\n"
+    attributes: [NSDictionary dictionaryWithObject: cellStyle1 forKey: NSParagraphStyleAttributeName]])];
+
+  NSUInteger tpos3 = [tableStorage length];
+  [tableStorage appendAttributedString: AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"cell 2\n"
+    attributes: [NSDictionary dictionaryWithObject: cellStyle2 forKey: NSParagraphStyleAttributeName]])];
+
+  NSUInteger tpos4 = [tableStorage length];
+  [tableStorage appendAttributedString: AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"other table\n"
+    attributes: [NSDictionary dictionaryWithObject: cellStyle3 forKey: NSParagraphStyleAttributeName]])];
+
+  NSUInteger tpos5 = [tableStorage length];
+  [tableStorage appendAttributedString: AUTORELEASE([[NSAttributedString alloc]
+    initWithString: @"ending\n"
+    attributes: [NSDictionary dictionaryWithObject: plain forKey: NSParagraphStyleAttributeName]])];
+
+  tableExpected = NSMakeRange(tpos2, tpos4 - tpos2);
+  tableActual = [tableStorage rangeOfTextTable: table1 atIndex: tpos2 + 1];
+  PASS(NSEqualRanges(tableExpected, tableActual), "Found correct range of table from its first cell");
+
+  tableExpected = NSMakeRange(tpos2, tpos4 - tpos2);
+  tableActual = [tableStorage rangeOfTextTable: table1 atIndex: tpos3 + 1];
+  PASS(NSEqualRanges(tableExpected, tableActual), "Found correct range of table from its second cell");
+
+  tableExpected = NSMakeRange(tpos4, tpos5 - tpos4);
+  tableActual = [tableStorage rangeOfTextTable: table2 atIndex: tpos4 + 1];
+  PASS(NSEqualRanges(tableExpected, tableActual), "Found correct range of an adjacent table");
+
+  tableActual = [tableStorage rangeOfTextTable: table1 atIndex: tpos4];
+  PASS(tableActual.location == NSNotFound, "Returned not found for location in different table");
+
+  tableActual = [tableStorage rangeOfTextTable: table1 atIndex: tpos1];
+  PASS(tableActual.location == NSNotFound, "Returned not found for location not in any table");
+
+  END_SET("NSAttributedString rangeOfTextTable:atIndex: category method");
+
+  DESTROY(arp);
+
+  return 0;
+}

--- a/Tests/gui/NSParagraphStyle/NSParagraphStyle_equalityTesting.m
+++ b/Tests/gui/NSParagraphStyle/NSParagraphStyle_equalityTesting.m
@@ -3,6 +3,7 @@
 #include <Foundation/NSAutoreleasePool.h>
 #include <AppKit/NSParagraphStyle.h>
 #include <AppKit/NSTextList.h>
+#include <AppKit/NSTextTable.h>
 
 int main(int argc, char **argv)
 {    
@@ -36,7 +37,38 @@ int main(int argc, char **argv)
     [[NSTextList alloc] init])]];
   
   PASS(![style1 isEqual: style2], "NSParagraphStyle isEqual: works for different textlists");
-  
+
+  NSMutableParagraphStyle *style3 = AUTORELEASE(
+    [[NSMutableParagraphStyle alloc] init]);
+  NSMutableParagraphStyle *style4 = AUTORELEASE(
+    [[NSMutableParagraphStyle alloc] init]);
+  NSTextBlock *textBlock = AUTORELEASE(
+    [[NSTextBlock alloc] init]);
+
+  [style3 setTextBlocks: [NSArray arrayWithObject: textBlock]];
+  [style4 setTextBlocks: [NSArray arrayWithObject: textBlock]];
+
+  PASS_EQUAL(style3, style4, "NSParagraphStyle isEqual: works for identical textblocks");
+
+  [style3 setTextBlocks: [NSArray arrayWithObject: AUTORELEASE(
+    [[NSTextBlock alloc] init])]];
+  [style4 setTextBlocks: [NSArray arrayWithObject: AUTORELEASE(
+    [[NSTextBlock alloc] init])]];
+
+  PASS(![style3 isEqual: style4], "NSParagraphStyle isEqual: works for different textblocks");
+
+  style3 = AUTORELEASE([[NSMutableParagraphStyle alloc] init]);
+  style4 = AUTORELEASE([[NSMutableParagraphStyle alloc] init]);
+  [style3 setTextBlocks: [NSArray arrayWithObject: textBlock]];
+
+  PASS(![style3 isEqual: style4], "NSParagraphStyle isEqual: works when only one has textblocks");
+
+  style3 = AUTORELEASE([[NSMutableParagraphStyle alloc] init]);
+  style4 = AUTORELEASE([[NSMutableParagraphStyle alloc] init]);
+  [style3 setBaseWritingDirection: NSWritingDirectionRightToLeft];
+
+  PASS(![style3 isEqual: style4], "NSParagraphStyle isEqual: works for different writing directions");
+
   END_SET("NSParagraphStyle equality tests");
   
   DESTROY(arp);


### PR DESCRIPTION
#295 was fixed for rangeOfTextList:atIndex: in 2bfb0bd, and the reporter noted there that the same code exists for text blocks and text tables and might share the problem. It does. Both loops walk outwards from the paragraph the block or table was found in and neither ends when the neighbouring paragraph does not carry it, so the range stops advancing and the call never returns. A two paragraph string with a different block in each hangs on rangeOfTextBlock:atIndex: on master today. The change is the one from 2bfb0bd applied to both methods.

That alone was not enough. NSParagraphStyle isEqual: compared the tab stops and the text lists but not the text blocks, so two styles that differ only in their blocks compared equal, an attributed string merged the two paragraphs into one run, and the lookup returned NSNotFound rather than a range. Text blocks are compared now, and so is the base writing direction, which was missing too. That part is #294 territory, so say if you would rather have it separately.

Checked on macOS first. For a string of six paragraphs where the second and fourth carry block1, the third carries block1 and block2, and the fifth carries block3, AppKit returns 15,7 for block2, 7,23 for block1 from any of its three paragraphs, 30,8 for the adjacent block3, and NSNotFound from the block3 paragraph or from a paragraph with no blocks. The table case behaves the same way through its cells. isEqual: there is NO for styles differing only in their text blocks, NO when only one of them has any, YES for the same blocks, and NO for a differing base writing direction. GNUstep matches all of that with this change.

Tests/gui/NSAttributedString/NSAttributedString_rangeOfTextBlock.m follows the layout of the existing rangeOfTextList test and covers both methods; the four new assertions in NSParagraphStyle_equalityTesting.m cover the equality change. 
