### PR TITLE
NSBrowser: ask the delegate about the selection a click proposes

### DIFF
--- a/Headers/AppKit/NSBrowser.h
+++ b/Headers/AppKit/NSBrowser.h
@@ -32,6 +32,7 @@
 #import <AppKit/AppKitDefines.h>
 
 #import <AppKit/NSControl.h>
+#import <AppKit/NSDragging.h>
 
 @class NSString;
 @class NSArray;
@@ -41,9 +42,14 @@
 
 @class NSCell;
 @class NSEvent;
+@class NSImage;
 @class NSMatrix;
+@class NSPasteboard;
 @class NSScroller;
+@class NSURL;
 @class NSViewController;
+
+@protocol NSDraggingInfo;
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_3, GS_API_LATEST)
 enum _NSBrowserColumnResizingType
@@ -53,6 +59,15 @@ enum _NSBrowserColumnResizingType
   NSBrowserUserColumnResizing
 };
 typedef NSUInteger NSBrowserColumnResizingType;
+#endif
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_5, GS_API_LATEST)
+enum _NSBrowserDropOperation
+{
+  NSBrowserDropOn,
+  NSBrowserDropAbove
+};
+typedef NSUInteger NSBrowserDropOperation;
 #endif
 
 APPKIT_EXPORT_CLASS
@@ -357,6 +372,43 @@ sizeToFitWidthOfColumn: (NSInteger)column;
 canDragRowsWithIndexes: (NSIndexSet *)rowIndexes
         inColumn: (NSInteger)column
        withEvent: (NSEvent *)event;
+- (NSImage *) browser: (NSBrowser *)browser
+draggingImageForRowsWithIndexes: (NSIndexSet *)rowIndexes
+             inColumn: (NSInteger)column
+            withEvent: (NSEvent *)event
+               offset: (NSPointPointer)dragImageOffset;
+- (BOOL) browser: (NSBrowser *)browser
+writeRowsWithIndexes: (NSIndexSet *)rowIndexes
+        inColumn: (NSInteger)column
+    toPasteboard: (NSPasteboard *)pasteboard;
+- (NSArray *) browser: (NSBrowser *)browser
+namesOfPromisedFilesDroppedAtDestination: (NSURL *)dropDestination
+forDraggedRowsWithIndexes: (NSIndexSet *)rowIndexes
+             inColumn: (NSInteger)column;
+- (NSDragOperation) browser: (NSBrowser *)browser
+               validateDrop: (id <NSDraggingInfo>)info
+                proposedRow: (NSInteger *)row
+                     column: (NSInteger *)column
+              dropOperation: (NSBrowserDropOperation *)dropOperation;
+- (BOOL) browser: (NSBrowser *)browser
+      acceptDrop: (id <NSDraggingInfo>)info
+           atRow: (NSInteger)row
+          column: (NSInteger)column
+   dropOperation: (NSBrowserDropOperation)dropOperation;
+- (NSString *) browser: (NSBrowser *)browser
+typeSelectStringForRow: (NSInteger)row
+              inColumn: (NSInteger)column;
+- (BOOL) browser: (NSBrowser *)browser
+shouldTypeSelectForEvent: (NSEvent *)event
+withCurrentSearchString: (NSString *)searchString;
+- (NSInteger) browser: (NSBrowser *)browser
+nextTypeSelectMatchFromRow: (NSInteger)startRow
+                toRow: (NSInteger)endRow
+             inColumn: (NSInteger)column
+            forString: (NSString *)searchString;
+- (BOOL) browser: (NSBrowser *)browser
+shouldShowCellExpansionForRow: (NSInteger)row
+          column: (NSInteger)column;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_6, GS_API_LATEST)
 - (NSInteger) browser: (NSBrowser *)browser
@@ -381,6 +433,12 @@ previewViewControllerForLeafItem: (id)item;
 - (void) browser: (NSBrowser *)browser
 didChangeLastColumn: (NSInteger)oldLastColumn
         toColumn: (NSInteger)column;
+- (CGFloat) browser: (NSBrowser *)browser
+        heightOfRow: (NSInteger)row
+           inColumn: (NSInteger)columnIndex;
+- (NSIndexSet *) browser: (NSBrowser *)browser
+selectionIndexesForProposedSelection: (NSIndexSet *)proposedSelectionIndexes
+                inColumn: (NSInteger)column;
 #endif
 
 @end

--- a/Source/NSBrowser.m
+++ b/Source/NSBrowser.m
@@ -45,6 +45,7 @@
 #import <Foundation/NSDictionary.h>
 #import <Foundation/NSException.h>
 #import <Foundation/NSIndexPath.h>
+#import <Foundation/NSIndexSet.h>
 #import <Foundation/NSNotification.h>
 #import <Foundation/NSUserDefaults.h>
 
@@ -2418,6 +2419,46 @@ static BOOL browserUseBezels;
       while ((cell = [enumerator nextObject]))
 	[sender selectCell: cell];
       [sender setAutoscroll: autoscroll];
+    }
+
+  if ([_browserDelegate respondsToSelector:
+	@selector(browser:selectionIndexesForProposedSelection:inColumn:)])
+    {
+      NSMutableIndexSet *proposed = [NSMutableIndexSet indexSet];
+      NSIndexSet *allowed;
+      NSInteger cellRow, cellColumn;
+
+      enumerator = [selectedCells objectEnumerator];
+      while ((cell = [enumerator nextObject]))
+	{
+	  if ([sender getRow: &cellRow column: &cellColumn ofCell: cell])
+	    {
+	      [proposed addIndex: cellRow];
+	    }
+	}
+
+      allowed = [_browserDelegate browser: self
+	 selectionIndexesForProposedSelection: proposed
+				     inColumn: column];
+
+      if (allowed != nil && ![allowed isEqualToIndexSet: proposed])
+	{
+	  BOOL autoscroll = [sender isAutoscroll];
+	  NSUInteger i = [allowed firstIndex];
+
+	  [sender setAutoscroll: NO];
+	  [sender deselectAllCells];
+	  while (i != NSNotFound)
+	    {
+	      [sender selectCellAtRow: i column: 0];
+	      i = [allowed indexGreaterThanIndex: i];
+	    }
+	  [sender setAutoscroll: autoscroll];
+
+	  RELEASE(selectedCells);
+	  selectedCells = [[sender selectedCells] mutableCopy];
+	  selectedCellsCount = [selectedCells count];
+	}
     }
 
   [self setLastColumn: column];

--- a/Source/NSBrowser.m
+++ b/Source/NSBrowser.m
@@ -255,6 +255,7 @@ static BOOL browserUseBezels;
 //
 @interface NSBrowser (Private)
 - (NSString *) _getTitleOfColumn: (NSInteger)column;
+- (void) _lastColumnChangedFrom: (NSInteger)oldLastColumn;
 - (void) _performLoadOfColumn: (NSInteger)column;
 - (id) _itemForColumn: (NSInteger)column;
 - (void) _remapColumnSubviews: (BOOL)flag;
@@ -1091,6 +1092,7 @@ static BOOL browserUseBezels;
 - (void) setLastColumn: (NSInteger)column
 {
   NSInteger i, count;
+  NSInteger oldLastColumn = _lastColumnLoaded;
   NSBrowserColumn *bc;
   NSScrollView *sc;
 
@@ -1136,6 +1138,8 @@ static BOOL browserUseBezels;
     }
 
   [self scrollColumnToVisible:column];
+
+  [self _lastColumnChangedFrom: oldLastColumn];
 }
 
 /** Returns the index of the first visible column. */
@@ -3227,6 +3231,20 @@ static BOOL browserUseBezels;
  */
 @implementation NSBrowser (Private)
 
+/* Tell the delegate the last loaded column moved, unless it did not.
+ */
+- (void) _lastColumnChangedFrom: (NSInteger)oldLastColumn
+{
+  if (oldLastColumn != _lastColumnLoaded
+    && [_browserDelegate respondsToSelector:
+      @selector(browser:didChangeLastColumn:toColumn:)])
+    {
+      [_browserDelegate browser: self
+	    didChangeLastColumn: oldLastColumn
+		       toColumn: _lastColumnLoaded];
+    }
+}
+
 - (void) _remapColumnSubviews: (BOOL)fromFirst
 {
   NSBrowserColumn *bc;
@@ -3618,7 +3636,10 @@ static BOOL browserUseBezels;
 
   if (column > _lastColumnLoaded)
     {
+      NSInteger oldLastColumn = _lastColumnLoaded;
+
       _lastColumnLoaded = column;
+      [self _lastColumnChangedFrom: oldLastColumn];
     }
 
   /* Determine the height of a cell in the matrix, and set that as the

--- a/Tests/gui/NSBrowser/lastColumn.m
+++ b/Tests/gui/NSBrowser/lastColumn.m
@@ -46,7 +46,6 @@ didChangeLastColumn: (NSInteger)oldLastColumn
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSBrowser *browser;
   ColumnWatcher *watcher;
 
@@ -98,7 +97,6 @@ main(int argc, const char **argv)
 
   END_SET("NSBrowser last column delegate method")
 
-  DESTROY(arp);
 
   return 0;
 }

--- a/Tests/gui/NSBrowser/lastColumn.m
+++ b/Tests/gui/NSBrowser/lastColumn.m
@@ -1,0 +1,104 @@
+/* The browser tells its delegate when the last loaded column changes, which
+   is how a delegate keeps track of how far the browser has been walked. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSValue.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSBrowser.h>
+#include <AppKit/NSBrowserCell.h>
+#include <AppKit/NSMatrix.h>
+
+@interface ColumnWatcher : NSObject
+{
+@public
+  NSInteger calls;
+  NSInteger lastOld;
+  NSInteger lastNew;
+}
+@end
+
+@implementation ColumnWatcher
+- (NSInteger) browser: (NSBrowser *)sender numberOfRowsInColumn: (NSInteger)column
+{
+  return 3;
+}
+- (void) browser: (NSBrowser *)sender
+ willDisplayCell: (id)cell
+	   atRow: (NSInteger)row
+	  column: (NSInteger)column
+{
+  [cell setStringValue: @"row"];
+  [cell setLeaf: (column > 1)];
+}
+- (void) browser: (NSBrowser *)browser
+didChangeLastColumn: (NSInteger)oldLastColumn
+	toColumn: (NSInteger)column
+{
+  calls++;
+  lastOld = oldLastColumn;
+  lastNew = column;
+}
+@end
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSBrowser *browser;
+  ColumnWatcher *watcher;
+
+  START_SET("NSBrowser last column delegate method")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      watcher = AUTORELEASE([[ColumnWatcher alloc] init]);
+      browser = AUTORELEASE([[NSBrowser alloc]
+	initWithFrame: NSMakeRect(0, 0, 400, 200)]);
+      [browser setDelegate: watcher];
+      [browser loadColumnZero];
+
+      PASS(watcher->calls == 1,
+	"loading column zero tells the delegate the last column changed");
+      PASS(watcher->lastOld == -1 && watcher->lastNew == 0,
+	"loading column zero reports the move from nothing to column zero");
+
+      watcher->calls = 0;
+      [browser setLastColumn: 0];
+      PASS(watcher->calls == 0,
+	"setting the last column to what it already is says nothing");
+
+      [browser addColumn];
+      PASS(watcher->calls > 0,
+	"loading another column tells the delegate the last column changed");
+      PASS(watcher->lastNew == [browser lastColumn],
+	"the delegate is told the column the browser ended up on");
+
+      watcher->calls = 0;
+      watcher->lastOld = -99;
+      [browser setLastColumn: 0];
+      PASS(watcher->calls == 1,
+	"unloading back to column zero tells the delegate once");
+      PASS(watcher->lastOld == 1 && watcher->lastNew == 0,
+	"the delegate is told which column it moved from and to");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSBrowser last column delegate method")
+
+  DESTROY(arp);
+
+  return 0;
+}

--- a/Tests/gui/NSBrowser/selectionIndexes.m
+++ b/Tests/gui/NSBrowser/selectionIndexes.m
@@ -1,0 +1,147 @@
+/* A delegate gets to change the selection a click proposes in a column. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSIndexSet.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSBrowser.h>
+#include <AppKit/NSBrowserCell.h>
+#include <AppKit/NSMatrix.h>
+
+static NSArray *rows;
+
+@interface Chooser : NSObject
+{
+@public
+  NSInteger calls;
+  NSIndexSet *proposed;
+  NSInteger inColumn;
+  NSIndexSet *answer;
+  BOOL answerWithProposed;
+}
+@end
+
+@implementation Chooser
+- (NSInteger) browser: (NSBrowser *)sender numberOfRowsInColumn: (NSInteger)column
+{
+  return [rows count];
+}
+- (void) browser: (NSBrowser *)sender
+ willDisplayCell: (id)cell
+	   atRow: (NSInteger)row
+	  column: (NSInteger)column
+{
+  [cell setStringValue: [rows objectAtIndex: row]];
+  [cell setLeaf: YES];
+}
+- (NSIndexSet *) browser: (NSBrowser *)browser
+selectionIndexesForProposedSelection: (NSIndexSet *)proposedSelectionIndexes
+		inColumn: (NSInteger)column
+{
+  calls++;
+  ASSIGN(proposed, proposedSelectionIndexes);
+  inColumn = column;
+  return answerWithProposed ? proposedSelectionIndexes : answer;
+}
+@end
+
+static NSBrowser *
+browserWithDelegate(id delegate)
+{
+  NSBrowser *browser = AUTORELEASE([[NSBrowser alloc]
+    initWithFrame: NSMakeRect(0, 0, 400, 200)]);
+
+  [browser setDelegate: delegate];
+  [browser loadColumnZero];
+  return browser;
+}
+
+/* The matrix carries the selection a click has just made, then tells the
+   browser about it, which is what a click in a column comes down to. */
+static void
+clickRow(NSBrowser *browser, NSInteger row)
+{
+  NSMatrix *matrix = [browser matrixInColumn: 0];
+
+  [matrix deselectAllCells];
+  [matrix selectCellAtRow: row column: 0];
+  [browser doClick: matrix];
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSBrowser *browser;
+  Chooser *chooser;
+
+  START_SET("NSBrowser proposed selection delegate method")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  rows = [NSArray arrayWithObjects: @"alpha", @"beta", @"Bravo", @"charlie",
+		  @"delta", nil];
+
+  NS_DURING
+    {
+      chooser = AUTORELEASE([[Chooser alloc] init]);
+      chooser->answerWithProposed = YES;
+      browser = browserWithDelegate(chooser);
+      clickRow(browser, 1);
+      PASS(chooser->calls == 1,
+	"clicking a row asks the delegate what the selection should be");
+      PASS([chooser->proposed isEqualToIndexSet:
+	     [NSIndexSet indexSetWithIndex: 1]],
+	"the delegate is told which row the click proposes");
+      PASS(chooser->inColumn == 0,
+	"the delegate is told which column the click was in");
+      PASS([browser selectedRowInColumn: 0] == 1,
+	"a delegate that hands the proposal back leaves the selection alone");
+
+      chooser = AUTORELEASE([[Chooser alloc] init]);
+      chooser->answer = [NSIndexSet indexSetWithIndex: 3];
+      browser = browserWithDelegate(chooser);
+      clickRow(browser, 1);
+      PASS([browser selectedRowInColumn: 0] == 3,
+	"the row the delegate returns is the row that ends up selected");
+
+      chooser = AUTORELEASE([[Chooser alloc] init]);
+      chooser->answer = [NSIndexSet indexSet];
+      browser = browserWithDelegate(chooser);
+      clickRow(browser, 1);
+      PASS([browser selectedRowInColumn: 0] == -1,
+	"an empty answer leaves the column with nothing selected");
+
+      chooser = AUTORELEASE([[Chooser alloc] init]);
+      chooser->answer = nil;
+      browser = browserWithDelegate(chooser);
+      clickRow(browser, 1);
+      PASS(chooser->calls == 1 && [browser selectedRowInColumn: 0] == 1,
+	"a delegate that answers nothing leaves the selection alone");
+
+      chooser = AUTORELEASE([[Chooser alloc] init]);
+      chooser->answerWithProposed = YES;
+      browser = browserWithDelegate(chooser);
+      [browser selectRow: 2 inColumn: 0];
+      PASS(chooser->calls == 0,
+	"selecting a row in code is not a proposal the delegate rules on");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSBrowser proposed selection delegate method")
+
+  DESTROY(arp);
+
+  return 0;
+}

--- a/Tests/gui/NSBrowser/selectionIndexes.m
+++ b/Tests/gui/NSBrowser/selectionIndexes.m
@@ -74,7 +74,6 @@ clickRow(NSBrowser *browser, NSInteger row)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSBrowser *browser;
   Chooser *chooser;
 
@@ -141,7 +140,6 @@ main(int argc, const char **argv)
 
   END_SET("NSBrowser proposed selection delegate method")
 
-  DESTROY(arp);
 
   return 0;
 }


### PR DESCRIPTION
Closes #279 in part. Stacked on #846, which declares the method, so the change to review here is the second commit. Independent of #847.

browser:selectionIndexesForProposedSelection:inColumn: was declared and never sent. -doClick:, which is where a click in a column arrives, now collects the rows the click has selected, offers them to the delegate, and selects the set it gets back. The selection is left as it is when the delegate returns the same set or nil, and an empty set clears the column.

AppKit does not ask the delegate for selections made in code: -selectRow:inColumn:, -selectRowIndexes:inColumn: and -selectAll: all go straight through, with the delegate implemented and never called. So this is wired to the click path only, and a test covers the code path staying quiet.

Tests/gui/NSBrowser/selectionIndexes.m covers it. 5 of its 8 assertions fail without this change; the other 3 are the ones that hold either way. NSBrowser, NSMatrix and NSTableView give 202 passing with it.
