### PR TITLE
NSBrowser: send the type select delegate methods

### DIFF
--- a/Headers/AppKit/NSBrowser.h
+++ b/Headers/AppKit/NSBrowser.h
@@ -32,6 +32,7 @@
 #import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSControl.h>
+#import <AppKit/NSDragging.h>
 
 @class NSString;
 @class NSArray;
@@ -41,9 +42,14 @@
 
 @class NSCell;
 @class NSEvent;
+@class NSImage;
 @class NSMatrix;
+@class NSPasteboard;
 @class NSScroller;
+@class NSURL;
 @class NSViewController;
+
+@protocol NSDraggingInfo;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_3, GS_API_LATEST)
 enum _NSBrowserColumnResizingType
@@ -53,6 +59,15 @@ enum _NSBrowserColumnResizingType
   NSBrowserUserColumnResizing
 };
 typedef NSUInteger NSBrowserColumnResizingType;
+#endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
+enum _NSBrowserDropOperation
+{
+  NSBrowserDropOn,
+  NSBrowserDropAbove
+};
+typedef NSUInteger NSBrowserDropOperation;
 #endif
 
 APPKIT_EXPORT_CLASS
@@ -357,6 +372,43 @@ sizeToFitWidthOfColumn: (NSInteger)column;
 canDragRowsWithIndexes: (NSIndexSet *)rowIndexes
         inColumn: (NSInteger)column
        withEvent: (NSEvent *)event;
+- (NSImage *) browser: (NSBrowser *)browser
+draggingImageForRowsWithIndexes: (NSIndexSet *)rowIndexes
+             inColumn: (NSInteger)column
+            withEvent: (NSEvent *)event
+               offset: (NSPointPointer)dragImageOffset;
+- (BOOL) browser: (NSBrowser *)browser
+writeRowsWithIndexes: (NSIndexSet *)rowIndexes
+        inColumn: (NSInteger)column
+    toPasteboard: (NSPasteboard *)pasteboard;
+- (NSArray *) browser: (NSBrowser *)browser
+namesOfPromisedFilesDroppedAtDestination: (NSURL *)dropDestination
+forDraggedRowsWithIndexes: (NSIndexSet *)rowIndexes
+             inColumn: (NSInteger)column;
+- (NSDragOperation) browser: (NSBrowser *)browser
+               validateDrop: (id <NSDraggingInfo>)info
+                proposedRow: (NSInteger *)row
+                     column: (NSInteger *)column
+              dropOperation: (NSBrowserDropOperation *)dropOperation;
+- (BOOL) browser: (NSBrowser *)browser
+      acceptDrop: (id <NSDraggingInfo>)info
+           atRow: (NSInteger)row
+          column: (NSInteger)column
+   dropOperation: (NSBrowserDropOperation)dropOperation;
+- (NSString *) browser: (NSBrowser *)browser
+typeSelectStringForRow: (NSInteger)row
+              inColumn: (NSInteger)column;
+- (BOOL) browser: (NSBrowser *)browser
+shouldTypeSelectForEvent: (NSEvent *)event
+withCurrentSearchString: (NSString *)searchString;
+- (NSInteger) browser: (NSBrowser *)browser
+nextTypeSelectMatchFromRow: (NSInteger)startRow
+                toRow: (NSInteger)endRow
+             inColumn: (NSInteger)column
+            forString: (NSString *)searchString;
+- (BOOL) browser: (NSBrowser *)browser
+shouldShowCellExpansionForRow: (NSInteger)row
+          column: (NSInteger)column;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
 - (NSInteger) browser: (NSBrowser *)browser
@@ -381,6 +433,12 @@ previewViewControllerForLeafItem: (id)item;
 - (void) browser: (NSBrowser *)browser
 didChangeLastColumn: (NSInteger)oldLastColumn
         toColumn: (NSInteger)column;
+- (CGFloat) browser: (NSBrowser *)browser
+        heightOfRow: (NSInteger)row
+           inColumn: (NSInteger)columnIndex;
+- (NSIndexSet *) browser: (NSBrowser *)browser
+selectionIndexesForProposedSelection: (NSIndexSet *)proposedSelectionIndexes
+                inColumn: (NSInteger)column;
 #endif
 
 @end

--- a/Source/NSBrowser.m
+++ b/Source/NSBrowser.m
@@ -262,6 +262,8 @@ static BOOL browserUseBezels;
 - (void) _setColumnTitlesNeedDisplay;
 - (NSBorderType) _resolvedBorderType;
 - (void) _themeDidActivate: (NSNotification*)notification;
+- (NSString *) _typeSelectStringForRow: (NSInteger)row
+			      inColumn: (NSInteger)column;
 @end
 
 // Category to handle bindings
@@ -2795,12 +2797,21 @@ static BOOL browserUseBezels;
       NSInteger i, n, s;
       NSInteger match;
       NSInteger selectedColumn;
-      SEL lcarcSel = @selector(loadedCellAtRow:column:);
-      IMP lcarc = [self methodForSelector: lcarcSel];
+      BOOL newSearch = YES;
 
       selectedColumn = [self selectedColumn];
       if (selectedColumn != -1)
 	{
+	  if ([_browserDelegate respondsToSelector:
+		@selector(browser:shouldTypeSelectForEvent:withCurrentSearchString:)]
+	      && ![_browserDelegate browser: self
+		     shouldTypeSelectForEvent: theEvent
+		      withCurrentSearchString: _charBuffer])
+	    {
+	      [super keyDown: theEvent];
+	      return;
+	    }
+
 	  matrix = [self matrixInColumn: selectedColumn];
 	  n = [matrix numberOfRows];
 	  s = [matrix selectedRow];
@@ -2822,6 +2833,7 @@ static BOOL browserUseBezels;
 		  RELEASE(_charBuffer);
 		  _charBuffer = transition;
 		  RETAIN(_charBuffer);
+		  newSearch = NO;
 		}
 	      else
 		{
@@ -2834,36 +2846,53 @@ static BOOL browserUseBezels;
 	  _alphaNumericalLastColumn = selectedColumn;
 	  _lastKeyPressed = [theEvent timestamp];
 
-	  sv = [((*lcarc)(self, lcarcSel, s, selectedColumn))
-		 stringValue];
-
-	  if (([sv length] > 0)
-	      && ([sv hasPrefix: _charBuffer]))
-	    return;
-
-	  match = -1;
-	  for (i = s + 1; i < n; i++)
+	  if ((n > 0) && [_browserDelegate respondsToSelector:
+		@selector(browser:nextTypeSelectMatchFromRow:toRow:inColumn:forString:)])
 	    {
-	      sv = [((*lcarc)(self, lcarcSel, i, selectedColumn))
-		     stringValue];
-	      if (([sv length] > 0)
-		  && ([sv hasPrefix: _charBuffer]))
+	      NSInteger from = newSearch ? (s + 1) % n : (s < 0 ? 0 : s);
+
+	      match = [_browserDelegate browser: self
+		     nextTypeSelectMatchFromRow: from
+					  toRow: (from + n - 1) % n
+				       inColumn: selectedColumn
+				      forString: _charBuffer];
+	      if ((match < 0) || (match >= n))
 		{
-		  match = i;
-		  break;
+		  match = -1;
 		}
 	    }
-	  if (i == n)
+	  else
 	    {
-	      for (i = 0; i < s; i++)
+	      sv = [self _typeSelectStringForRow: s inColumn: selectedColumn];
+
+	      if (([sv length] > 0)
+		  && ([sv hasPrefix: _charBuffer]))
+		return;
+
+	      match = -1;
+	      for (i = s + 1; i < n; i++)
 		{
-		  sv = [((*lcarc)(self, lcarcSel, i, selectedColumn))
-			 stringValue];
+		  sv = [self _typeSelectStringForRow: i
+					    inColumn: selectedColumn];
 		  if (([sv length] > 0)
 		      && ([sv hasPrefix: _charBuffer]))
 		    {
 		      match = i;
 		      break;
+		    }
+		}
+	      if (i == n)
+		{
+		  for (i = 0; i < s; i++)
+		    {
+		      sv = [self _typeSelectStringForRow: i
+						inColumn: selectedColumn];
+		      if (([sv length] > 0)
+			  && ([sv hasPrefix: _charBuffer]))
+			{
+			  match = i;
+			  break;
+			}
 		    }
 		}
 	    }
@@ -3243,6 +3272,20 @@ static BOOL browserUseBezels;
 	    didChangeLastColumn: oldLastColumn
 		       toColumn: _lastColumnLoaded];
     }
+}
+
+- (NSString *) _typeSelectStringForRow: (NSInteger)row
+			      inColumn: (NSInteger)column
+{
+  if ([_browserDelegate respondsToSelector:
+	@selector(browser:typeSelectStringForRow:inColumn:)])
+    {
+      return [_browserDelegate browser: self
+		typeSelectStringForRow: row
+			      inColumn: column];
+    }
+
+  return [[self loadedCellAtRow: row column: column] stringValue];
 }
 
 - (void) _remapColumnSubviews: (BOOL)fromFirst

--- a/Source/NSBrowser.m
+++ b/Source/NSBrowser.m
@@ -255,6 +255,7 @@ static BOOL browserUseBezels;
 //
 @interface NSBrowser (Private)
 - (NSString *) _getTitleOfColumn: (NSInteger)column;
+- (void) _lastColumnChangedFrom: (NSInteger)oldLastColumn;
 - (void) _performLoadOfColumn: (NSInteger)column;
 - (id) _itemForColumn: (NSInteger)column;
 - (void) _remapColumnSubviews: (BOOL)flag;
@@ -1091,6 +1092,7 @@ static BOOL browserUseBezels;
 - (void) setLastColumn: (NSInteger)column
 {
   NSInteger i, count;
+  NSInteger oldLastColumn = _lastColumnLoaded;
   NSBrowserColumn *bc;
   NSScrollView *sc;
 
@@ -1136,6 +1138,8 @@ static BOOL browserUseBezels;
     }
 
   [self scrollColumnToVisible:column];
+
+  [self _lastColumnChangedFrom: oldLastColumn];
 }
 
 /** Returns the index of the first visible column. */
@@ -3227,6 +3231,20 @@ static BOOL browserUseBezels;
  */
 @implementation NSBrowser (Private)
 
+/* Tell the delegate the last loaded column moved, unless it did not.
+ */
+- (void) _lastColumnChangedFrom: (NSInteger)oldLastColumn
+{
+  if (oldLastColumn != _lastColumnLoaded
+    && [_browserDelegate respondsToSelector:
+      @selector(browser:didChangeLastColumn:toColumn:)])
+    {
+      [_browserDelegate browser: self
+	    didChangeLastColumn: oldLastColumn
+		       toColumn: _lastColumnLoaded];
+    }
+}
+
 - (void) _remapColumnSubviews: (BOOL)fromFirst
 {
   NSBrowserColumn *bc;
@@ -3618,7 +3636,10 @@ static BOOL browserUseBezels;
 
   if (column > _lastColumnLoaded)
     {
+      NSInteger oldLastColumn = _lastColumnLoaded;
+
       _lastColumnLoaded = column;
+      [self _lastColumnChangedFrom: oldLastColumn];
     }
 
   /* Determine the height of a cell in the matrix, and set that as the

--- a/Tests/gui/NSBrowser/lastColumn.m
+++ b/Tests/gui/NSBrowser/lastColumn.m
@@ -46,7 +46,6 @@ didChangeLastColumn: (NSInteger)oldLastColumn
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSBrowser *browser;
   ColumnWatcher *watcher;
 
@@ -98,7 +97,6 @@ main(int argc, const char **argv)
 
   END_SET("NSBrowser last column delegate method")
 
-  DESTROY(arp);
 
   return 0;
 }

--- a/Tests/gui/NSBrowser/lastColumn.m
+++ b/Tests/gui/NSBrowser/lastColumn.m
@@ -1,0 +1,104 @@
+/* The browser tells its delegate when the last loaded column changes, which
+   is how a delegate keeps track of how far the browser has been walked. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSValue.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSBrowser.h>
+#include <AppKit/NSBrowserCell.h>
+#include <AppKit/NSMatrix.h>
+
+@interface ColumnWatcher : NSObject
+{
+@public
+  NSInteger calls;
+  NSInteger lastOld;
+  NSInteger lastNew;
+}
+@end
+
+@implementation ColumnWatcher
+- (NSInteger) browser: (NSBrowser *)sender numberOfRowsInColumn: (NSInteger)column
+{
+  return 3;
+}
+- (void) browser: (NSBrowser *)sender
+ willDisplayCell: (id)cell
+	   atRow: (NSInteger)row
+	  column: (NSInteger)column
+{
+  [cell setStringValue: @"row"];
+  [cell setLeaf: (column > 1)];
+}
+- (void) browser: (NSBrowser *)browser
+didChangeLastColumn: (NSInteger)oldLastColumn
+	toColumn: (NSInteger)column
+{
+  calls++;
+  lastOld = oldLastColumn;
+  lastNew = column;
+}
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSBrowser *browser;
+  ColumnWatcher *watcher;
+
+  START_SET("NSBrowser last column delegate method")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      watcher = AUTORELEASE([[ColumnWatcher alloc] init]);
+      browser = AUTORELEASE([[NSBrowser alloc]
+	initWithFrame: NSMakeRect(0, 0, 400, 200)]);
+      [browser setDelegate: watcher];
+      [browser loadColumnZero];
+
+      PASS(watcher->calls == 1,
+	"loading column zero tells the delegate the last column changed");
+      PASS(watcher->lastOld == -1 && watcher->lastNew == 0,
+	"loading column zero reports the move from nothing to column zero");
+
+      watcher->calls = 0;
+      [browser setLastColumn: 0];
+      PASS(watcher->calls == 0,
+	"setting the last column to what it already is says nothing");
+
+      [browser addColumn];
+      PASS(watcher->calls > 0,
+	"loading another column tells the delegate the last column changed");
+      PASS(watcher->lastNew == [browser lastColumn],
+	"the delegate is told the column the browser ended up on");
+
+      watcher->calls = 0;
+      watcher->lastOld = -99;
+      [browser setLastColumn: 0];
+      PASS(watcher->calls == 1,
+	"unloading back to column zero tells the delegate once");
+      PASS(watcher->lastOld == 1 && watcher->lastNew == 0,
+	"the delegate is told which column it moved from and to");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSBrowser last column delegate method")
+
+  DESTROY(arp);
+
+  return 0;
+}

--- a/Tests/gui/NSBrowser/typeSelect.m
+++ b/Tests/gui/NSBrowser/typeSelect.m
@@ -1,0 +1,211 @@
+/* A delegate can supply the strings type select searches, veto a keystroke
+   before the search starts, and take over the search itself. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSBrowser.h>
+#include <AppKit/NSBrowserCell.h>
+#include <AppKit/NSEvent.h>
+#include <AppKit/NSMatrix.h>
+
+static NSArray *rows;
+
+@interface Lister : NSObject
+@end
+
+@implementation Lister
+- (NSInteger) browser: (NSBrowser *)sender numberOfRowsInColumn: (NSInteger)column
+{
+  return [rows count];
+}
+- (void) browser: (NSBrowser *)sender
+ willDisplayCell: (id)cell
+	   atRow: (NSInteger)row
+	  column: (NSInteger)column
+{
+  [cell setStringValue: [rows objectAtIndex: row]];
+  [cell setLeaf: YES];
+}
+@end
+
+/* The cells say nothing useful, so a match proves the search used the string
+   the delegate handed out rather than the cell's own. */
+@interface Renamer : Lister
+@end
+
+@implementation Renamer
+- (void) browser: (NSBrowser *)sender
+ willDisplayCell: (id)cell
+	   atRow: (NSInteger)row
+	  column: (NSInteger)column
+{
+  [cell setStringValue: @"-"];
+  [cell setLeaf: YES];
+}
+- (NSString *) browser: (NSBrowser *)browser
+typeSelectStringForRow: (NSInteger)row
+	      inColumn: (NSInteger)column
+{
+  return [rows objectAtIndex: ([rows count] - 1 - row)];
+}
+@end
+
+@interface Vetoer : Lister
+{
+@public
+  NSInteger calls;
+  BOOL sawNilSearchString;
+}
+@end
+
+@implementation Vetoer
+- (BOOL) browser: (NSBrowser *)browser
+shouldTypeSelectForEvent: (NSEvent *)event
+withCurrentSearchString: (NSString *)searchString
+{
+  if (calls == 0 && searchString == nil)
+    {
+      sawNilSearchString = YES;
+    }
+  calls++;
+  return NO;
+}
+@end
+
+@interface Searcher : Lister
+{
+@public
+  NSInteger calls;
+  NSInteger fromRow;
+  NSInteger toRow;
+  NSInteger inColumn;
+  NSString *forString;
+  NSInteger answer;
+}
+@end
+
+@implementation Searcher
+- (NSInteger) browser: (NSBrowser *)browser
+nextTypeSelectMatchFromRow: (NSInteger)startRow
+		toRow: (NSInteger)endRow
+	     inColumn: (NSInteger)column
+	    forString: (NSString *)searchString
+{
+  calls++;
+  fromRow = startRow;
+  toRow = endRow;
+  inColumn = column;
+  ASSIGN(forString, searchString);
+  return answer;
+}
+@end
+
+static NSBrowser *
+browserWithDelegate(id delegate)
+{
+  NSBrowser *browser = AUTORELEASE([[NSBrowser alloc]
+    initWithFrame: NSMakeRect(0, 0, 400, 200)]);
+
+  [browser setDelegate: delegate];
+  [browser loadColumnZero];
+  [browser selectRow: 0 inColumn: 0];
+  return browser;
+}
+
+static void
+typeCharacter(NSBrowser *browser, NSString *characters)
+{
+  NSEvent *event = [NSEvent keyEventWithType: NSKeyDown
+				    location: NSZeroPoint
+			       modifierFlags: 0
+				   timestamp: 0.0
+				windowNumber: 0
+				     context: nil
+				  characters: characters
+		 charactersIgnoringModifiers: characters
+				   isARepeat: NO
+				     keyCode: 0];
+
+  [browser keyDown: event];
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSBrowser *browser;
+  Vetoer *vetoer;
+  Searcher *searcher;
+
+  START_SET("NSBrowser type select delegate methods")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  rows = [NSArray arrayWithObjects: @"alpha", @"beta", @"Bravo", @"charlie",
+		  @"delta", nil];
+
+  NS_DURING
+    {
+      browser = browserWithDelegate(AUTORELEASE([[Renamer alloc] init]));
+      typeCharacter(browser, @"c");
+      PASS([browser selectedRowInColumn: 0] == 1,
+	"type select matches the string the delegate supplies for a row");
+
+      vetoer = AUTORELEASE([[Vetoer alloc] init]);
+      browser = browserWithDelegate(vetoer);
+      typeCharacter(browser, @"d");
+      PASS(vetoer->calls == 1,
+	"the delegate is asked whether a key should start type select");
+      PASS(vetoer->sawNilSearchString,
+	"the first keystroke of a search carries no search string yet");
+      PASS([browser selectedRowInColumn: 0] == 0,
+	"a delegate that refuses the keystroke stops the search");
+
+      searcher = AUTORELEASE([[Searcher alloc] init]);
+      searcher->answer = 3;
+      browser = browserWithDelegate(searcher);
+      typeCharacter(browser, @"b");
+      PASS(searcher->calls == 1,
+	"a delegate that implements the search is asked to run it");
+      PASS(searcher->fromRow == 1 && searcher->toRow == 0,
+	"the search starts below the selected row and wraps back to it");
+      PASS(searcher->inColumn == 0
+	&& [searcher->forString isEqualToString: @"b"],
+	"the search is given the column and the characters typed so far");
+      PASS([browser selectedRowInColumn: 0] == 3,
+	"the row the delegate picks is the row that gets selected");
+
+      typeCharacter(browser, @"r");
+      PASS(searcher->calls == 2
+	&& [searcher->forString isEqualToString: @"br"],
+	"a second keystroke extends the string the delegate searches for");
+      PASS(searcher->fromRow == 3,
+	"extending the string can match the row already selected");
+
+      searcher = AUTORELEASE([[Searcher alloc] init]);
+      searcher->answer = -1;
+      browser = browserWithDelegate(searcher);
+      typeCharacter(browser, @"b");
+      PASS(searcher->calls == 1 && [browser selectedRowInColumn: 0] == 0,
+	"a delegate that finds nothing leaves the selection alone");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSBrowser type select delegate methods")
+
+  DESTROY(arp);
+
+  return 0;
+}

--- a/Tests/gui/NSBrowser/typeSelect.m
+++ b/Tests/gui/NSBrowser/typeSelect.m
@@ -136,7 +136,6 @@ typeCharacter(NSBrowser *browser, NSString *characters)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSBrowser *browser;
   Vetoer *vetoer;
   Searcher *searcher;
@@ -205,7 +204,6 @@ main(int argc, const char **argv)
 
   END_SET("NSBrowser type select delegate methods")
 
-  DESTROY(arp);
 
   return 0;
 }


### PR DESCRIPTION
Closes #279 in part. Stacked on #846, which declares these methods and is needed for this to compile, so the change to review here is the second commit.

Three of the type select methods the protocol declares were never sent:

    browser:shouldTypeSelectForEvent:withCurrentSearchString:
    browser:typeSelectStringForRow:inColumn:
    browser:nextTypeSelectMatchFromRow:toRow:inColumn:forString:

-keyDown: now asks the first of them before a keystroke starts or extends a search, and a delegate that answers NO stops the keystroke there, leaving the search string as it was. Rows are matched against the string the second returns when the delegate implements it, otherwise against the cell's string value as before. The third takes over the search: it gets the row to start from, the row to stop at, the column and the characters typed so far, and the row it returns is selected. A row outside the column, -1 included, leaves the selection where it was.

Behaviour was checked against AppKit first. The first keystroke of a search carries a nil search string; the search starts one row below the selected row and wraps back round to it; extending the string searches again from the selected row, so a longer string can keep the row it just picked; and the string the delegate supplies is what a row is matched on, not the cell's own value.

Tests/gui/NSBrowser/typeSelect.m covers those. Its 11 assertions all fail without this change. With it, NSBrowser and NSMatrix give 144 passing.

The default search is left as it was. It is case sensitive where AppKit's is not, and it keeps the selected row when that row still matches, where AppKit moves on to the next match. Both belong in a separate change.
