### PR TITLE
Fix: remove a toolbar observer without reading the window back

### DIFF
--- a/Source/NSToolbar.m
+++ b/Source/NSToolbar.m
@@ -408,24 +408,27 @@ static GSValidationCenter *vc = nil;
 {
   GSValidationObject *vobj;
   NSMutableArray *observersWindow;
-  NSArray *windows;
+  NSArray *vobjs;
   NSEnumerator *e;
-  NSWindow *w;
 
+  /* Walk the validation objects themselves. A window reaches this while it is
+     deallocating, and a validation object keeps no reference to the window it
+     observes, so reading one back out here would touch an object that is
+     already going away. */
   if (window == nil)
     {
-      windows = [_vobjs valueForKey: @"_window"];
+      vobjs = [NSArray arrayWithArray: _vobjs];
     }
   else
     {
-      windows = [NSArray arrayWithObject: window];
+      vobj = [self validationObjectForWindow: window];
+      vobjs = (vobj != nil) ? [NSArray arrayWithObject: vobj] : [NSArray array];
     }
 
-  e = [windows objectEnumerator];
+  e = [vobjs objectEnumerator];
 
-  while ((w = [e nextObject]) != nil)
+  while ((vobj = [e nextObject]) != nil)
     {
-      vobj = [self validationObjectForWindow: w];
       observersWindow = [vobj observers];
 
       if (observersWindow != nil && [observersWindow containsObject: observer])

--- a/Tests/gui/NSToolbar/windowRelease.m
+++ b/Tests/gui/NSToolbar/windowRelease.m
@@ -53,7 +53,6 @@ buildWindowWithToolbar(NSString *identifier)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSAutoreleasePool *inner;
   NSWindow *w;
 
@@ -99,6 +98,5 @@ main(int argc, char **argv)
 
   END_SET("NSToolbar window release")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSToolbar/windowRelease.m
+++ b/Tests/gui/NSToolbar/windowRelease.m
@@ -1,0 +1,104 @@
+/* A window that carries a toolbar can be released without being closed. The
+   toolbar registers with the validation center for the window it is shown in,
+   and that registration has to go away with the window rather than leave a
+   pointer to it behind. */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSToolbar.h>
+#include <AppKit/NSToolbarItem.h>
+#include <AppKit/NSWindow.h>
+
+@interface TBReleaseDelegate : NSObject
+@end
+
+@implementation TBReleaseDelegate
+- (NSToolbarItem *) toolbar: (NSToolbar *)tb
+      itemForItemIdentifier: (NSString *)ident
+  willBeInsertedIntoToolbar: (BOOL)flag
+{
+  return AUTORELEASE([[NSToolbarItem alloc] initWithItemIdentifier: ident]);
+}
+- (NSArray *) toolbarAllowedItemIdentifiers: (NSToolbar *)tb
+{
+  return [NSArray arrayWithObject: @"only"];
+}
+- (NSArray *) toolbarDefaultItemIdentifiers: (NSToolbar *)tb
+{
+  return [NSArray arrayWithObject: @"only"];
+}
+@end
+
+static NSWindow *
+buildWindowWithToolbar(NSString *identifier)
+{
+  NSWindow *w = AUTORELEASE([[NSWindow alloc]
+    initWithContentRect: NSMakeRect(0, 0, 300, 200)
+              styleMask: NSTitledWindowMask
+                backing: NSBackingStoreBuffered
+                  defer: NO]);
+  NSToolbar *t = AUTORELEASE([[NSToolbar alloc]
+    initWithIdentifier: identifier]);
+
+  [t setDelegate: AUTORELEASE([[TBReleaseDelegate alloc] init])];
+  [w setToolbar: t];
+
+  return w;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSAutoreleasePool *inner;
+  NSWindow *w;
+
+  START_SET("NSToolbar window release")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      /* The window and its toolbar go away here without -close being called,
+         which is what leaves a stale registration behind. */
+      inner = [NSAutoreleasePool new];
+      w = buildWindowWithToolbar(@"released");
+      PASS([[[w toolbar] items] count] == 1,
+        "the toolbar shown in the window has the item its delegate offers");
+      RELEASE(inner);
+
+      /* Reaching this point at all means the drain above did not read the
+         released window back. A second window has to work as the first did,
+         which it cannot if a stale entry is still held for the old one. */
+      w = buildWindowWithToolbar(@"replacement");
+      PASS([[[w toolbar] items] count] == 1,
+        "a later window still builds its toolbar after the first is released");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSToolbar window release")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Releasing a window that has a toolbar reads freed memory as the autorelease pool
drains, and crashes. #851 has the reproduction, the root cause and the valgrind
output.

`GSValidationObject` holds its window without retaining it, and its entry is
dropped only on `-windowWillClose:` or when the last observer goes, so a window
released rather than closed is still registered while it deallocates. Tearing
down its view tree reached `-[GSValidationCenter removeObserver:window:]` with a
nil window, which built its list with `[_vobjs valueForKey: @"_window"]` and so
put the dying window into an autoreleased array. That branch now walks the
validation objects directly, so the window is never read back out of one.
Removing the observer while the pointer is still good also lets the entry go
with the window rather than outlive it.

Tests/gui/NSToolbar/windowRelease.m aborted at the drain before, after 1 of its
2 assertions had run, and both pass after. On the #851 reproduction valgrind
goes from an invalid read to none and `NSZombieEnabled=YES` reports nothing. The
full Tests/gui suite runs 4328 assertions clean.

Closes #851
