### PR TITLE
Watch the source file of a linked document

### DIFF
--- a/Source/NSDataLinkManager.m
+++ b/Source/NSDataLinkManager.m
@@ -146,13 +146,14 @@
       _destinationLinks = [[NSMutableArray alloc] init];
       _watchDescriptors = [[NSMutableDictionary alloc] init];
       _nextLinkNumber = 1;
+      _inotifyFD = -1;
 #ifdef HAVE_SYS_INOTIFY_H
       _inotifyFD = inotify_init();
-#endif
       if (_inotifyFD < 0)
 	{
 	  NSLog(@"Failed to initialize inotify");
 	}
+#endif
       [self startMonitoring];
     }
 
@@ -166,11 +167,13 @@
 
 - (void) dealloc
 {
+  /* Monitoring reads the watch table, so it has to be stopped first. */
+  [self stopMonitoring];
+
   RELEASE(_sourceLinks);
   RELEASE(_destinationLinks);
   RELEASE(_watchDescriptors);
-
-  [self stopMonitoring];
+  RELEASE(_monitorThread);
   [super dealloc];
 }
 
@@ -206,8 +209,81 @@
 
 - (void)startMonitoring
 {
+  /* With no descriptor to read there is nothing to wait on, and the loop
+     would spin. */
+  if (_inotifyFD < 0)
+    {
+      return;
+    }
+
   _monitorThread = [[NSThread alloc] initWithTarget:self selector:@selector(monitorLoop) object:nil];
   [_monitorThread start];
+}
+
+/* Watch the file a link takes its contents from, and remember which link the
+   watch belongs to.  Watching the same file twice returns the same descriptor,
+   so the table keeps the most recently added link for it. */
+- (void) _watchSourceOfLink: (NSDataLink *)link
+{
+#ifdef HAVE_SYS_INOTIFY_H
+  NSString *path = [link sourceFilename];
+  int wd;
+
+  if (_inotifyFD < 0 || path == nil)
+    {
+      return;
+    }
+
+  wd = inotify_add_watch(_inotifyFD, [path fileSystemRepresentation],
+			 IN_CLOSE_WRITE | IN_MODIFY | IN_MOVE_SELF);
+  if (wd < 0)
+    {
+      return;
+    }
+
+  [_watchDescriptors setObject: link forKey: [NSNumber numberWithInt: wd]];
+#endif
+}
+
+- (void) _unwatchSourceOfLink: (NSDataLink *)link
+{
+#ifdef HAVE_SYS_INOTIFY_H
+  NSArray *keys = [_watchDescriptors allKeysForObject: link];
+  NSEnumerator *en = [keys objectEnumerator];
+  NSNumber *key;
+
+  while ((key = [en nextObject]) != nil)
+    {
+      if (_inotifyFD >= 0)
+	{
+	  inotify_rm_watch(_inotifyFD, [key intValue]);
+	}
+      [_watchDescriptors removeObjectForKey: key];
+    }
+#endif
+}
+
+/* Called on the main thread for each watch that reported a change, so the
+   delegate is never messaged from the monitoring thread. */
+- (void) _sourceChangedForWatch: (NSNumber *)descriptor
+{
+  NSDataLink *link = [_watchDescriptors objectForKey: descriptor];
+
+  if (link == nil)
+    {
+      return;
+    }
+
+  [link noteSourceEdited];
+
+  if ([_delegate respondsToSelector:
+	@selector(dataLinkManager:isUpdateNeededForLink:)])
+    {
+      if ([_delegate dataLinkManager: self isUpdateNeededForLink: link])
+	{
+	  [link updateDestination];
+	}
+    }
 }
 
 - (void)monitorLoop
@@ -223,28 +299,21 @@
 	}
 
       ssize_t i = 0;
+      CREATE_AUTORELEASE_POOL(pool);
+
       while (i < length)
 	{
 	  struct inotify_event *event = (struct inotify_event *)&buffer[i];
-	  NSNumber *key = [NSNumber numberWithInt:event->wd];
-	  NSDataLink *link = [_watchDescriptors objectForKey: key];
-	  if (link != nil)
-	    {
-	      [link noteSourceEdited];
-	      NSLog(@"Source file changed for link #%d", [link linkNumber]);
+	  NSNumber *key = [NSNumber numberWithInt: event->wd];
 
-	      // Check if delegate wants to verify this update
-	      if ([_delegate respondsToSelector: @selector(dataLinkManager:isUpdateNeededForLink:)])
-		{
-		  BOOL needsUpdate = [_delegate dataLinkManager: self isUpdateNeededForLink: link];
-		  if (needsUpdate)
-		    {
-		      [link updateDestination];
-		    }
-		}
-	    }
+	  /* The watch table and the delegate belong to the main thread. */
+	  [self performSelectorOnMainThread: @selector(_sourceChangedForWatch:)
+				 withObject: key
+			      waitUntilDone: NO];
+
 	  i += sizeof(struct inotify_event) + event->len;
 	}
+      DESTROY(pool);
     }
 #endif
 }
@@ -272,6 +341,7 @@
   if ([_destinationLinks containsObject: link] == NO)
     {
       [_destinationLinks addObject: link];
+      [self _watchSourceOfLink: link];
       result = YES;
 
       // Notify delegate that we're starting to track this link
@@ -356,6 +426,8 @@
 	}
       [_destinationLinks removeObject: link];
     }
+
+  [self _unwatchSourceOfLink: link];
 }
 
 - (BOOL) addSourceLink: (NSDataLink *)link

--- a/Tests/gui/NSDataLink/sourceMonitoring.m
+++ b/Tests/gui/NSDataLink/sourceMonitoring.m
@@ -58,13 +58,13 @@ waitForNotice(DLWatchDoc *doc, NSTimeInterval limit)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-  NSFileManager *mgr = [NSFileManager defaultManager];
+  NSFileManager *mgr;
   NSString *dir;
   NSString *source;
 
   START_SET("NSDataLinkManager source monitoring")
 
+  mgr = [NSFileManager defaultManager];
   dir = [NSTemporaryDirectory()
           stringByAppendingPathComponent: @"nsdl-monitor-test"];
   [mgr createDirectoryAtPath: dir
@@ -106,6 +106,5 @@ main(int argc, const char **argv)
 
   END_SET("NSDataLinkManager source monitoring")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDataLink/sourceMonitoring.m
+++ b/Tests/gui/NSDataLink/sourceMonitoring.m
@@ -1,0 +1,111 @@
+/* NSDataLinkManager watches the source file of every link it tracks, so that
+   editing that file outside the application marks the link as needing an
+   update.  The manager asks its delegate whether the update is wanted, and it
+   has to ask on the main thread: the answer usually comes from the document,
+   and the delegate must not be called from the monitoring thread. */
+#import "Testing.h"
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+#import <AppKit/NSDataLink.h>
+#import <AppKit/NSDataLinkManager.h>
+#import <AppKit/NSSelection.h>
+
+@interface DLWatchDoc : NSObject
+{
+@public
+  int   askedCount;
+  BOOL  askedOnMainThread;
+  BOOL  importCalled;
+}
+@end
+
+@implementation DLWatchDoc
+- (BOOL) dataLinkManager: (NSDataLinkManager *)m
+   isUpdateNeededForLink: (NSDataLink *)l
+{
+  askedCount++;
+  askedOnMainThread = [NSThread isMainThread];
+  return NO;      /* keep the test to the notification itself */
+}
+- (BOOL) importFile: (NSString *)filename at: (NSSelection *)selection
+{
+  importCalled = YES;
+  return YES;
+}
+@end
+
+static NSSelection *
+aSelection(void)
+{
+  return [NSSelection selectionWithDescriptionData:
+           [@"sel" dataUsingEncoding: NSUTF8StringEncoding]];
+}
+
+/* Spin the run loop until the delegate has been asked, or the time runs out. */
+static void
+waitForNotice(DLWatchDoc *doc, NSTimeInterval limit)
+{
+  NSDate *end = [NSDate dateWithTimeIntervalSinceNow: limit];
+
+  while (doc->askedCount == 0 && [end timeIntervalSinceNow] > 0)
+    {
+      [[NSRunLoop currentRunLoop]
+        runMode: NSDefaultRunLoopMode
+        beforeDate: [NSDate dateWithTimeIntervalSinceNow: 0.1]];
+    }
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSFileManager *mgr = [NSFileManager defaultManager];
+  NSString *dir;
+  NSString *source;
+
+  START_SET("NSDataLinkManager source monitoring")
+
+  dir = [NSTemporaryDirectory()
+          stringByAppendingPathComponent: @"nsdl-monitor-test"];
+  [mgr createDirectoryAtPath: dir
+ withIntermediateDirectories: YES
+                  attributes: nil
+                       error: NULL];
+  source = [dir stringByAppendingPathComponent: @"source.txt"];
+
+  if (![@"first" writeToFile: source atomically: YES])
+    {
+      SKIP("could not create a source file to watch")
+    }
+
+  {
+    DLWatchDoc *doc = AUTORELEASE([DLWatchDoc new]);
+    NSDataLinkManager *manager = AUTORELEASE([[NSDataLinkManager alloc]
+      initWithDelegate: doc
+              fromFile: [dir stringByAppendingPathComponent: @"doc"]]);
+    NSDataLink *link = AUTORELEASE([[NSDataLink alloc]
+      initLinkedToFile: source]);
+
+    PASS([manager addLink: link at: aSelection()] == YES,
+      "a link to a source file is added to the manager");
+
+    /* Change the file the way another application would. */
+    [@"second" writeToFile: source atomically: NO];
+
+    waitForNotice(doc, 5.0);
+
+    PASS(doc->askedCount > 0,
+      "editing the source file asks the delegate whether an update is needed");
+    PASS(doc->askedCount == 0 || doc->askedOnMainThread,
+      "the delegate is asked on the main thread");
+
+    [manager removeLink: link];
+  }
+
+  [mgr removeItemAtPath: dir error: NULL];
+
+  END_SET("NSDataLinkManager source monitoring")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
NSDataLinkManager never watched anything. It set up an inotify descriptor, a
thread reading events, and a table mapping watch descriptors to links, but
`inotify_add_watch` was never called and the table was never filled, so an edit
to a link's source file was never noticed. This is the filesystem notification
part of #167.

A watch is now registered on the source file when a link is added and removed
when the link is removed. Each event is handed to the main thread before the
table is consulted and the delegate is asked, since the delegate is the document
and was otherwise going to be messaged from the monitoring thread. The thread is
not started when there is no descriptor, since reading a closed one returns at
once and the loop would spin.

The `-dealloc` order is corrected but unreachable:
`-[NSThread initWithTarget:selector:object:]` retains the manager, so one whose
monitor thread runs is never deallocated. Whether to watch the descriptor from
the run loop rather than a thread is a design question I have put on the issue.
Monitoring stays Linux only.

Tests/gui/NSDataLink/sourceMonitoring.m had 1 assertion failing before and none
after. The full Tests/gui suite runs 4329 assertions clean.

Refers to #167
