### PR TITLE
NSBrowser: take drops and tell the delegate about them

### DIFF
--- a/Source/NSBrowser.m
+++ b/Source/NSBrowser.m
@@ -78,6 +78,12 @@ static CGFloat browserColumnSeparation;
 static CGFloat browserVerticalPadding;
 static BOOL browserUseBezels;
 
+/* The drop the current drag is over, as the delegate last left it. */
+static NSInteger currentDropRow = -1;
+static NSInteger currentDropColumn = -1;
+static NSBrowserDropOperation currentDropOperation = NSBrowserDropOn;
+static NSDragOperation currentDragOperation = NSDragOperationNone;
+
 #define NSBR_COLUMN_IS_VISIBLE(i) \
 (((i)>=_firstVisibleColumn)&&((i)<=_lastVisibleColumn))
 
@@ -262,6 +268,10 @@ static BOOL browserUseBezels;
 - (void) _setColumnTitlesNeedDisplay;
 - (NSBorderType) _resolvedBorderType;
 - (void) _themeDidActivate: (NSNotification*)notification;
+- (NSInteger) _columnAtPoint: (NSPoint)point;
+- (NSInteger) _dropRowAtPoint: (NSPoint)point
+		     inColumn: (NSInteger)column
+		    operation: (NSBrowserDropOperation *)operation;
 @end
 
 // Category to handle bindings
@@ -1561,6 +1571,80 @@ static BOOL browserUseBezels;
       // FIXME
       return NO;
     }
+}
+
+/*
+ * Dragging destination
+ */
+
+- (NSDragOperation) draggingEntered: (id <NSDraggingInfo>)sender
+{
+  return [self draggingUpdated: sender];
+}
+
+- (NSDragOperation) draggingUpdated: (id <NSDraggingInfo>)sender
+{
+  NSPoint point = [self convertPoint: [sender draggingLocation] fromView: nil];
+  NSInteger row = -1;
+  NSInteger column = [self _columnAtPoint: point];
+  NSBrowserDropOperation operation = NSBrowserDropOn;
+
+  if (column != -1)
+    {
+      row = [self _dropRowAtPoint: point
+			 inColumn: column
+			operation: &operation];
+      if (row == -1)
+	{
+	  column = -1;
+	}
+    }
+
+  currentDragOperation = NSDragOperationNone;
+  if ([_browserDelegate respondsToSelector:
+	@selector(browser:validateDrop:proposedRow:column:dropOperation:)])
+    {
+      currentDragOperation = [_browserDelegate browser: self
+					  validateDrop: sender
+					   proposedRow: &row
+						column: &column
+					 dropOperation: &operation];
+    }
+
+  currentDropRow = row;
+  currentDropColumn = column;
+  currentDropOperation = operation;
+
+  return currentDragOperation;
+}
+
+- (void) draggingExited: (id <NSDraggingInfo>)sender
+{
+  currentDropRow = -1;
+  currentDropColumn = -1;
+  currentDropOperation = NSBrowserDropOn;
+  currentDragOperation = NSDragOperationNone;
+}
+
+- (BOOL) prepareForDragOperation: (id <NSDraggingInfo>)sender
+{
+  return currentDragOperation != NSDragOperationNone;
+}
+
+- (BOOL) performDragOperation: (id <NSDraggingInfo>)sender
+{
+  if (currentDragOperation != NSDragOperationNone
+    && [_browserDelegate respondsToSelector:
+	 @selector(browser:acceptDrop:atRow:column:dropOperation:)])
+    {
+      return [_browserDelegate browser: self
+			   acceptDrop: sender
+				atRow: currentDropRow
+			       column: currentDropColumn
+			dropOperation: currentDropOperation];
+    }
+
+  return NO;
 }
 
 /*
@@ -3243,6 +3327,62 @@ static BOOL browserUseBezels;
 	    didChangeLastColumn: oldLastColumn
 		       toColumn: _lastColumnLoaded];
     }
+}
+
+- (NSInteger) _columnAtPoint: (NSPoint)point
+{
+  NSInteger i;
+
+  for (i = _firstVisibleColumn; i <= _lastVisibleColumn; i++)
+    {
+      if (NSPointInRect(point, [self frameOfColumn: i]))
+	{
+	  return i;
+	}
+    }
+
+  return -1;
+}
+
+/* Which row of a column a point drops on, and whether it drops on that row or
+   above it. A point past the last row gives the row after the last, a point
+   above the first row gives no row at all. */
+- (NSInteger) _dropRowAtPoint: (NSPoint)point
+		     inColumn: (NSInteger)column
+		    operation: (NSBrowserDropOperation *)operation
+{
+  NSMatrix *matrix = [self matrixInColumn: column];
+  NSPoint inMatrix = [matrix convertPoint: point fromView: self];
+  NSInteger rows = [matrix numberOfRows];
+  CGFloat height = [matrix cellSize].height + [matrix intercellSpacing].height;
+  NSInteger row;
+  CGFloat inRow;
+
+  *operation = NSBrowserDropOn;
+
+  if (height <= 0.0 || inMatrix.y < 0.0)
+    {
+      return -1;
+    }
+
+  row = (NSInteger)(inMatrix.y / height);
+  if (row >= rows)
+    {
+      return rows;
+    }
+
+  inRow = inMatrix.y - row * height;
+  if (inRow <= height / 4)
+    {
+      *operation = NSBrowserDropAbove;
+    }
+  else if (inRow > (3 * height) / 4)
+    {
+      *operation = NSBrowserDropAbove;
+      row++;
+    }
+
+  return row;
 }
 
 - (void) _remapColumnSubviews: (BOOL)fromFirst

--- a/Tests/gui/NSBrowser/drop.m
+++ b/Tests/gui/NSBrowser/drop.m
@@ -154,7 +154,6 @@ pointInRow(NSInteger row, CGFloat fraction)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   FakeDrag *drag;
   Dropper *dropper;
 
@@ -225,7 +224,6 @@ main(int argc, const char **argv)
 
   END_SET("NSBrowser drop delegate methods")
 
-  DESTROY(arp);
 
   return 0;
 }

--- a/Tests/gui/NSBrowser/drop.m
+++ b/Tests/gui/NSBrowser/drop.m
@@ -1,0 +1,231 @@
+/* A drag over a browser offers the delegate a row and a column to drop on,
+   and the drop itself goes to whatever the delegate settled on. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSURL.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSBrowser.h>
+#include <AppKit/NSBrowserCell.h>
+#include <AppKit/NSDragging.h>
+#include <AppKit/NSMatrix.h>
+#include <AppKit/NSPasteboard.h>
+
+static NSArray *rows;
+
+@interface FakeDrag : NSObject <NSDraggingInfo>
+{
+@public
+  NSPoint location;
+}
+@end
+
+@implementation FakeDrag
+- (NSWindow *) draggingDestinationWindow
+{
+  return nil;
+}
+- (NSPoint) draggingLocation
+{
+  return location;
+}
+- (NSPasteboard *) draggingPasteboard
+{
+  return [NSPasteboard pasteboardWithName: NSDragPboard];
+}
+- (NSInteger) draggingSequenceNumber
+{
+  return 1;
+}
+- (id) draggingSource
+{
+  return nil;
+}
+- (NSDragOperation) draggingSourceOperationMask
+{
+  return NSDragOperationEvery;
+}
+- (NSImage *) draggedImage
+{
+  return nil;
+}
+- (NSPoint) draggedImageLocation
+{
+  return location;
+}
+- (void) slideDraggedImageTo: (NSPoint)screenPoint
+{
+}
+- (NSArray *) namesOfPromisedFilesDroppedAtDestination: (NSURL *)dropDestination
+{
+  return nil;
+}
+@end
+
+@interface Dropper : NSObject
+{
+@public
+  NSInteger validateCalls;
+  NSInteger acceptCalls;
+  NSInteger proposedRow;
+  NSInteger proposedColumn;
+  NSBrowserDropOperation proposedOperation;
+  NSInteger acceptedRow;
+  NSInteger acceptedColumn;
+  NSBrowserDropOperation acceptedOperation;
+  BOOL retarget;
+  NSInteger retargetRow;
+  NSDragOperation answer;
+}
+@end
+
+@implementation Dropper
+- (NSInteger) browser: (NSBrowser *)sender numberOfRowsInColumn: (NSInteger)column
+{
+  return [rows count];
+}
+- (void) browser: (NSBrowser *)sender
+ willDisplayCell: (id)cell
+	   atRow: (NSInteger)row
+	  column: (NSInteger)column
+{
+  [cell setStringValue: [rows objectAtIndex: row]];
+  [cell setLeaf: YES];
+}
+- (NSDragOperation) browser: (NSBrowser *)browser
+	       validateDrop: (id <NSDraggingInfo>)info
+		proposedRow: (NSInteger *)row
+		     column: (NSInteger *)column
+	      dropOperation: (NSBrowserDropOperation *)dropOperation
+{
+  validateCalls++;
+  proposedRow = *row;
+  proposedColumn = *column;
+  proposedOperation = *dropOperation;
+  if (retarget)
+    {
+      *row = retargetRow;
+    }
+  return answer;
+}
+- (BOOL) browser: (NSBrowser *)browser
+      acceptDrop: (id <NSDraggingInfo>)info
+	   atRow: (NSInteger)row
+	  column: (NSInteger)column
+   dropOperation: (NSBrowserDropOperation)dropOperation
+{
+  acceptCalls++;
+  acceptedRow = row;
+  acceptedColumn = column;
+  acceptedOperation = dropOperation;
+  return YES;
+}
+@end
+
+static NSBrowser *browser;
+static NSMatrix *matrix;
+
+static void
+buildBrowser(id delegate)
+{
+  browser = AUTORELEASE([[NSBrowser alloc]
+    initWithFrame: NSMakeRect(0, 0, 400, 200)]);
+  [browser setMaxVisibleColumns: 1];
+  [browser setDelegate: delegate];
+  [browser loadColumnZero];
+  matrix = [browser matrixInColumn: 0];
+}
+
+/* A point a given fraction down the band row occupies, in the coordinates a
+   drag reports. */
+static NSPoint
+pointInRow(NSInteger row, CGFloat fraction)
+{
+  CGFloat height = [matrix cellSize].height + [matrix intercellSpacing].height;
+  NSPoint p = NSMakePoint([matrix cellSize].width / 2,
+			  row * height + fraction * height);
+
+  return [browser convertPoint: p fromView: matrix];
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  FakeDrag *drag;
+  Dropper *dropper;
+
+  START_SET("NSBrowser drop delegate methods")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  rows = [NSArray arrayWithObjects: @"alpha", @"beta", @"Bravo", @"charlie",
+		  @"delta", nil];
+  drag = AUTORELEASE([[FakeDrag alloc] init]);
+
+  NS_DURING
+    {
+      dropper = AUTORELEASE([[Dropper alloc] init]);
+      dropper->answer = NSDragOperationCopy;
+      buildBrowser(dropper);
+
+      drag->location = pointInRow(2, 0.5);
+      PASS([browser draggingEntered: drag] == NSDragOperationCopy,
+	"the operation the delegate returns is what the drag is told");
+      PASS(dropper->validateCalls == 1,
+	"a drag over the browser asks the delegate to validate the drop");
+      PASS(dropper->proposedRow == 2 && dropper->proposedColumn == 0,
+	"the row and column under the drag are what is proposed");
+      PASS(dropper->proposedOperation == NSBrowserDropOn,
+	"a drag over the middle of a row proposes dropping on it");
+
+      drag->location = pointInRow(3, 0.05);
+      [browser draggingUpdated: drag];
+      PASS(dropper->proposedRow == 3
+	&& dropper->proposedOperation == NSBrowserDropAbove,
+	"a drag near the top of a row proposes dropping above it");
+
+      drag->location = pointInRow([rows count], 0.5);
+      [browser draggingUpdated: drag];
+      PASS(dropper->proposedRow == (NSInteger)[rows count],
+	"a drag past the last row proposes the row after it");
+
+      dropper->retarget = YES;
+      dropper->retargetRow = 4;
+      drag->location = pointInRow(1, 0.5);
+      [browser draggingUpdated: drag];
+      PASS([browser performDragOperation: drag] == YES,
+	"the drop is accepted when the delegate accepts it");
+      PASS(dropper->acceptCalls == 1 && dropper->acceptedRow == 4
+	&& dropper->acceptedColumn == 0,
+	"the drop lands on the row the delegate moved it to");
+
+      dropper = AUTORELEASE([[Dropper alloc] init]);
+      dropper->answer = NSDragOperationNone;
+      buildBrowser(dropper);
+      drag->location = pointInRow(2, 0.5);
+      PASS([browser draggingEntered: drag] == NSDragOperationNone,
+	"a delegate that refuses the drag is what the drag is told");
+      PASS([browser performDragOperation: drag] == NO
+	&& dropper->acceptCalls == 0,
+	"a refused drag does not drop");
+    }
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("No display available")
+  NS_ENDHANDLER
+
+  END_SET("NSBrowser drop delegate methods")
+
+  DESTROY(arp);
+
+  return 0;
+}

--- a/Tests/gui/NSBrowser/lastColumn.m
+++ b/Tests/gui/NSBrowser/lastColumn.m
@@ -46,7 +46,6 @@ didChangeLastColumn: (NSInteger)oldLastColumn
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSBrowser *browser;
   ColumnWatcher *watcher;
 
@@ -98,7 +97,6 @@ main(int argc, const char **argv)
 
   END_SET("NSBrowser last column delegate method")
 
-  DESTROY(arp);
 
   return 0;
 }


### PR DESCRIPTION
Closes #279 in part. Stacked on #846, which declares these methods, so the change to review here is the second commit. Independent of #847 and #848.

NSBrowser was not a dragging destination at all, so browser:validateDrop:proposedRow:column:dropOperation: and browser:acceptDrop:atRow:column:dropOperation: could never be sent. -draggingEntered:, -draggingUpdated:, -draggingExited:, -prepareForDragOperation: and -performDragOperation: are implemented now. A drag over a column works out the row under it and offers the delegate that row, the column and a drop operation; the delegate writes through those pointers to move the drop somewhere else, and the drop is delivered where it left them. The application still registers the dragged types on the browser as before.

The proposed values follow AppKit: a point over the middle of a row drops on that row, a point near a row boundary drops above the lower of the two, a point past the last row gives the row after the last, and a point above the first row gives row -1 in column -1. The quarter of a row that counts as a boundary is the same rule NSTableView already uses here.

The drop target is kept in file statics between the drag being validated and the drop arriving, which is how NSTableView keeps its own, rather than in new instance variables, since NSBrowser's are in the public header.

Tests/gui/NSBrowser/drop.m covers it, with a stand-in dragging info object. Without this change its first three assertions fail and the file stops where NSView is asked to handle a drag, since NSView has no -draggingEntered:. With it, 10 assertions pass, and NSBrowser, NSMatrix and NSTableView give 204.

The drag out half of #279 is not here. It needs the column matrices to start drags, which is a separate piece of work.
