### PR TITLE
NSBrowser: declare the rest of the delegate methods and send didChangeLastColumn

### DIFF
--- a/Headers/AppKit/NSBrowser.h
+++ b/Headers/AppKit/NSBrowser.h
@@ -32,6 +32,7 @@
 #import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSControl.h>
+#import <AppKit/NSDragging.h>
 
 @class NSString;
 @class NSArray;
@@ -41,9 +42,14 @@
 
 @class NSCell;
 @class NSEvent;
+@class NSImage;
 @class NSMatrix;
+@class NSPasteboard;
 @class NSScroller;
+@class NSURL;
 @class NSViewController;
+
+@protocol NSDraggingInfo;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_3, GS_API_LATEST)
 enum _NSBrowserColumnResizingType
@@ -53,6 +59,15 @@ enum _NSBrowserColumnResizingType
   NSBrowserUserColumnResizing
 };
 typedef NSUInteger NSBrowserColumnResizingType;
+#endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
+enum _NSBrowserDropOperation
+{
+  NSBrowserDropOn,
+  NSBrowserDropAbove
+};
+typedef NSUInteger NSBrowserDropOperation;
 #endif
 
 APPKIT_EXPORT_CLASS
@@ -357,6 +372,43 @@ sizeToFitWidthOfColumn: (NSInteger)column;
 canDragRowsWithIndexes: (NSIndexSet *)rowIndexes
         inColumn: (NSInteger)column
        withEvent: (NSEvent *)event;
+- (NSImage *) browser: (NSBrowser *)browser
+draggingImageForRowsWithIndexes: (NSIndexSet *)rowIndexes
+             inColumn: (NSInteger)column
+            withEvent: (NSEvent *)event
+               offset: (NSPointPointer)dragImageOffset;
+- (BOOL) browser: (NSBrowser *)browser
+writeRowsWithIndexes: (NSIndexSet *)rowIndexes
+        inColumn: (NSInteger)column
+    toPasteboard: (NSPasteboard *)pasteboard;
+- (NSArray *) browser: (NSBrowser *)browser
+namesOfPromisedFilesDroppedAtDestination: (NSURL *)dropDestination
+forDraggedRowsWithIndexes: (NSIndexSet *)rowIndexes
+             inColumn: (NSInteger)column;
+- (NSDragOperation) browser: (NSBrowser *)browser
+               validateDrop: (id <NSDraggingInfo>)info
+                proposedRow: (NSInteger *)row
+                     column: (NSInteger *)column
+              dropOperation: (NSBrowserDropOperation *)dropOperation;
+- (BOOL) browser: (NSBrowser *)browser
+      acceptDrop: (id <NSDraggingInfo>)info
+           atRow: (NSInteger)row
+          column: (NSInteger)column
+   dropOperation: (NSBrowserDropOperation)dropOperation;
+- (NSString *) browser: (NSBrowser *)browser
+typeSelectStringForRow: (NSInteger)row
+              inColumn: (NSInteger)column;
+- (BOOL) browser: (NSBrowser *)browser
+shouldTypeSelectForEvent: (NSEvent *)event
+withCurrentSearchString: (NSString *)searchString;
+- (NSInteger) browser: (NSBrowser *)browser
+nextTypeSelectMatchFromRow: (NSInteger)startRow
+                toRow: (NSInteger)endRow
+             inColumn: (NSInteger)column
+            forString: (NSString *)searchString;
+- (BOOL) browser: (NSBrowser *)browser
+shouldShowCellExpansionForRow: (NSInteger)row
+          column: (NSInteger)column;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
 - (NSInteger) browser: (NSBrowser *)browser
@@ -381,6 +433,12 @@ previewViewControllerForLeafItem: (id)item;
 - (void) browser: (NSBrowser *)browser
 didChangeLastColumn: (NSInteger)oldLastColumn
         toColumn: (NSInteger)column;
+- (CGFloat) browser: (NSBrowser *)browser
+        heightOfRow: (NSInteger)row
+           inColumn: (NSInteger)columnIndex;
+- (NSIndexSet *) browser: (NSBrowser *)browser
+selectionIndexesForProposedSelection: (NSIndexSet *)proposedSelectionIndexes
+                inColumn: (NSInteger)column;
 #endif
 
 @end

--- a/Source/NSBrowser.m
+++ b/Source/NSBrowser.m
@@ -255,6 +255,7 @@ static BOOL browserUseBezels;
 //
 @interface NSBrowser (Private)
 - (NSString *) _getTitleOfColumn: (NSInteger)column;
+- (void) _lastColumnChangedFrom: (NSInteger)oldLastColumn;
 - (void) _performLoadOfColumn: (NSInteger)column;
 - (id) _itemForColumn: (NSInteger)column;
 - (void) _remapColumnSubviews: (BOOL)flag;
@@ -1091,6 +1092,7 @@ static BOOL browserUseBezels;
 - (void) setLastColumn: (NSInteger)column
 {
   NSInteger i, count;
+  NSInteger oldLastColumn = _lastColumnLoaded;
   NSBrowserColumn *bc;
   NSScrollView *sc;
 
@@ -1136,6 +1138,8 @@ static BOOL browserUseBezels;
     }
 
   [self scrollColumnToVisible:column];
+
+  [self _lastColumnChangedFrom: oldLastColumn];
 }
 
 /** Returns the index of the first visible column. */
@@ -3227,6 +3231,20 @@ static BOOL browserUseBezels;
  */
 @implementation NSBrowser (Private)
 
+/* Tell the delegate the last loaded column moved, unless it did not.
+ */
+- (void) _lastColumnChangedFrom: (NSInteger)oldLastColumn
+{
+  if (oldLastColumn != _lastColumnLoaded
+    && [_browserDelegate respondsToSelector:
+      @selector(browser:didChangeLastColumn:toColumn:)])
+    {
+      [_browserDelegate browser: self
+	    didChangeLastColumn: oldLastColumn
+		       toColumn: _lastColumnLoaded];
+    }
+}
+
 - (void) _remapColumnSubviews: (BOOL)fromFirst
 {
   NSBrowserColumn *bc;
@@ -3618,7 +3636,10 @@ static BOOL browserUseBezels;
 
   if (column > _lastColumnLoaded)
     {
+      NSInteger oldLastColumn = _lastColumnLoaded;
+
       _lastColumnLoaded = column;
+      [self _lastColumnChangedFrom: oldLastColumn];
     }
 
   /* Determine the height of a cell in the matrix, and set that as the

--- a/Tests/gui/NSBrowser/lastColumn.m
+++ b/Tests/gui/NSBrowser/lastColumn.m
@@ -46,7 +46,6 @@ didChangeLastColumn: (NSInteger)oldLastColumn
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSBrowser *browser;
   ColumnWatcher *watcher;
 
@@ -98,7 +97,6 @@ main(int argc, const char **argv)
 
   END_SET("NSBrowser last column delegate method")
 
-  DESTROY(arp);
 
   return 0;
 }

--- a/Tests/gui/NSBrowser/lastColumn.m
+++ b/Tests/gui/NSBrowser/lastColumn.m
@@ -1,0 +1,104 @@
+/* The browser tells its delegate when the last loaded column changes, which
+   is how a delegate keeps track of how far the browser has been walked. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSValue.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSBrowser.h>
+#include <AppKit/NSBrowserCell.h>
+#include <AppKit/NSMatrix.h>
+
+@interface ColumnWatcher : NSObject
+{
+@public
+  NSInteger calls;
+  NSInteger lastOld;
+  NSInteger lastNew;
+}
+@end
+
+@implementation ColumnWatcher
+- (NSInteger) browser: (NSBrowser *)sender numberOfRowsInColumn: (NSInteger)column
+{
+  return 3;
+}
+- (void) browser: (NSBrowser *)sender
+ willDisplayCell: (id)cell
+	   atRow: (NSInteger)row
+	  column: (NSInteger)column
+{
+  [cell setStringValue: @"row"];
+  [cell setLeaf: (column > 1)];
+}
+- (void) browser: (NSBrowser *)browser
+didChangeLastColumn: (NSInteger)oldLastColumn
+	toColumn: (NSInteger)column
+{
+  calls++;
+  lastOld = oldLastColumn;
+  lastNew = column;
+}
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSBrowser *browser;
+  ColumnWatcher *watcher;
+
+  START_SET("NSBrowser last column delegate method")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      watcher = AUTORELEASE([[ColumnWatcher alloc] init]);
+      browser = AUTORELEASE([[NSBrowser alloc]
+	initWithFrame: NSMakeRect(0, 0, 400, 200)]);
+      [browser setDelegate: watcher];
+      [browser loadColumnZero];
+
+      PASS(watcher->calls == 1,
+	"loading column zero tells the delegate the last column changed");
+      PASS(watcher->lastOld == -1 && watcher->lastNew == 0,
+	"loading column zero reports the move from nothing to column zero");
+
+      watcher->calls = 0;
+      [browser setLastColumn: 0];
+      PASS(watcher->calls == 0,
+	"setting the last column to what it already is says nothing");
+
+      [browser addColumn];
+      PASS(watcher->calls > 0,
+	"loading another column tells the delegate the last column changed");
+      PASS(watcher->lastNew == [browser lastColumn],
+	"the delegate is told the column the browser ended up on");
+
+      watcher->calls = 0;
+      watcher->lastOld = -99;
+      [browser setLastColumn: 0];
+      PASS(watcher->calls == 1,
+	"unloading back to column zero tells the delegate once");
+      PASS(watcher->lastOld == 1 && watcher->lastNew == 0,
+	"the delegate is told which column it moved from and to");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSBrowser last column delegate method")
+
+  DESTROY(arp);
+
+  return 0;
+}


### PR DESCRIPTION
Closes #279 in part: the delegate protocol now carries the whole set.

The list came from AppKit's NSBrowser.h and from the protocol as the runtime reports it. There are 34 optional methods; 23 were already declared here. The 11 that were missing are added with the same signatures:

    browser:heightOfRow:inColumn:
    browser:shouldShowCellExpansionForRow:column:
    browser:writeRowsWithIndexes:inColumn:toPasteboard:
    browser:namesOfPromisedFilesDroppedAtDestination:forDraggedRowsWithIndexes:inColumn:
    browser:draggingImageForRowsWithIndexes:inColumn:withEvent:offset:
    browser:validateDrop:proposedRow:column:dropOperation:
    browser:acceptDrop:atRow:column:dropOperation:
    browser:typeSelectStringForRow:inColumn:
    browser:shouldTypeSelectForEvent:withCurrentSearchString:
    browser:nextTypeSelectMatchFromRow:toRow:inColumn:forString:
    browser:selectionIndexesForProposedSelection:inColumn:

The drop methods need NSBrowserDropOperation, which was missing, so that is added too, and the header imports NSDragging.h for NSDragOperation the way NSTableView.h does.

browser:didChangeLastColumn:toColumn: was declared but nothing ever sent it. It is sent now whenever the last loaded column moves, both when a column is loaded and from -setLastColumn:. The behaviour was checked against AppKit first: loading column zero reports a move from -1 to 0, adding a column reports 0 to 1, setting the last column to the value it already has says nothing, and reloading a column says nothing. Tests/gui/NSBrowser/lastColumn.m covers those; 6 of its assertions fail without this change. The NSBrowser tests give 59, and the whole gui suite passes.

The other ten are declared but the browser does not call them yet. They need drag and drop, type select and cell expansion in the column matrices, which is a larger piece of work than this. Declaring them lets code that implements them build, and gives the browser somewhere to send to as those parts are filled in.
