### PR TITLE
Fix: keep the PPD keyword that follows *OrderDependency or *UIConstraints

### DIFF
--- a/Source/NSPrinter.m
+++ b/Source/NSPrinter.m
@@ -414,14 +414,32 @@ static NSMutableDictionary* printerCache;
 
   result = [NSMutableDictionary dictionary];
   
-  if ([self isKey: @"DefaultResolution" 
+  if ([self isKey: @"DefaultResolution"
           inTable:@"PPD"])
     {
-      int dpi = [self intForKey: @"DefaultResolution" 
-                        inTable: @"PPD"];
+      NSString *resolution;
+      NSScanner *bits;
+      int xdpi, ydpi;
 
-      [result setObject: [NSNumber numberWithInt: dpi]
-                forKey: NSDeviceResolution];
+      /* A resolution reads '600dpi' or '600x300dpi', but the keyword also
+         takes values such as 'default' that name no resolution at all. */
+      resolution = [self stringForKey: @"DefaultResolution"
+                              inTable: @"PPD"];
+      bits = [NSScanner scannerWithString: resolution];
+
+      if ([bits scanInt: &xdpi] && xdpi > 0)
+        {
+          if (!([bits scanString: @"x"
+                   intoString: NULL]
+                && [bits scanInt: &ydpi]
+                && ydpi > 0))
+            {
+              ydpi = xdpi;
+            }
+
+          [result setObject: [NSValue valueWithSize: NSMakeSize(xdpi, ydpi)]
+                     forKey: NSDeviceResolution];
+        }
     }
 
   if ([self isKey: @"ColorDevice" 
@@ -1251,6 +1269,7 @@ static NSMutableDictionary* printerCache;
   NSString* optionKey1 = nil;
   NSString* mainKey2 = nil;
   NSString* optionKey2 = nil;
+  NSUInteger location;
 
   // UIConstraint should have no option keyword
   if (![constraint scanString: @":" 
@@ -1284,16 +1303,20 @@ static NSMutableDictionary* printerCache;
               [NSCharacterSet whitespaceAndNewlineCharacterSet]
                              intoString: &mainKey2];
                             
-  if (![constraint scanCharactersFromSet: newlineSet 
-                              intoString: NULL])
+  location = [constraint scanLocation];
+
+  if ([constraint scanCharactersFromSet: newlineSet
+                             intoString: NULL])
     {
-      [constraint scanUpToCharactersFromSet: 
-                  [NSCharacterSet whitespaceAndNewlineCharacterSet]
-                                 intoString: &optionKey2];
+      // The caller skips the rest of the line, so leave the line terminator
+      optionKey2 = @"";
+      [constraint setScanLocation: location];
     }
   else
     {
-      optionKey2 = @"";
+      [constraint scanUpToCharactersFromSet:
+                  [NSCharacterSet whitespaceAndNewlineCharacterSet]
+                                 intoString: &optionKey2];
     }
 
   // Add to table
@@ -1319,6 +1342,7 @@ static NSMutableDictionary* printerCache;
   NSString *section = nil;
   NSString *keyword = nil;
   NSString *optionKeyword = nil;
+  NSUInteger location;
 
   // Order dependency should have no option keyword
   if (![dependency scanString: @":" 
@@ -1342,19 +1366,22 @@ static NSMutableDictionary* printerCache;
               [NSCharacterSet whitespaceAndNewlineCharacterSet]
                              intoString: &keyword];
                             
-  if (![dependency scanCharactersFromSet: newlineSet 
-                              intoString: NULL])
+  location = [dependency scanLocation];
+
+  if ([dependency scanCharactersFromSet: newlineSet
+                             intoString: NULL])
+    {
+      // The caller skips the rest of the line, so leave the line terminator
+      [dependency setScanLocation: location];
+    }
+  else
     {
       // Optional keyword exists
-      [dependency scanUpToCharactersFromSet: 
+      [dependency scanUpToCharactersFromSet:
                   [NSCharacterSet whitespaceAndNewlineCharacterSet]
                                  intoString: &optionKeyword];
     }
 
-  // Go to next line of PPD file
-  [dependency scanCharactersFromSet: newlineSet 
-                         intoString: NULL];
-                         
   // Add to table
   if (optionKeyword)
     keyword = [keyword stringByAppendingFormat: @"/%@", optionKeyword];

--- a/Tests/gui/NSPrinter/deviceDescription.m
+++ b/Tests/gui/NSPrinter/deviceDescription.m
@@ -69,8 +69,6 @@ static NSPrinter *printerWithResolution(NSString *resolution, NSString *path)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSPrinter device description")
 
   NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
@@ -167,6 +165,5 @@ main(int argc, char **argv)
 
   END_SET("NSPrinter device description")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPrinter/deviceDescription.m
+++ b/Tests/gui/NSPrinter/deviceDescription.m
@@ -1,0 +1,172 @@
+/* NSDeviceResolution holds an NSValue with an NSSize, as it does in the device
+   description of a screen and as -[NSImage bestRepresentationForDevice:] reads
+   it.  A PPD resolution reads '600dpi' or '600x300dpi'; a keyword naming no
+   resolution at all, such as the 'default' of the shipped generic PPD, leaves
+   the entry out.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSDictionary.h>
+#include <Foundation/NSException.h>
+#include <Foundation/NSFileManager.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSPathUtilities.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSUserDefaults.h>
+#include <Foundation/NSValue.h>
+
+#include <AppKit/NSGraphics.h>
+#include <AppKit/NSImage.h>
+#include <AppKit/NSBitmapImageRep.h>
+#include <AppKit/NSPrinter.h>
+
+static NSString *ppdFormat =
+  @"*PPD-Adobe: \"4.3\"\n"
+  @"*ModelName: \"Test\"\n"
+  @"*ColorDevice: False\n"
+  @"*DefaultResolution: %@\n"
+  @"*DefaultPageSize: Letter\n"
+  @"*PaperDimension Letter/US Letter: \"612 792\"\n";
+
+static NSPrinter *printerWithResolution(NSString *resolution, NSString *path)
+{
+  NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+  NSDictionary *entry;
+  NSPrinter *printer = nil;
+
+  if (![[NSString stringWithFormat: ppdFormat, resolution]
+         writeToFile: path atomically: YES])
+    {
+      return nil;
+    }
+
+  entry = [NSDictionary dictionaryWithObjectsAndKeys:
+    path, @"PPDPath",
+    @"localhost", @"Host",
+    resolution, @"Type",
+    @"test", @"Note",
+    nil];
+
+  [ud setObject: @"GSLPR" forKey: @"GSPrinting"];
+  [ud setObject: [NSDictionary dictionaryWithObject: entry
+                                             forKey: resolution]
+         forKey: @"GSLPRPrinters"];
+
+  NS_DURING
+    {
+      printer = [NSPrinter printerWithName: resolution];
+    }
+  NS_HANDLER
+    {
+      printer = nil;
+    }
+  NS_ENDHANDLER
+
+  return printer;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSPrinter device description")
+
+  NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+  id savedPrinters = [ud objectForKey: @"GSLPRPrinters"];
+  id savedBundle = [ud objectForKey: @"GSPrinting"];
+  NSString *path;
+  NSPrinter *printer;
+  NSDictionary *description;
+  id resolution;
+
+  path = [NSTemporaryDirectory()
+           stringByAppendingPathComponent: @"gsDeviceDescription.ppd"];
+
+  printer = printerWithResolution(@"600dpi", path);
+
+  if (printer == nil)
+    {
+      SKIP("no printing bundle able to read a PPD")
+    }
+
+  description = [printer deviceDescription];
+  resolution = [description objectForKey: NSDeviceResolution];
+
+  PASS([resolution respondsToSelector: @selector(sizeValue)],
+       "NSDeviceResolution of a printer holds a size");
+
+  PASS(NSEqualSizes([resolution sizeValue], NSMakeSize(600, 600)),
+       "a resolution of 600dpi is 600 by 600");
+
+  PASS(NSEqualSizes([[description objectForKey: NSDeviceSize] sizeValue],
+                    NSMakeSize(612, 792)),
+       "NSDeviceSize is the size of the default paper");
+
+  /* The documented consumer of a device description. */
+  {
+    NSImage *image;
+    NSBitmapImageRep *rep;
+    NSImageRep *best = nil;
+    BOOL raised = NO;
+
+    image = AUTORELEASE([[NSImage alloc] initWithSize: NSMakeSize(16, 16)]);
+    rep = AUTORELEASE([[NSBitmapImageRep alloc]
+                        initWithBitmapDataPlanes: NULL
+                                      pixelsWide: 16
+                                      pixelsHigh: 16
+                                   bitsPerSample: 8
+                                 samplesPerPixel: 3
+                                        hasAlpha: NO
+                                        isPlanar: NO
+                                  colorSpaceName: NSDeviceRGBColorSpace
+                                     bytesPerRow: 0
+                                    bitsPerPixel: 0]);
+    [image addRepresentation: rep];
+
+    NS_DURING
+      {
+        best = [image bestRepresentationForDevice: description];
+      }
+    NS_HANDLER
+      {
+        raised = YES;
+      }
+    NS_ENDHANDLER
+
+    PASS(raised == NO,
+         "asking an image for its best representation for a printer does not "
+         "raise");
+    PASS_EQUAL(best, rep,
+               "the representation of the image is returned");
+  }
+
+  printer = printerWithResolution(@"600x300dpi", path);
+  resolution = [[printer deviceDescription] objectForKey: NSDeviceResolution];
+
+  PASS(NSEqualSizes([resolution sizeValue], NSMakeSize(600, 300)),
+       "an asymmetric resolution keeps both directions");
+
+  printer = printerWithResolution(@"default", path);
+
+  PASS([[printer deviceDescription] objectForKey: NSDeviceResolution] == nil,
+       "a keyword naming no resolution leaves NSDeviceResolution out");
+
+  [[NSFileManager defaultManager] removeFileAtPath: path handler: nil];
+
+  if (savedPrinters != nil)
+    [ud setObject: savedPrinters forKey: @"GSLPRPrinters"];
+  else
+    [ud removeObjectForKey: @"GSLPRPrinters"];
+
+  if (savedBundle != nil)
+    [ud setObject: savedBundle forKey: @"GSPrinting"];
+  else
+    [ud removeObjectForKey: @"GSPrinting"];
+
+  END_SET("NSPrinter device description")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSPrinter/ppdOrderDependency.m
+++ b/Tests/gui/NSPrinter/ppdOrderDependency.m
@@ -34,8 +34,6 @@ static NSString *ppdText =
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("PPD keyword after OrderDependency")
 
   NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
@@ -112,6 +110,5 @@ main(int argc, char **argv)
 
   END_SET("PPD keyword after OrderDependency")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPrinter/ppdOrderDependency.m
+++ b/Tests/gui/NSPrinter/ppdOrderDependency.m
@@ -1,0 +1,117 @@
+/* A keyword on the line after *OrderDependency or *UIConstraints must still be
+   read.  The shipped Generic-PostScript_Printer-Postscript.ppd puts
+   *DefaultPageSize, *DefaultPageRegion and *DefaultResolution directly after an
+   *OrderDependency line, so losing that line leaves the printer with no default
+   page size and no default resolution.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSDictionary.h>
+#include <Foundation/NSException.h>
+#include <Foundation/NSFileManager.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSPathUtilities.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSUserDefaults.h>
+
+#include <AppKit/NSPrinter.h>
+
+static NSString *ppdText =
+  @"*PPD-Adobe: \"4.3\"\n"
+  @"*ModelName: \"Test\"\n"
+  @"*OpenUI *PageSize/Page Size: PickOne\n"
+  @"*OrderDependency: 100 AnySetup *PageSize\n"
+  @"*DefaultPageSize: Letter\n"
+  @"*PageSize Letter/US Letter: \"612 792\"\n"
+  @"*CloseUI: *PageSize\n"
+  @"*OrderDependency: 110 AnySetup *Resolution Default\n"
+  @"*DefaultResolution: 600dpi\n"
+  @"*UIConstraints: *PageSize Legal *Duplex\n"
+  @"*DefaultColorSpace: Gray\n"
+  @"*PaperDimension Letter/US Letter: \"612 792\"\n";
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("PPD keyword after OrderDependency")
+
+  NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+  id savedPrinters = [ud objectForKey: @"GSLPRPrinters"];
+  id savedBundle = [ud objectForKey: @"GSPrinting"];
+  NSString *path;
+  NSDictionary *entry;
+  NSPrinter *printer = nil;
+
+  path = [NSTemporaryDirectory()
+           stringByAppendingPathComponent: @"gsOrderDependency.ppd"];
+
+  if (![ppdText writeToFile: path atomically: YES])
+    {
+      SKIP("could not write a PPD to the temporary directory")
+    }
+
+  entry = [NSDictionary dictionaryWithObjectsAndKeys:
+    path, @"PPDPath",
+    @"localhost", @"Host",
+    @"Test", @"Type",
+    @"test", @"Note",
+    nil];
+
+  [ud setObject: @"GSLPR" forKey: @"GSPrinting"];
+  [ud setObject: [NSDictionary dictionaryWithObject: entry
+                                             forKey: @"OrderDependencyPrinter"]
+         forKey: @"GSLPRPrinters"];
+
+  NS_DURING
+    {
+      printer = [NSPrinter printerWithName: @"OrderDependencyPrinter"];
+    }
+  NS_HANDLER
+    {
+      printer = nil;
+    }
+  NS_ENDHANDLER
+
+  if (printer == nil)
+    {
+      [[NSFileManager defaultManager] removeFileAtPath: path handler: nil];
+      SKIP("no printing bundle able to read a PPD")
+    }
+
+  PASS_EQUAL([printer stringForKey: @"DefaultPageSize" inTable: @"PPD"],
+             @"Letter",
+             "*DefaultPageSize after *OrderDependency is read");
+
+  PASS_EQUAL([printer stringForKey: @"DefaultResolution" inTable: @"PPD"],
+             @"600dpi",
+             "*DefaultResolution after an *OrderDependency with an option "
+             "keyword is read");
+
+  PASS_EQUAL([printer stringForKey: @"DefaultColorSpace" inTable: @"PPD"],
+             @"Gray",
+             "*DefaultColorSpace after *UIConstraints is read");
+
+  PASS(NSEqualSizes([printer pageSizeForPaper: @"Letter"],
+                    NSMakeSize(612, 792)),
+       "the paper dimensions of the printer are read");
+
+  [[NSFileManager defaultManager] removeFileAtPath: path handler: nil];
+
+  if (savedPrinters != nil)
+    [ud setObject: savedPrinters forKey: @"GSLPRPrinters"];
+  else
+    [ud removeObjectForKey: @"GSLPRPrinters"];
+
+  if (savedBundle != nil)
+    [ud setObject: savedBundle forKey: @"GSPrinting"];
+  else
+    [ud removeObjectForKey: @"GSPrinting"];
+
+  END_SET("PPD keyword after OrderDependency")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
In a PPD the keyword on the line after `*OrderDependency` or `*UIConstraints` is discarded. Both parsers consume the line terminator, and the caller then skips to the end of the following line. The shipped Generic-PostScript_Printer-Postscript.ppd puts `*DefaultPageSize`, `*DefaultPageRegion` and `*DefaultResolution` directly after an `*OrderDependency` line, so the default printer ends up with no default paper size and no resolution.

Both parsers now leave the line terminator where the caller expects it. With the resolution read again, `-deviceDescription` was putting an NSNumber under NSDeviceResolution, while a screen stores an NSValue holding an NSSize there and `-[NSImage bestRepresentationForDevice:]` reads it with `-sizeValue`, which raised NSInvalidArgumentException. It now stores a size, reads both `600dpi` and `600x300dpi`, and leaves the entry out when the keyword names no resolution, as the generic PPD's `default` does.

The two changes belong together: on its own the parser change makes that raise reachable for the default printer, where the entry used to be missing.

Tests/gui/NSPrinter/ppdOrderDependency.m and Tests/gui/NSPrinter/deviceDescription.m. Eight assertions fail before the change and pass after.

Refers to #133.

