### PR TITLE
Feature: Implement NSPredicateEditorRowTemplate

### DIFF
--- a/Headers/AppKit/NSPredicateEditorRowTemplate.h
+++ b/Headers/AppKit/NSPredicateEditorRowTemplate.h
@@ -55,8 +55,15 @@ enum {
 typedef NSUInteger NSAttributeType;
 
 APPKIT_EXPORT_CLASS
-@interface NSPredicateEditorRowTemplate : NSObject {
-
+@interface NSPredicateEditorRowTemplate : NSObject <NSCoding, NSCopying> {
+  NSArray                       *_leftExpressions;
+  NSArray                       *_rightExpressions;
+  NSArray                       *_operators;
+  NSArray                       *_compoundTypes;
+  NSArray                       *_views;
+  NSAttributeType                _rightExpressionAttributeType;
+  NSComparisonPredicateModifier  _modifier;
+  NSUInteger                     _options;
 }
 
 + (NSArray *) templatesWithAttributeKeyPaths: (NSArray *)paths

--- a/Source/NSPredicateEditorRowTemplate.m
+++ b/Source/NSPredicateEditorRowTemplate.m
@@ -26,28 +26,76 @@
    Boston, MA 02110-1301, USA.
 */
 
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDate.h>
+#import <Foundation/NSDecimalNumber.h>
+#import <Foundation/NSEnumerator.h>
+#import <Foundation/NSException.h>
+#import <Foundation/NSExpression.h>
+#import <Foundation/NSPredicate.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
+
+#import "AppKit/NSDatePicker.h"
+#import "AppKit/NSPopUpButton.h"
 #import "AppKit/NSPredicateEditorRowTemplate.h"
+#import "AppKit/NSTextField.h"
+#import "GSGuiPrivate.h"
+
+/* The views are created at this size; the rule editor lays them out. */
+static const CGFloat viewWidth = 100.0;
+static const CGFloat viewHeight = 22.0;
+
+/* How well a predicate fits this template.  A comparison the template can
+   represent scores 0.81, one that differs only in its options 0.729, and a
+   compound predicate of a type the template holds 0.5, which is what OS X
+   reports for the same templates.
+*/
+static const double comparisonMatch = 0.81;
+static const double comparisonMatchOtherOptions = 0.729;
+static const double compoundMatch = 0.5;
+
+@interface NSPredicateEditorRowTemplate (Private)
+- (NSPopUpButton *) _popUpButtonWithTitles: (NSArray *)titles;
+- (NSPopUpButton *) _popUpButtonAtIndex: (NSUInteger)index;
+- (NSString *) _titleForExpression: (NSExpression *)expression;
+- (NSString *) _titleForOperator: (NSPredicateOperatorType)type;
+- (NSString *) _titleForCompoundType: (NSCompoundPredicateType)type;
+- (NSView *) _rightView;
+- (NSExpression *) _rightExpressionFromView;
+- (void) _setRightViewToExpression: (NSExpression *)expression;
+@end
 
 @implementation NSPredicateEditorRowTemplate
 
 + (NSArray *) templatesWithAttributeKeyPaths: (NSArray *)paths
                          inEntityDescription: (NSEntityDescription *)entityDesc
 {
+  /* Entity descriptions belong to CoreData, which GNUstep does not have. */
   return nil;
 }
 
-- (NSArray *) compoundTypes
+- (id) initWithLeftExpressions: (NSArray *)leftExprs
+              rightExpressions: (NSArray *)rightExprs
+                      modifier: (NSComparisonPredicateModifier)modif
+                     operators: (NSArray *)ops
+                       options: (NSUInteger)opts
 {
-  return nil;
-}
+  self = [super init];
+  if (self == nil)
+    {
+      return nil;
+    }
 
-- (NSArray *) displayableSubpredicatesOfPredicate: (NSPredicate *)pred
-{
-  return nil;
-}
+  ASSIGNCOPY(_leftExpressions, leftExprs);
+  ASSIGNCOPY(_rightExpressions, rightExprs);
+  ASSIGNCOPY(_operators, ops);
+  _compoundTypes = nil;
+  _views = nil;
+  _rightExpressionAttributeType = NSUndefinedAttributeType;
+  _modifier = modif;
+  _options = opts;
 
-- (id) initWithCompoundTypes: (NSArray *)types
-{
   return self;
 }
 
@@ -57,65 +105,634 @@
                      operators: (NSArray *)ops
                        options: (NSUInteger)opts
 {
+  self = [self initWithLeftExpressions: leftExprs
+                      rightExpressions: nil
+                              modifier: modif
+                             operators: ops
+                               options: opts];
+  if (self != nil)
+    {
+      _rightExpressionAttributeType = attrType;
+    }
+
   return self;
 }
 
-- (id) initWithLeftExpressions: (NSArray *)leftExprs
-              rightExpressions: (NSArray *)rightExprs
-                      modifier: (NSComparisonPredicateModifier)modif
-                     operators: (NSArray *)ops
-                       options: (NSUInteger)opts
+- (id) initWithCompoundTypes: (NSArray *)types
 {
+  self = [self initWithLeftExpressions: nil
+                      rightExpressions: nil
+                              modifier: NSDirectPredicateModifier
+                             operators: nil
+                               options: 0];
+  if (self != nil)
+    {
+      ASSIGNCOPY(_compoundTypes, types);
+    }
+
   return self;
+}
+
+- (void) dealloc
+{
+  RELEASE(_leftExpressions);
+  RELEASE(_rightExpressions);
+  RELEASE(_operators);
+  RELEASE(_compoundTypes);
+  RELEASE(_views);
+  [super dealloc];
+}
+
+- (NSArray *) compoundTypes
+{
+  return _compoundTypes;
 }
 
 - (NSArray *) leftExpressions
 {
+  return _leftExpressions;
+}
+
+- (NSArray *) rightExpressions
+{
+  return _rightExpressions;
+}
+
+- (NSAttributeType) rightExpressionAttributeType
+{
+  return _rightExpressionAttributeType;
+}
+
+- (NSComparisonPredicateModifier) modifier
+{
+  return _modifier;
+}
+
+- (NSArray *) operators
+{
+  return _operators;
+}
+
+- (NSUInteger) options
+{
+  return _options;
+}
+
+- (NSArray *) templateViews
+{
+  if (_views != nil)
+    {
+      return _views;
+    }
+
+  if (_compoundTypes != nil)
+    {
+      NSMutableArray *titles;
+      NSEnumerator *enumerator;
+      NSNumber *type;
+
+      titles = [NSMutableArray arrayWithCapacity: [_compoundTypes count]];
+      enumerator = [_compoundTypes objectEnumerator];
+      while ((type = [enumerator nextObject]) != nil)
+        {
+          [titles addObject:
+            [self _titleForCompoundType: [type unsignedIntegerValue]]];
+        }
+
+      _views = [[NSArray alloc] initWithObjects:
+        [self _popUpButtonWithTitles: titles],
+        [self _popUpButtonWithTitles:
+          [NSArray arrayWithObject: _(@"of the following are true")]],
+        nil];
+    }
+  else if (_leftExpressions != nil)
+    {
+      NSMutableArray *leftTitles;
+      NSMutableArray *operatorTitles;
+      NSEnumerator *enumerator;
+      NSExpression *expression;
+      NSNumber *type;
+
+      leftTitles = [NSMutableArray arrayWithCapacity: [_leftExpressions count]];
+      enumerator = [_leftExpressions objectEnumerator];
+      while ((expression = [enumerator nextObject]) != nil)
+        {
+          [leftTitles addObject: [self _titleForExpression: expression]];
+        }
+
+      operatorTitles = [NSMutableArray arrayWithCapacity: [_operators count]];
+      enumerator = [_operators objectEnumerator];
+      while ((type = [enumerator nextObject]) != nil)
+        {
+          [operatorTitles addObject:
+            [self _titleForOperator: [type unsignedIntegerValue]]];
+        }
+
+      _views = [[NSArray alloc] initWithObjects:
+        [self _popUpButtonWithTitles: leftTitles],
+        [self _popUpButtonWithTitles: operatorTitles],
+        [self _rightView],
+        nil];
+    }
+  else
+    {
+      _views = [[NSArray alloc] init];
+    }
+
+  return _views;
+}
+
+- (NSArray *) displayableSubpredicatesOfPredicate: (NSPredicate *)pred
+{
+  if ([pred isKindOfClass: [NSCompoundPredicate class]])
+    {
+      return [(NSCompoundPredicate *)pred subpredicates];
+    }
+
   return nil;
 }
 
 - (double) matchForPredicate: (NSPredicate *)pred
 {
+  if (pred == nil)
+    {
+      [NSException raise: NSInvalidArgumentException
+                  format: @"%@ was passed a nil predicate",
+        NSStringFromSelector(_cmd)];
+    }
+
+  if (_compoundTypes != nil)
+    {
+      NSCompoundPredicateType type;
+
+      if (![pred isKindOfClass: [NSCompoundPredicate class]])
+        {
+          return 0.0;
+        }
+
+      type = [(NSCompoundPredicate *)pred compoundPredicateType];
+      if ([_compoundTypes containsObject:
+            [NSNumber numberWithUnsignedInteger: type]])
+        {
+          return compoundMatch;
+        }
+
+      return 0.0;
+    }
+
+  if ([pred isKindOfClass: [NSComparisonPredicate class]])
+    {
+      NSComparisonPredicate *comparison = (NSComparisonPredicate *)pred;
+      NSExpression *right = [comparison rightExpression];
+
+      if (![_leftExpressions containsObject: [comparison leftExpression]])
+        {
+          return 0.0;
+        }
+
+      if (![_operators containsObject: [NSNumber numberWithUnsignedInteger:
+             [comparison predicateOperatorType]]])
+        {
+          return 0.0;
+        }
+
+      if (_rightExpressions != nil)
+        {
+          if (![_rightExpressions containsObject: right])
+            {
+              return 0.0;
+            }
+        }
+      else if ([right expressionType] != NSConstantValueExpressionType)
+        {
+          return 0.0;
+        }
+
+      if ([comparison options] != _options)
+        {
+          return comparisonMatchOtherOptions;
+        }
+
+      return comparisonMatch;
+    }
+
   return 0.0;
-}
-
-- (NSComparisonPredicateModifier) modifier
-{
-  return NSDirectPredicateModifier;
-}
-
-- (NSArray *) operators
-{
-  return nil;
-}
-
-- (NSUInteger) options
-{
-  return 0;
 }
 
 - (NSPredicate *) predicateWithSubpredicates: (NSArray *)subpred
 {
-  return nil;
-}
+  if (_compoundTypes != nil)
+    {
+      NSInteger index = [[self _popUpButtonAtIndex: 0] indexOfSelectedItem];
+      NSCompoundPredicateType type;
 
-- (NSAttributeType) rightExpressionAttributeType
-{
-  return 0;
-}
+      if (index < 0 || (NSUInteger)index >= [_compoundTypes count])
+        {
+          return nil;
+        }
 
-- (NSArray *) rightExpressions
-{
+      type = [[_compoundTypes objectAtIndex: index] unsignedIntegerValue];
+
+      switch (type)
+        {
+          case NSNotPredicateType:
+            return [NSCompoundPredicate notPredicateWithSubpredicate:
+              ([subpred count] > 0 ? [subpred objectAtIndex: 0] : nil)];
+          case NSOrPredicateType:
+            return [NSCompoundPredicate orPredicateWithSubpredicates: subpred];
+          case NSAndPredicateType:
+          default:
+            return [NSCompoundPredicate andPredicateWithSubpredicates: subpred];
+        }
+    }
+
+  if (_leftExpressions != nil)
+    {
+      NSInteger leftIndex = [[self _popUpButtonAtIndex: 0] indexOfSelectedItem];
+      NSInteger operatorIndex
+        = [[self _popUpButtonAtIndex: 1] indexOfSelectedItem];
+      NSPredicateOperatorType type;
+
+      if (leftIndex < 0 || (NSUInteger)leftIndex >= [_leftExpressions count]
+        || operatorIndex < 0 || (NSUInteger)operatorIndex >= [_operators count])
+        {
+          return nil;
+        }
+
+      type = [[_operators objectAtIndex: operatorIndex] unsignedIntegerValue];
+
+      return [NSComparisonPredicate
+        predicateWithLeftExpression: [_leftExpressions objectAtIndex: leftIndex]
+                    rightExpression: [self _rightExpressionFromView]
+                           modifier: _modifier
+                               type: type
+                            options: _options];
+    }
+
   return nil;
 }
 
 - (void) setPredicate: (NSPredicate *)pred
 {
+  if (_compoundTypes != nil)
+    {
+      NSUInteger index;
+
+      if (![pred isKindOfClass: [NSCompoundPredicate class]])
+        {
+          return;
+        }
+
+      index = [_compoundTypes indexOfObject:
+        [NSNumber numberWithUnsignedInteger:
+          [(NSCompoundPredicate *)pred compoundPredicateType]]];
+      if (index != NSNotFound)
+        {
+          [[self _popUpButtonAtIndex: 0] selectItemAtIndex: index];
+        }
+
+      return;
+    }
+
+  if ([pred isKindOfClass: [NSComparisonPredicate class]])
+    {
+      NSComparisonPredicate *comparison = (NSComparisonPredicate *)pred;
+      NSUInteger index;
+
+      index = [_leftExpressions indexOfObject: [comparison leftExpression]];
+      if (index != NSNotFound)
+        {
+          [[self _popUpButtonAtIndex: 0] selectItemAtIndex: index];
+        }
+
+      index = [_operators indexOfObject: [NSNumber numberWithUnsignedInteger:
+        [comparison predicateOperatorType]]];
+      if (index != NSNotFound)
+        {
+          [[self _popUpButtonAtIndex: 1] selectItemAtIndex: index];
+        }
+
+      [self _setRightViewToExpression: [comparison rightExpression]];
+    }
 }
 
-- (NSArray *) templateViews
+//
+// NSCoding protocol
+//
+- (void) encodeWithCoder: (NSCoder *)aCoder
 {
-  return nil;
+  if ([aCoder allowsKeyedCoding])
+    {
+      [aCoder encodeObject: _leftExpressions forKey: @"NSLeftExpressions"];
+      [aCoder encodeObject: _rightExpressions forKey: @"NSRightExpressions"];
+      [aCoder encodeObject: _operators forKey: @"NSOperators"];
+      [aCoder encodeObject: _compoundTypes forKey: @"NSCompoundTypes"];
+      [aCoder encodeInteger: _rightExpressionAttributeType
+                     forKey: @"NSRightExpressionAttributeType"];
+      [aCoder encodeInteger: _modifier forKey: @"NSModifier"];
+      [aCoder encodeInteger: _options forKey: @"NSOptions"];
+    }
+  else
+    {
+      NSUInteger attributeType = _rightExpressionAttributeType;
+      NSUInteger modifier = _modifier;
+
+      [aCoder encodeObject: _leftExpressions];
+      [aCoder encodeObject: _rightExpressions];
+      [aCoder encodeObject: _operators];
+      [aCoder encodeObject: _compoundTypes];
+      [aCoder encodeValueOfObjCType: @encode(NSUInteger) at: &attributeType];
+      [aCoder encodeValueOfObjCType: @encode(NSUInteger) at: &modifier];
+      [aCoder encodeValueOfObjCType: @encode(NSUInteger) at: &_options];
+    }
+}
+
+- (id) initWithCoder: (NSCoder *)aDecoder
+{
+  self = [super init];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  if ([aDecoder allowsKeyedCoding])
+    {
+      ASSIGN(_leftExpressions,
+        [aDecoder decodeObjectForKey: @"NSLeftExpressions"]);
+      ASSIGN(_rightExpressions,
+        [aDecoder decodeObjectForKey: @"NSRightExpressions"]);
+      ASSIGN(_operators, [aDecoder decodeObjectForKey: @"NSOperators"]);
+      ASSIGN(_compoundTypes, [aDecoder decodeObjectForKey: @"NSCompoundTypes"]);
+      _rightExpressionAttributeType
+        = [aDecoder decodeIntegerForKey: @"NSRightExpressionAttributeType"];
+      _modifier = [aDecoder decodeIntegerForKey: @"NSModifier"];
+      _options = [aDecoder decodeIntegerForKey: @"NSOptions"];
+    }
+  else
+    {
+      NSUInteger attributeType;
+      NSUInteger modifier;
+
+      ASSIGN(_leftExpressions, [aDecoder decodeObject]);
+      ASSIGN(_rightExpressions, [aDecoder decodeObject]);
+      ASSIGN(_operators, [aDecoder decodeObject]);
+      ASSIGN(_compoundTypes, [aDecoder decodeObject]);
+      [aDecoder decodeValueOfObjCType: @encode(NSUInteger) at: &attributeType];
+      [aDecoder decodeValueOfObjCType: @encode(NSUInteger) at: &modifier];
+      [aDecoder decodeValueOfObjCType: @encode(NSUInteger) at: &_options];
+      _rightExpressionAttributeType = attributeType;
+      _modifier = modifier;
+    }
+
+  return self;
+}
+
+//
+// NSCopying protocol
+//
+- (id) copyWithZone: (NSZone *)zone
+{
+  NSPredicateEditorRowTemplate *copy;
+
+  copy = [[[self class] allocWithZone: zone]
+    initWithLeftExpressions: _leftExpressions
+           rightExpressions: _rightExpressions
+                   modifier: _modifier
+                  operators: _operators
+                    options: _options];
+  if (copy != nil)
+    {
+      copy->_rightExpressionAttributeType = _rightExpressionAttributeType;
+      ASSIGNCOPY(copy->_compoundTypes, _compoundTypes);
+    }
+
+  return copy;
+}
+
+@end
+
+@implementation NSPredicateEditorRowTemplate (Private)
+
+- (NSPopUpButton *) _popUpButtonWithTitles: (NSArray *)titles
+{
+  NSPopUpButton *button;
+
+  button = [[NSPopUpButton alloc]
+    initWithFrame: NSMakeRect(0.0, 0.0, viewWidth, viewHeight)
+        pullsDown: NO];
+  [button addItemsWithTitles: titles];
+  if ([titles count] > 0)
+    {
+      [button selectItemAtIndex: 0];
+    }
+
+  return AUTORELEASE(button);
+}
+
+- (NSPopUpButton *) _popUpButtonAtIndex: (NSUInteger)index
+{
+  NSArray *views = [self templateViews];
+
+  if (index >= [views count])
+    {
+      return nil;
+    }
+
+  return [views objectAtIndex: index];
+}
+
+- (NSString *) _titleForExpression: (NSExpression *)expression
+{
+  if ([expression expressionType] == NSKeyPathExpressionType)
+    {
+      return [expression keyPath];
+    }
+  else if ([expression expressionType] == NSConstantValueExpressionType)
+    {
+      return [[expression constantValue] description];
+    }
+
+  return [expression description];
+}
+
+- (NSString *) _titleForOperator: (NSPredicateOperatorType)type
+{
+  switch (type)
+    {
+      case NSLessThanPredicateOperatorType:
+        return _(@"is less than");
+      case NSLessThanOrEqualToPredicateOperatorType:
+        return _(@"is less than or equal to");
+      case NSGreaterThanPredicateOperatorType:
+        return _(@"is greater than");
+      case NSGreaterThanOrEqualToPredicateOperatorType:
+        return _(@"is greater than or equal to");
+      case NSEqualToPredicateOperatorType:
+        return _(@"is");
+      case NSNotEqualToPredicateOperatorType:
+        return _(@"is not");
+      case NSMatchesPredicateOperatorType:
+        return _(@"matches");
+      case NSLikePredicateOperatorType:
+        return _(@"is like");
+      case NSBeginsWithPredicateOperatorType:
+        return _(@"begins with");
+      case NSEndsWithPredicateOperatorType:
+        return _(@"ends with");
+      case NSInPredicateOperatorType:
+        return _(@"in");
+      case NSContainsPredicateOperatorType:
+        return _(@"contains");
+      case NSBetweenPredicateOperatorType:
+        return _(@"between");
+      default:
+        return _(@"is");
+    }
+}
+
+- (NSString *) _titleForCompoundType: (NSCompoundPredicateType)type
+{
+  switch (type)
+    {
+      case NSOrPredicateType:
+        return _(@"Any");
+      case NSNotPredicateType:
+        return _(@"None");
+      case NSAndPredicateType:
+      default:
+        return _(@"All");
+    }
+}
+
+- (NSView *) _rightView
+{
+  if (_rightExpressions != nil)
+    {
+      NSMutableArray *titles;
+      NSEnumerator *enumerator;
+      NSExpression *expression;
+
+      titles = [NSMutableArray arrayWithCapacity: [_rightExpressions count]];
+      enumerator = [_rightExpressions objectEnumerator];
+      while ((expression = [enumerator nextObject]) != nil)
+        {
+          [titles addObject: [self _titleForExpression: expression]];
+        }
+
+      return [self _popUpButtonWithTitles: titles];
+    }
+
+  if (_rightExpressionAttributeType == NSDateAttributeType)
+    {
+      return AUTORELEASE([[NSDatePicker alloc]
+        initWithFrame: NSMakeRect(0.0, 0.0, viewWidth, viewHeight)]);
+    }
+
+  return AUTORELEASE([[NSTextField alloc]
+    initWithFrame: NSMakeRect(0.0, 0.0, viewWidth, viewHeight)]);
+}
+
+- (NSExpression *) _rightExpressionFromView
+{
+  NSArray *views = [self templateViews];
+  NSView *view;
+  NSString *value;
+
+  if ([views count] < 3)
+    {
+      return nil;
+    }
+
+  view = [views objectAtIndex: 2];
+
+  if (_rightExpressions != nil)
+    {
+      NSInteger index = [(NSPopUpButton *)view indexOfSelectedItem];
+
+      if (index < 0 || (NSUInteger)index >= [_rightExpressions count])
+        {
+          return nil;
+        }
+
+      return [_rightExpressions objectAtIndex: index];
+    }
+
+  if ([view isKindOfClass: [NSDatePicker class]])
+    {
+      return [NSExpression expressionForConstantValue:
+        [(NSDatePicker *)view dateValue]];
+    }
+
+  value = [(NSTextField *)view stringValue];
+
+  switch (_rightExpressionAttributeType)
+    {
+      case NSInteger16AttributeType:
+      case NSInteger32AttributeType:
+      case NSInteger64AttributeType:
+      case NSBooleanAttributeType:
+        return [NSExpression expressionForConstantValue:
+          [NSNumber numberWithInteger: [value integerValue]]];
+      case NSDoubleAttributeType:
+      case NSFloatAttributeType:
+        return [NSExpression expressionForConstantValue:
+          [NSNumber numberWithDouble: [value doubleValue]]];
+      case NSDecimalAttributeType:
+        if ([value length] == 0)
+          {
+            return [NSExpression expressionForConstantValue:
+              [NSDecimalNumber notANumber]];
+          }
+        return [NSExpression expressionForConstantValue:
+          [NSDecimalNumber decimalNumberWithString: value]];
+      default:
+        return [NSExpression expressionForConstantValue: value];
+    }
+}
+
+- (void) _setRightViewToExpression: (NSExpression *)expression
+{
+  NSArray *views = [self templateViews];
+  NSView *view;
+  id value;
+
+  if ([views count] < 3 || expression == nil)
+    {
+      return;
+    }
+
+  view = [views objectAtIndex: 2];
+
+  if (_rightExpressions != nil)
+    {
+      NSUInteger index = [_rightExpressions indexOfObject: expression];
+
+      if (index != NSNotFound)
+        {
+          [(NSPopUpButton *)view selectItemAtIndex: index];
+        }
+
+      return;
+    }
+
+  if ([expression expressionType] != NSConstantValueExpressionType)
+    {
+      return;
+    }
+
+  value = [expression constantValue];
+
+  if ([view isKindOfClass: [NSDatePicker class]])
+    {
+      if ([value isKindOfClass: [NSDate class]])
+        {
+          [(NSDatePicker *)view setDateValue: value];
+        }
+
+      return;
+    }
+
+  [(NSTextField *)view setStringValue: [value description]];
 }
 
 @end

--- a/Tests/gui/NSPredicateEditorRowTemplate/basic.m
+++ b/Tests/gui/NSPredicateEditorRowTemplate/basic.m
@@ -23,8 +23,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSPredicateEditorRowTemplate")
 
   NSPredicateEditorRowTemplate *plain;
@@ -276,6 +274,5 @@ rightExpressionAttributeType: NSStringAttributeType
 
   END_SET("NSPredicateEditorRowTemplate")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPredicateEditorRowTemplate/basic.m
+++ b/Tests/gui/NSPredicateEditorRowTemplate/basic.m
@@ -1,0 +1,281 @@
+/* The row templates hold the expressions, operators and options a row of the
+   predicate editor can take, build the views for such a row, read a predicate
+   out of those views and set them from a predicate.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSArray.h>
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSData.h>
+#include <Foundation/NSException.h>
+#include <Foundation/NSExpression.h>
+#include <Foundation/NSKeyedArchiver.h>
+#include <Foundation/NSPredicate.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSValue.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSDatePicker.h>
+#include <AppKit/NSPopUpButton.h>
+#include <AppKit/NSPredicateEditorRowTemplate.h>
+#include <AppKit/NSTextField.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSPredicateEditorRowTemplate")
+
+  NSPredicateEditorRowTemplate *plain;
+  NSPredicateEditorRowTemplate *template;
+  NSPredicateEditorRowTemplate *compound;
+  NSPredicateEditorRowTemplate *listed;
+  NSArray *left;
+  NSArray *operators;
+  NSArray *views;
+  NSPredicate *predicate;
+  NSComparisonPredicate *comparison;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      NSLog(@"guard caught %@: %@", [localException name],
+            [localException reason]);
+      SKIP("no GUI backend available")
+    }
+  NS_ENDHANDLER
+
+  /* A template that was given nothing describes nothing. */
+  plain = AUTORELEASE([[NSPredicateEditorRowTemplate alloc] init]);
+  PASS([plain leftExpressions] == nil, "a plain template has no left expressions");
+  PASS([plain rightExpressions] == nil, "a plain template has no right expressions");
+  PASS([plain operators] == nil, "a plain template has no operators");
+  PASS([plain compoundTypes] == nil, "a plain template has no compound types");
+  PASS([plain modifier] == NSDirectPredicateModifier,
+       "a plain template compares directly");
+  PASS([plain options] == 0, "a plain template has no options");
+  PASS([plain rightExpressionAttributeType] == NSUndefinedAttributeType,
+       "a plain template has an undefined attribute type");
+  PASS([[plain templateViews] count] == 0, "a plain template has no views");
+
+  left = [NSArray arrayWithObjects:
+    [NSExpression expressionForKeyPath: @"name"],
+    [NSExpression expressionForKeyPath: @"title"], nil];
+  operators = [NSArray arrayWithObjects:
+    [NSNumber numberWithUnsignedInteger: NSEqualToPredicateOperatorType],
+    [NSNumber numberWithUnsignedInteger: NSContainsPredicateOperatorType], nil];
+
+  template = AUTORELEASE([[NSPredicateEditorRowTemplate alloc]
+    initWithLeftExpressions: left
+rightExpressionAttributeType: NSStringAttributeType
+                   modifier: NSDirectPredicateModifier
+                  operators: operators
+                    options: NSCaseInsensitivePredicateOption]);
+
+  PASS_EQUAL([template leftExpressions], left,
+             "the left expressions are the ones the template was given");
+  PASS([template rightExpressions] == nil,
+       "a template built with an attribute type has no right expressions");
+  PASS([template rightExpressionAttributeType] == NSStringAttributeType,
+       "the attribute type is the one the template was given");
+  PASS([template options] == NSCaseInsensitivePredicateOption,
+       "the options are the ones the template was given");
+
+  views = [template templateViews];
+  PASS([views count] == 3, "a comparison row has three views");
+  PASS([[views objectAtIndex: 0] isKindOfClass: [NSPopUpButton class]],
+       "the left expressions are shown in a pop up button");
+  PASS([[views objectAtIndex: 1] isKindOfClass: [NSPopUpButton class]],
+       "the operators are shown in a pop up button");
+  PASS([[views objectAtIndex: 2] isKindOfClass: [NSTextField class]],
+       "a string is typed into a text field");
+  PASS_EQUAL([[views objectAtIndex: 0] itemTitles],
+             ([NSArray arrayWithObjects: @"name", @"title", nil]),
+             "the left pop up button lists the key paths");
+  PASS_EQUAL([[views objectAtIndex: 1] itemTitles],
+             ([NSArray arrayWithObjects: @"is", @"contains", nil]),
+             "the operator pop up button names the operators");
+  PASS([template templateViews] == views,
+       "the same views are returned each time");
+
+  /* The predicate is read out of the views. */
+  predicate = [template predicateWithSubpredicates: nil];
+  PASS([predicate isKindOfClass: [NSComparisonPredicate class]],
+       "a comparison template builds a comparison predicate");
+  comparison = (NSComparisonPredicate *)predicate;
+  PASS_EQUAL([[comparison leftExpression] keyPath], @"name",
+             "the first left expression is used");
+  PASS([comparison predicateOperatorType] == NSEqualToPredicateOperatorType,
+       "the first operator is used");
+  PASS([comparison options] == NSCaseInsensitivePredicateOption,
+       "the options of the template are used");
+  PASS([comparison comparisonPredicateModifier] == NSDirectPredicateModifier,
+       "the modifier of the template is used");
+  PASS_EQUAL([[comparison rightExpression] constantValue], @"",
+             "an empty text field gives an empty string");
+
+  /* Matching. */
+  PASS([template matchForPredicate:
+         [NSPredicate predicateWithFormat: @"name CONTAINS[c] 'x'"]] == 0.81,
+       "a predicate the template can hold matches");
+  PASS([template matchForPredicate:
+         [NSPredicate predicateWithFormat: @"name CONTAINS 'x'"]] == 0.729,
+       "a predicate that differs only in its options matches less well");
+  PASS([template matchForPredicate:
+         [NSPredicate predicateWithFormat: @"other CONTAINS[c] 'x'"]] == 0.0,
+       "a predicate on another key path does not match");
+  PASS([template matchForPredicate:
+         [NSPredicate predicateWithFormat: @"name BEGINSWITH[c] 'x'"]] == 0.0,
+       "a predicate with an operator the template lacks does not match");
+  PASS([template matchForPredicate:
+         [NSPredicate predicateWithFormat: @"name ==[c] other"]] == 0.0,
+       "a comparison of two key paths does not match");
+  PASS([template matchForPredicate:
+         [NSPredicate predicateWithFormat: @"name == 'a' AND title == 'b'"]] == 0.0,
+       "a compound predicate does not match a comparison template");
+
+  {
+    BOOL raised = NO;
+
+    NS_DURING
+      {
+        [template matchForPredicate: nil];
+      }
+    NS_HANDLER
+      {
+        raised = YES;
+      }
+    NS_ENDHANDLER
+    PASS(raised == YES, "matching a nil predicate raises");
+  }
+
+  /* Setting the row from a predicate, then reading it back. */
+  [template setPredicate:
+    [NSPredicate predicateWithFormat: @"title CONTAINS[c] 'x'"]];
+  PASS([[views objectAtIndex: 0] indexOfSelectedItem] == 1,
+       "the left pop up button follows the predicate");
+  PASS([[views objectAtIndex: 1] indexOfSelectedItem] == 1,
+       "the operator pop up button follows the predicate");
+  PASS_EQUAL([[views objectAtIndex: 2] stringValue], @"x",
+             "the text field follows the predicate");
+
+  comparison = (NSComparisonPredicate *)[template predicateWithSubpredicates: nil];
+  PASS_EQUAL([[comparison leftExpression] keyPath], @"title",
+             "the predicate read back uses the chosen left expression");
+  PASS([comparison predicateOperatorType] == NSContainsPredicateOperatorType,
+       "the predicate read back uses the chosen operator");
+  PASS_EQUAL([[comparison rightExpression] constantValue], @"x",
+             "the predicate read back uses the text that was set");
+
+  /* Subpredicates are only displayable for a compound predicate. */
+  PASS([template displayableSubpredicatesOfPredicate:
+         [NSPredicate predicateWithFormat: @"name == 'a'"]] == nil,
+       "a comparison predicate has no displayable subpredicates");
+  PASS([[template displayableSubpredicatesOfPredicate:
+          [NSPredicate predicateWithFormat: @"name == 'a' AND title == 'b'"]]
+         count] == 2,
+       "a compound predicate shows its subpredicates");
+
+  /* A compound template. */
+  compound = AUTORELEASE([[NSPredicateEditorRowTemplate alloc]
+    initWithCompoundTypes: ([NSArray arrayWithObjects:
+      [NSNumber numberWithUnsignedInteger: NSAndPredicateType],
+      [NSNumber numberWithUnsignedInteger: NSOrPredicateType], nil])]);
+
+  PASS([[compound compoundTypes] count] == 2,
+       "the compound types are the ones the template was given");
+  PASS([compound leftExpressions] == nil,
+       "a compound template has no left expressions");
+  views = [compound templateViews];
+  PASS([views count] == 2, "a compound row has two views");
+  PASS_EQUAL([[views objectAtIndex: 0] itemTitles],
+             ([NSArray arrayWithObjects: @"All", @"Any", nil]),
+             "the compound types are named in a pop up button");
+
+  predicate = [compound predicateWithSubpredicates:
+    ([NSArray arrayWithObjects:
+      [NSPredicate predicateWithFormat: @"a == 1"],
+      [NSPredicate predicateWithFormat: @"b == 2"], nil])];
+  PASS([predicate isKindOfClass: [NSCompoundPredicate class]],
+       "a compound template builds a compound predicate");
+  PASS([(NSCompoundPredicate *)predicate compoundPredicateType]
+         == NSAndPredicateType,
+       "the first compound type is used");
+  PASS([[(NSCompoundPredicate *)predicate subpredicates] count] == 2,
+       "the subpredicates are kept");
+  PASS([compound matchForPredicate:
+         [NSPredicate predicateWithFormat: @"a == 1 AND b == 2"]] == 0.5,
+       "a compound predicate of a type the template holds matches");
+  PASS([compound matchForPredicate:
+         [NSPredicate predicateWithFormat: @"a == 1"]] == 0.0,
+       "a comparison does not match a compound template");
+
+  /* Right expressions given as a list are chosen from a pop up button. */
+  listed = AUTORELEASE([[NSPredicateEditorRowTemplate alloc]
+    initWithLeftExpressions: [NSArray arrayWithObject:
+                               [NSExpression expressionForKeyPath: @"state"]]
+           rightExpressions: ([NSArray arrayWithObjects:
+                               [NSExpression expressionForConstantValue: @"open"],
+                               [NSExpression expressionForConstantValue: @"shut"],
+                               nil])
+                   modifier: NSDirectPredicateModifier
+                  operators: [NSArray arrayWithObject:
+                               [NSNumber numberWithUnsignedInteger:
+                                 NSEqualToPredicateOperatorType]]
+                    options: 0]);
+
+  views = [listed templateViews];
+  PASS([[views objectAtIndex: 2] isKindOfClass: [NSPopUpButton class]],
+       "listed right expressions are shown in a pop up button");
+  PASS_EQUAL([[views objectAtIndex: 2] itemTitles],
+             ([NSArray arrayWithObjects: @"open", @"shut", nil]),
+             "the right pop up button lists the constants");
+  comparison = (NSComparisonPredicate *)[listed predicateWithSubpredicates: nil];
+  PASS_EQUAL([[comparison rightExpression] constantValue], @"open",
+             "the chosen right expression is used");
+
+  /* A date is edited in a date picker. */
+  {
+    NSPredicateEditorRowTemplate *dated;
+
+    dated = AUTORELEASE([[NSPredicateEditorRowTemplate alloc]
+      initWithLeftExpressions: [NSArray arrayWithObject:
+                                 [NSExpression expressionForKeyPath: @"due"]]
+ rightExpressionAttributeType: NSDateAttributeType
+                     modifier: NSDirectPredicateModifier
+                    operators: [NSArray arrayWithObject:
+                                 [NSNumber numberWithUnsignedInteger:
+                                   NSLessThanPredicateOperatorType]]
+                      options: 0]);
+    PASS([[[dated templateViews] objectAtIndex: 2]
+           isKindOfClass: [NSDatePicker class]],
+         "a date is edited in a date picker");
+    PASS_EQUAL([[[dated templateViews] objectAtIndex: 1] itemTitles],
+               [NSArray arrayWithObject: @"is less than"],
+               "the operator is named");
+  }
+
+  /* Archiving a template is not tested here: an expression cannot be
+     archived yet, so a template holding one cannot be either. */
+
+  /* Copying. */
+  {
+    NSPredicateEditorRowTemplate *copy = AUTORELEASE([template copy]);
+
+    PASS_EQUAL([copy leftExpressions], left, "a copy keeps the left expressions");
+    PASS([copy options] == NSCaseInsensitivePredicateOption,
+         "a copy keeps the options");
+    PASS([[copy templateViews] count] == 3, "a copy builds its own views");
+    PASS([copy templateViews] != [template templateViews],
+         "a copy does not share the views of the original");
+  }
+
+  END_SET("NSPredicateEditorRowTemplate")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Every method of NSPredicateEditorRowTemplate was a stub returning nil or zero, and the initialisers kept none of what they were given, so a template described nothing, showed nothing and built no predicate.

A template now keeps its left expressions, its right expressions or attribute type, its modifier, operators and options, and builds the views of a row from them: a pop up button of the left expressions, one of the operators, and a field for the right hand side, which is a date picker for a date and a third pop up button when the right hand sides were given as a list. It reads a comparison predicate out of those views, sets them from a predicate, and reports how well a predicate fits it: 0.81 for one it can hold, 0.729 for one differing only in its options and 0.5 for a compound of a type it holds, the values OS X gives for the same templates.

Templates cannot yet be archived, since an expression cannot be. Entity descriptions belong to CoreData, so the method taking one still returns nil. The class gains instance variables, having had none.

Tests/gui/NSPredicateEditorRowTemplate/basic.m. 36 assertions fail before the change and pass after.

Refers to #96.
