### PR TITLE
Fix: add -[NSToolbar init]

### DIFF
--- a/Headers/AppKit/NSToolbar.h
+++ b/Headers/AppKit/NSToolbar.h
@@ -101,6 +101,9 @@ APPKIT_EXPORT_CLASS
 }
 
 // Instance methods
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_13, GS_API_LATEST)
+- (id) init;
+#endif
 - (id) initWithIdentifier: (NSString*)identifier;
 
 - (void) insertItemWithItemIdentifier: (NSString*)itemIdentifier 

--- a/Source/NSToolbar.m
+++ b/Source/NSToolbar.m
@@ -491,6 +491,11 @@ static GSValidationCenter *vc = nil;
 
 // Instance methods
 
+- (id) init
+{
+  return [self initWithIdentifier: @""];
+}
+
 - (id) initWithIdentifier: (NSString *)identifier
 {
   NSToolbar *toolbarModel = nil;
@@ -1233,6 +1238,12 @@ static GSValidationCenter *vc = nil;
 {
   NSArray *linked;
   id toolbar;
+
+  /* A toolbar without an identifier shares its configuration with nothing. */
+  if ([[self identifier] length] == 0)
+    {
+      return nil;
+    }
 
   linked = [[self class] _toolbarsWithIdentifier: [self identifier]];
 

--- a/Tests/gui/NSToolbar/basicInit.m
+++ b/Tests/gui/NSToolbar/basicInit.m
@@ -1,0 +1,67 @@
+/* -init creates a toolbar with an empty identifier, leaving it in the same
+   state as one built with -initWithIdentifier:. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSToolbar.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSToolbar *ref;
+  NSToolbar *tb;
+
+  START_SET("NSToolbar basic init")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      /* A toolbar built the long way, to compare the defaults against. Its
+         identifier differs from the one -init uses, so it does not act as the
+         configuration model for the toolbar built below. */
+      ref = AUTORELEASE([[NSToolbar alloc] initWithIdentifier: @"reference"]);
+      tb = AUTORELEASE([[NSToolbar alloc] init]);
+
+      PASS([[tb identifier] isEqualToString: @""],
+        "-init gives the toolbar an empty identifier");
+      PASS([tb displayMode] == [ref displayMode],
+        "-init leaves the display mode at its default");
+      PASS([tb sizeMode] == [ref sizeMode],
+        "-init leaves the size mode at its default");
+      PASS([tb showsBaselineSeparator] == [ref showsBaselineSeparator],
+        "-init leaves the baseline separator at its default");
+      PASS([tb isVisible] == [ref isVisible],
+        "-init leaves the toolbar visible by default");
+      PASS([tb items] != nil && [[tb items] count] == 0,
+        "-init starts the toolbar with an empty item list");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSToolbar basic init")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSToolbar/defaultIdentifierItems.m
+++ b/Tests/gui/NSToolbar/defaultIdentifierItems.m
@@ -1,0 +1,93 @@
+/* Toolbars built with -init all carry the same empty identifier, so they must
+   not be taken for each other's configuration model: each one builds the items
+   its own delegate offers. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSToolbar.h>
+#include <AppKit/NSToolbarItem.h>
+
+@interface TBFirstDelegate : NSObject
+@end
+
+@implementation TBFirstDelegate
+- (NSToolbarItem *) toolbar: (NSToolbar *)tb
+      itemForItemIdentifier: (NSString *)ident
+  willBeInsertedIntoToolbar: (BOOL)flag
+{
+  return AUTORELEASE([[NSToolbarItem alloc] initWithItemIdentifier: ident]);
+}
+- (NSArray *) toolbarAllowedItemIdentifiers: (NSToolbar *)tb
+{
+  return [NSArray arrayWithObjects: @"first", @"second", nil];
+}
+- (NSArray *) toolbarDefaultItemIdentifiers: (NSToolbar *)tb
+{
+  return [NSArray arrayWithObject: @"first"];
+}
+@end
+
+@interface TBSecondDelegate : TBFirstDelegate
+@end
+
+@implementation TBSecondDelegate
+- (NSArray *) toolbarDefaultItemIdentifiers: (NSToolbar *)tb
+{
+  return [NSArray arrayWithObject: @"second"];
+}
+@end
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSToolbar *t1;
+  NSToolbar *t2;
+
+  START_SET("NSToolbar default identifier items")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      t1 = AUTORELEASE([[NSToolbar alloc] init]);
+      [t1 setDelegate: AUTORELEASE([[TBFirstDelegate alloc] init])];
+
+      t2 = AUTORELEASE([[NSToolbar alloc] init]);
+      [t2 setDelegate: AUTORELEASE([[TBSecondDelegate alloc] init])];
+
+      PASS([[[t1 items] valueForKey: @"itemIdentifier"]
+             isEqual: [NSArray arrayWithObject: @"first"]],
+        "a toolbar built with -init shows the items its delegate offers");
+      PASS([[[t2 items] valueForKey: @"itemIdentifier"]
+             isEqual: [NSArray arrayWithObject: @"second"]],
+        "a second toolbar built with -init shows its own delegate's items");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSToolbar default identifier items")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
`[[NSToolbar alloc] init]` does not give back a usable toolbar. NSToolbar
implements no `-init`, so the call reaches NSObject and returns a toolbar with a
nil identifier, no item list and `isVisible` NO. The example linked from #269
builds its toolbar that way, so it needs an explicit `setVisible: YES`. On macOS
`-init` is equivalent to `-initWithIdentifier:` with an empty identifier, and no
such call is needed.

`-init` now chains to `-initWithIdentifier: @""`. That alone gives every default
toolbar the same empty identifier, and a shared identifier makes one toolbar
copy its configuration and items from the first live toolbar holding it, so a
second toolbar would show the first one's items instead of asking its own
delegate. `-_toolbarModel` therefore no longer matches an identifier of zero
length.

On macOS a toolbar reports `isVisible` NO until a window takes it and YES
afterwards, where GNUstep sets it YES at init and `-[NSWindow setToolbar:]`
leaves it alone. The reported case ends up the same either way, so that is left
alone here.

Tests/gui/NSToolbar/basicInit.m had 6 assertions failing before and none after.
Tests/gui/NSToolbar/defaultIdentifierItems.m passes on master too; it guards the
item sharing the first hunk would otherwise introduce.

#269
