### PR TITLE
Feature: Implement NSRuleEditor

### DIFF
--- a/Headers/AppKit/NSRuleEditor.h
+++ b/Headers/AppKit/NSRuleEditor.h
@@ -62,6 +62,20 @@ APPKIT_EXPORT_CLASS
 @interface NSRuleEditor : NSControl {
   id _target;
   SEL _action;
+  id _delegate;
+  NSMutableArray *_rows;
+  NSMutableIndexSet *_selectedRows;
+  NSString *_criteriaKeyPath;
+  NSString *_displayValuesKeyPath;
+  NSString *_rowTypeKeyPath;
+  NSString *_subrowsKeyPath;
+  NSDictionary *_formattingDictionary;
+  NSString *_formattingStringsFilename;
+  Class _rowClass;
+  CGFloat _rowHeight;
+  NSRuleEditorNestingMode _nestingMode;
+  BOOL _editable;
+  BOOL _canRemoveAllRows;
 }
 
 - (void) addRow: (id)sender;

--- a/Source/NSRuleEditor.m
+++ b/Source/NSRuleEditor.m
@@ -4,8 +4,7 @@
 
    Copyright (C) 2020 Free Software Foundation, Inc.
 
-   Author: Fred Kiefer <fredkiefer@gmx.de>
-   Date:   January 2020
+   Created by Fabian Spillner on 03.12.07.
 
    This file is part of the GNUstep GUI Library.
 
@@ -16,7 +15,7 @@
 
    This library is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
    Lesser General Public License for more details.
 
    You should have received a copy of the GNU Lesser General Public
@@ -26,228 +25,877 @@
    Boston, MA 02110-1301, USA.
 */
 
-#import "AppKit/NSRuleEditor.h"
+#import <Foundation/NSArray.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSEnumerator.h>
+#import <Foundation/NSException.h>
+#import <Foundation/NSExpression.h>
+#import <Foundation/NSIndexSet.h>
+#import <Foundation/NSNotification.h>
+#import <Foundation/NSPredicate.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSValue.h>
 
+#import "AppKit/NSButton.h"
+#import "AppKit/NSRuleEditor.h"
+#import "AppKit/NSTextField.h"
+#import "AppKit/NSView.h"
+#import "GSGuiPrivate.h"
+
+static const CGFloat defaultRowHeight = 32.0;
+static const CGFloat rowInset = 4.0;
+static const CGFloat viewGap = 4.0;
+static const CGFloat indentPerLevel = 20.0;
+static const CGFloat buttonWidth = 24.0;
+
+/* One row of the editor: what it was built from, what it shows, and where it
+ * sits in the tree.
+ */
+@interface GSRuleEditorRow : NSObject
+{
+@public
+  NSMutableArray         *criteria;
+  NSMutableArray         *displayValues;
+  NSRuleEditorRowType     rowType;
+  GSRuleEditorRow        *parent;	// not retained
+}
+@end
+
+@implementation GSRuleEditorRow
+
+- (id) init
+{
+  if ((self = [super init]) != nil)
+    {
+      criteria = [NSMutableArray new];
+      displayValues = [NSMutableArray new];
+    }
+  return self;
+}
+
+- (void) dealloc
+{
+  RELEASE(criteria);
+  RELEASE(displayValues);
+  [super dealloc];
+}
+
+@end
+
+@interface NSRuleEditor (Private)
+- (GSRuleEditorRow *) _rowAtIndex: (NSInteger)index;
+- (GSRuleEditorRow *) _rootRow;
+- (void) _populateRow: (GSRuleEditorRow *)row;
+- (NSPredicate *) _predicateForRow: (GSRuleEditorRow *)row;
+- (NSDictionary *) _partsForRow: (GSRuleEditorRow *)row;
+- (NSArray *) _childRowsOf: (GSRuleEditorRow *)row;
+- (void) _rowsDidChange;
+- (void) _reloadRowViews;
+@end
 
 @implementation NSRuleEditor
-- (void) addRow: (id)sender
+
+- (id) initWithFrame: (NSRect)frame
 {
+  self = [super initWithFrame: frame];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  _rows = [[NSMutableArray alloc] init];
+  _selectedRows = [[NSMutableIndexSet alloc] init];
+  ASSIGN(_criteriaKeyPath, @"criteria");
+  ASSIGN(_displayValuesKeyPath, @"displayValues");
+  ASSIGN(_rowTypeKeyPath, @"rowType");
+  ASSIGN(_subrowsKeyPath, @"subrows");
+  _rowClass = [NSMutableDictionary class];
+  _rowHeight = defaultRowHeight;
+  _nestingMode = NSRuleEditorNestingModeCompound;
+  _editable = YES;
+  _canRemoveAllRows = YES;
+
+  return self;
 }
 
-- (BOOL) canRemoveAllRows
+- (void) dealloc
 {
-  return YES;
+  RELEASE(_rows);
+  RELEASE(_selectedRows);
+  RELEASE(_criteriaKeyPath);
+  RELEASE(_displayValuesKeyPath);
+  RELEASE(_rowTypeKeyPath);
+  RELEASE(_subrowsKeyPath);
+  RELEASE(_formattingDictionary);
+  RELEASE(_formattingStringsFilename);
+  [super dealloc];
 }
 
-- (NSArray *) criteriaForRow: (NSInteger)index
-{
-  return nil;
-}
-
-- (NSString *) criteriaKeyPath
-{
-  return nil;
-}
-
+//
+// Configuring
+//
 - (id) delegate
 {
-  return nil;
+  return _delegate;
 }
 
-- (NSArray *) displayValuesForRow: (NSInteger)index
+- (void) setDelegate: (id)delegate
 {
-  return nil;
-}
+  NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
 
-- (NSString *) displayValuesKeyPath
-{
-  return nil;
-}
+  if (_delegate == delegate)
+    {
+      return;
+    }
 
-- (NSDictionary *) formattingDictionary
-{
-  return nil;
-}
+  /* The delegate hears about the rows through the notification. */
+  if (_delegate != nil)
+    {
+      [center removeObserver: _delegate
+                        name: NSRuleEditorRowsDidChangeNotification
+                      object: self];
+    }
 
-- (NSString *) formattingStringsFilename
-{
-  return nil;
-}
+  _delegate = delegate;
 
-- (void) insertRowAtIndex: (NSInteger)index
-                 withType: (NSRuleEditorRowType)type
-            asSubrowOfRow: (NSInteger)row
-                  animate: (BOOL)flag
-{
+  if (_delegate != nil
+    && [_delegate respondsToSelector: @selector(ruleEditorRowsDidChange:)])
+    {
+      [center addObserver: _delegate
+                 selector: @selector(ruleEditorRowsDidChange:)
+                     name: NSRuleEditorRowsDidChangeNotification
+                   object: self];
+    }
 }
 
 - (BOOL) isEditable
 {
-  return YES;
+  return _editable;
 }
 
-- (NSRuleEditorNestingMode) nestingMode
+- (void) setEditable: (BOOL)flag
 {
-  return NSRuleEditorNestingModeSingle;
+  _editable = flag;
 }
 
-- (NSInteger) numberOfRows
+- (BOOL) canRemoveAllRows
 {
-  return 0;
-}
-
-- (NSInteger) parentRowForRow: (NSInteger)row
-{
-  return 0;
-}
-
-- (NSPredicate *) predicate
-{
-  return nil;
-}
-
-- (NSPredicate *) predicateForRow: (NSInteger)row
-{
-  return nil;
-}
-
-- (void) reloadCriteria
-{
-}
-
-- (void) reloadPredicate
-{
-}
-
-- (void) removeRowAtIndex: (NSInteger)index
-{
-}
-
-- (void) removeRowsAtIndexes: (NSIndexSet *)rowIds includeSubrows: (BOOL)flag
-{
-}
-
-- (Class) rowClass
-{
-  return nil;
-}
-
-- (NSInteger) rowForDisplayValue: (id)value
-{
-  return 0;
-}
-
-- (CGFloat) rowHeight
-{
-  return 0.0;
-}
-
-- (NSRuleEditorRowType) rowTypeForRow: (NSInteger)row
-{
-  return NSRuleEditorRowTypeSimple;
-}
-
-- (NSString *) rowTypeKeyPath
-{
-  return nil;
-}
-
-- (NSIndexSet *) selectedRowIndexes
-{
-  return nil;
-}
-
-- (void) selectRowIndexes: (NSIndexSet *)ids
-     byExtendingSelection: (BOOL)flag
-{
+  return _canRemoveAllRows;
 }
 
 - (void) setCanRemoveAllRows: (BOOL)flag
 {
+  _canRemoveAllRows = flag;
+}
+
+- (NSRuleEditorNestingMode) nestingMode
+{
+  return _nestingMode;
+}
+
+- (void) setNestingMode: (NSRuleEditorNestingMode)mode
+{
+  _nestingMode = mode;
+}
+
+- (CGFloat) rowHeight
+{
+  return _rowHeight;
+}
+
+- (void) setRowHeight: (CGFloat)height
+{
+  _rowHeight = height;
+  [self _reloadRowViews];
+}
+
+- (Class) rowClass
+{
+  return _rowClass;
+}
+
+- (void) setRowClass: (Class)rowClass
+{
+  _rowClass = rowClass;
+}
+
+- (NSString *) criteriaKeyPath
+{
+  return _criteriaKeyPath;
+}
+
+- (void) setCriteriaKeyPath: (NSString *)path
+{
+  ASSIGN(_criteriaKeyPath, path);
+}
+
+- (NSString *) displayValuesKeyPath
+{
+  return _displayValuesKeyPath;
+}
+
+- (void) setDisplayValuesKeyPath: (NSString *)path
+{
+  ASSIGN(_displayValuesKeyPath, path);
+}
+
+- (NSString *) rowTypeKeyPath
+{
+  return _rowTypeKeyPath;
+}
+
+- (void) setRowTypeKeyPath: (NSString *)path
+{
+  ASSIGN(_rowTypeKeyPath, path);
+}
+
+- (NSString *) subrowsKeyPath
+{
+  return _subrowsKeyPath;
+}
+
+- (void) setSubrowsKeyPath: (NSString *)path
+{
+  ASSIGN(_subrowsKeyPath, path);
+}
+
+- (NSDictionary *) formattingDictionary
+{
+  return _formattingDictionary;
+}
+
+- (void) setFormattingDictionary: (NSDictionary *)dict
+{
+  ASSIGN(_formattingDictionary, dict);
+}
+
+- (NSString *) formattingStringsFilename
+{
+  return _formattingStringsFilename;
+}
+
+- (void) setFormattingStringsFilename: (NSString *)filename
+{
+  ASSIGN(_formattingStringsFilename, filename);
+}
+
+//
+// Rows
+//
+- (NSInteger) numberOfRows
+{
+  return (NSInteger)[_rows count];
+}
+
+- (NSArray *) criteriaForRow: (NSInteger)index
+{
+  GSRuleEditorRow *row = [self _rowAtIndex: index];
+
+  return row != nil ? AUTORELEASE([row->criteria copy]) : nil;
+}
+
+- (NSArray *) displayValuesForRow: (NSInteger)index
+{
+  GSRuleEditorRow *row = [self _rowAtIndex: index];
+
+  return row != nil ? AUTORELEASE([row->displayValues copy]) : nil;
+}
+
+- (NSRuleEditorRowType) rowTypeForRow: (NSInteger)index
+{
+  GSRuleEditorRow *row = [self _rowAtIndex: index];
+
+  return row != nil ? row->rowType : NSRuleEditorRowTypeSimple;
+}
+
+- (NSInteger) parentRowForRow: (NSInteger)index
+{
+  GSRuleEditorRow *row = [self _rowAtIndex: index];
+
+  if (row == nil || row->parent == nil)
+    {
+      return -1;
+    }
+
+  return (NSInteger)[_rows indexOfObjectIdenticalTo: row->parent];
+}
+
+- (NSIndexSet *) subrowIndexesForRow: (NSInteger)index
+{
+  GSRuleEditorRow *row = [self _rowAtIndex: index];
+  NSMutableIndexSet *result = [NSMutableIndexSet indexSet];
+  NSUInteger i;
+  NSUInteger count = [_rows count];
+
+  if (row == nil)
+    {
+      return result;
+    }
+
+  for (i = 0; i < count; i++)
+    {
+      if (((GSRuleEditorRow *)[_rows objectAtIndex: i])->parent == row)
+        {
+          [result addIndex: i];
+        }
+    }
+
+  return result;
+}
+
+- (NSInteger) rowForDisplayValue: (id)value
+{
+  NSUInteger i;
+  NSUInteger count = [_rows count];
+
+  for (i = 0; i < count; i++)
+    {
+      GSRuleEditorRow *row = [_rows objectAtIndex: i];
+
+      if ([row->displayValues indexOfObjectIdenticalTo: value] != NSNotFound)
+        {
+          return (NSInteger)i;
+        }
+    }
+
+  return -1;
+}
+
+- (void) addRow: (id)sender
+{
+  if (_nestingMode == NSRuleEditorNestingModeSingle && [_rows count] > 0)
+    {
+      return;
+    }
+
+  if (_nestingMode == NSRuleEditorNestingModeSingle
+    || _nestingMode == NSRuleEditorNestingModeList)
+    {
+      [self insertRowAtIndex: [self numberOfRows]
+                    withType: NSRuleEditorRowTypeSimple
+               asSubrowOfRow: -1
+                     animate: NO];
+      return;
+    }
+
+  /* The nesting modes that hold their rows under a compound row make that
+   * row first, so there is something for the new row to sit under.
+   */
+  if ([_rows count] == 0)
+    {
+      [self insertRowAtIndex: 0
+                    withType: NSRuleEditorRowTypeCompound
+               asSubrowOfRow: -1
+                     animate: NO];
+    }
+
+  [self insertRowAtIndex: [self numberOfRows]
+                withType: NSRuleEditorRowTypeSimple
+           asSubrowOfRow: 0
+                 animate: NO];
+}
+
+- (void) insertRowAtIndex: (NSInteger)index
+                 withType: (NSRuleEditorRowType)type
+            asSubrowOfRow: (NSInteger)parentIndex
+                  animate: (BOOL)flag
+{
+  GSRuleEditorRow *row;
+
+  if (index < 0 || index > [self numberOfRows])
+    {
+      [NSException raise: NSRangeException
+                  format: @"%@ index %ld out of range",
+        NSStringFromSelector(_cmd), (long)index];
+    }
+
+  row = AUTORELEASE([[GSRuleEditorRow alloc] init]);
+  row->rowType = type;
+  if (parentIndex >= 0)
+    {
+      row->parent = [self _rowAtIndex: parentIndex];
+    }
+
+  [_rows insertObject: row atIndex: (NSUInteger)index];
+  [self _populateRow: row];
+  [self _rowsDidChange];
+}
+
+- (void) removeRowAtIndex: (NSInteger)index
+{
+  if (index < 0 || index >= [self numberOfRows])
+    {
+      return;
+    }
+
+  [self removeRowsAtIndexes: [NSIndexSet indexSetWithIndex: (NSUInteger)index]
+             includeSubrows: YES];
+}
+
+- (void) removeRowsAtIndexes: (NSIndexSet *)rowIds includeSubrows: (BOOL)flag
+{
+  NSMutableArray *doomed = [NSMutableArray array];
+  NSUInteger index = [rowIds firstIndex];
+
+  while (index != NSNotFound)
+    {
+      GSRuleEditorRow *row = [self _rowAtIndex: (NSInteger)index];
+
+      if (row != nil)
+        {
+          [doomed addObject: row];
+        }
+      index = [rowIds indexGreaterThanIndex: index];
+    }
+
+  if (flag)
+    {
+      BOOL added = YES;
+
+      /* A subrow may itself hold subrows, so keep going until nothing more
+       * belongs to what is being removed.
+       */
+      while (added)
+        {
+          NSEnumerator *e = [_rows objectEnumerator];
+          GSRuleEditorRow *row;
+
+          added = NO;
+          while ((row = [e nextObject]) != nil)
+            {
+              if (row->parent != nil
+                && [doomed indexOfObjectIdenticalTo: row->parent] != NSNotFound
+                && [doomed indexOfObjectIdenticalTo: row] == NSNotFound)
+                {
+                  [doomed addObject: row];
+                  added = YES;
+                }
+            }
+        }
+    }
+  else
+    {
+      NSEnumerator *e = [_rows objectEnumerator];
+      GSRuleEditorRow *row;
+
+      /* What is left behind has to belong to something that stays. */
+      while ((row = [e nextObject]) != nil)
+        {
+          if (row->parent != nil
+            && [doomed indexOfObjectIdenticalTo: row->parent] != NSNotFound)
+            {
+              row->parent = nil;
+            }
+        }
+    }
+
+  [_rows removeObjectsInArray: doomed];
+  [_selectedRows removeAllIndexes];
+  [self _rowsDidChange];
 }
 
 - (void) setCriteria: (NSArray *)crits
     andDisplayValues: (NSArray *)vals
        forRowAtIndex: (NSInteger)index
 {
+  GSRuleEditorRow *row = [self _rowAtIndex: index];
+
+  if (row == nil)
+    {
+      return;
+    }
+
+  /* The arguments may be the arrays the row is already holding. */
+  crits = AUTORELEASE([crits copy]);
+  vals = AUTORELEASE([vals copy]);
+
+  [row->criteria setArray: crits];
+  [row->displayValues setArray: vals];
+  [self _rowsDidChange];
 }
 
-- (void) setCriteriaKeyPath: (NSString *)path
+//
+// Selection
+//
+- (NSIndexSet *) selectedRowIndexes
 {
+  return AUTORELEASE([_selectedRows copy]);
 }
 
-- (void) setDelegate: (id)delegate
+- (void) selectRowIndexes: (NSIndexSet *)ids
+     byExtendingSelection: (BOOL)flag
 {
+  if (!flag)
+    {
+      [_selectedRows removeAllIndexes];
+    }
+  [_selectedRows addIndexes: ids];
 }
 
-- (void) setDisplayValuesKeyPath: (NSString *)path
+//
+// Predicates
+//
+- (NSPredicate *) predicateForRow: (NSInteger)index
 {
+  return [self _predicateForRow: [self _rowAtIndex: index]];
 }
 
-- (void) setEditable: (BOOL)flag
+- (NSPredicate *) predicate
 {
+  NSMutableArray *predicates;
+  NSEnumerator *e;
+  GSRuleEditorRow *row;
+
+  if ([_rows count] == 0)
+    {
+      return nil;
+    }
+
+  /* The rows that sit at the top level carry the whole thing.  A compound
+   * row gathers its own subrows, so a tree has just the one.
+   */
+  predicates = [NSMutableArray array];
+  e = [_rows objectEnumerator];
+  while ((row = [e nextObject]) != nil)
+    {
+      if (row->parent == nil)
+        {
+          NSPredicate *p = [self _predicateForRow: row];
+
+          if (p != nil)
+            {
+              [predicates addObject: p];
+            }
+        }
+    }
+
+  if ([predicates count] == 0)
+    {
+      return nil;
+    }
+  if ([predicates count] == 1)
+    {
+      return [predicates objectAtIndex: 0];
+    }
+
+  return [NSCompoundPredicate orPredicateWithSubpredicates: predicates];
 }
 
-- (void) setFormattingDictionary: (NSDictionary *)dict
+- (void) reloadCriteria
 {
+  NSEnumerator *e = [_rows objectEnumerator];
+  GSRuleEditorRow *row;
+
+  while ((row = [e nextObject]) != nil)
+    {
+      [row->criteria removeAllObjects];
+      [row->displayValues removeAllObjects];
+      [self _populateRow: row];
+    }
+
+  [self _rowsDidChange];
 }
 
-- (void) setFormattingStringsFilename: (NSString *)filename
+- (void) reloadPredicate
 {
+  [self _rowsDidChange];
 }
 
-- (void) setNestingMode: (NSRuleEditorNestingMode)flag
+@end
+
+@implementation NSRuleEditor (Private)
+
+- (GSRuleEditorRow *) _rowAtIndex: (NSInteger)index
 {
+  if (index < 0 || index >= (NSInteger)[_rows count])
+    {
+      return nil;
+    }
+
+  return [_rows objectAtIndex: (NSUInteger)index];
 }
 
-- (void) setRowClass: (Class)rowClass
+- (GSRuleEditorRow *) _rootRow
 {
-}
+  NSEnumerator *e = [_rows objectEnumerator];
+  GSRuleEditorRow *row;
 
-- (void) setRowHeight: (CGFloat)height
-{
-}
+  while ((row = [e nextObject]) != nil)
+    {
+      if (row->parent == nil)
+        {
+          return row;
+        }
+    }
 
-- (void) setRowTypeKeyPath: (NSString *)path
-{
-}
-
-- (void) setSubrowsKeyPath: (NSString *)path
-{
-}
-
-- (NSIndexSet *) subrowIndexesForRow: (NSInteger)row
-{
   return nil;
 }
 
-- (NSString *) subrowsKeyPath
+- (NSArray *) _childRowsOf: (GSRuleEditorRow *)row
 {
-  return nil;
+  NSMutableArray *result = [NSMutableArray array];
+  NSEnumerator *e = [_rows objectEnumerator];
+  GSRuleEditorRow *other;
+
+  while ((other = [e nextObject]) != nil)
+    {
+      if (other->parent == row)
+        {
+          [result addObject: other];
+        }
+    }
+
+  return result;
 }
 
-- (void) viewDidMoveToWindow
+/* Walk the delegate from the root of its criteria, taking the first child at
+ * each step, until it offers no more.  That is the row as it starts out.
+ */
+- (void) _populateRow: (GSRuleEditorRow *)row
 {
+  id criterion = nil;
+  NSInteger rowIndex;
+
+  if (_delegate == nil)
+    {
+      return;
+    }
+
+  rowIndex = (NSInteger)[_rows indexOfObjectIdenticalTo: row];
+
+  while (YES)
+    {
+      NSInteger count;
+      id child;
+      id displayValue;
+
+      count = [_delegate ruleEditor: self
+       numberOfChildrenForCriterion: criterion
+                        withRowType: row->rowType];
+      if (count <= 0)
+        {
+          break;
+        }
+
+      child = [_delegate ruleEditor: self
+                             child: 0
+                      forCriterion: criterion
+                       withRowType: row->rowType];
+      if (child == nil)
+        {
+          break;
+        }
+
+      displayValue = [_delegate ruleEditor: self
+                 displayValueForCriterion: child
+                                    inRow: rowIndex];
+
+      [row->criteria addObject: child];
+      [row->displayValues addObject:
+        (displayValue != nil ? displayValue : (id)child)];
+
+      criterion = child;
+    }
 }
 
-- (void) setAction: (SEL)action
+/* Gather what the delegate says each criterion of the row contributes. */
+- (NSDictionary *) _partsForRow: (GSRuleEditorRow *)row
 {
-  _action = action;
+  NSMutableDictionary *parts = [NSMutableDictionary dictionary];
+  NSUInteger i;
+  NSUInteger count = [row->criteria count];
+  NSInteger rowIndex = (NSInteger)[_rows indexOfObjectIdenticalTo: row];
+
+  if (_delegate == nil
+    || ![_delegate respondsToSelector:
+          @selector(ruleEditor:predicatePartsForCriterion:withDisplayValue:inRow:)])
+    {
+      return parts;
+    }
+
+  for (i = 0; i < count; i++)
+    {
+      NSDictionary *part;
+
+      part = [_delegate ruleEditor: self
+        predicatePartsForCriterion: [row->criteria objectAtIndex: i]
+                  withDisplayValue: [row->displayValues objectAtIndex: i]
+                             inRow: rowIndex];
+      if (part != nil)
+        {
+          [parts addEntriesFromDictionary: part];
+        }
+    }
+
+  return parts;
 }
 
-- (SEL) action
+- (NSPredicate *) _predicateForRow: (GSRuleEditorRow *)row
 {
-  return _action;
+  NSDictionary *parts;
+  NSExpression *left;
+  NSExpression *right;
+  NSNumber *operator;
+  NSNumber *compound;
+
+  if (row == nil)
+    {
+      return nil;
+    }
+
+  parts = [self _partsForRow: row];
+  compound = [parts objectForKey: NSRuleEditorPredicateCompoundType];
+
+  if (row->rowType == NSRuleEditorRowTypeCompound || compound != nil)
+    {
+      NSArray *children = [self _childRowsOf: row];
+      NSMutableArray *subpredicates = [NSMutableArray array];
+      NSEnumerator *e = [children objectEnumerator];
+      GSRuleEditorRow *child;
+      NSCompoundPredicateType type;
+
+      while ((child = [e nextObject]) != nil)
+        {
+          NSPredicate *p = [self _predicateForRow: child];
+
+          if (p != nil)
+            {
+              [subpredicates addObject: p];
+            }
+        }
+
+      if ([subpredicates count] == 0)
+        {
+          return nil;
+        }
+
+      type = (compound != nil
+        ? [compound unsignedIntegerValue] : NSAndPredicateType);
+
+      if ([subpredicates count] == 1 && type != NSNotPredicateType)
+        {
+          return [subpredicates objectAtIndex: 0];
+        }
+
+      switch (type)
+        {
+          case NSNotPredicateType:
+            return [NSCompoundPredicate notPredicateWithSubpredicate:
+              [subpredicates objectAtIndex: 0]];
+          case NSOrPredicateType:
+            return [NSCompoundPredicate
+              orPredicateWithSubpredicates: subpredicates];
+          case NSAndPredicateType:
+          default:
+            return [NSCompoundPredicate
+              andPredicateWithSubpredicates: subpredicates];
+        }
+    }
+
+  left = [parts objectForKey: NSRuleEditorPredicateLeftExpression];
+  right = [parts objectForKey: NSRuleEditorPredicateRightExpression];
+  operator = [parts objectForKey: NSRuleEditorPredicateOperatorType];
+
+  if (left == nil || right == nil || operator == nil)
+    {
+      return nil;
+    }
+
+  return [NSComparisonPredicate
+    predicateWithLeftExpression: left
+                rightExpression: right
+                       modifier: [[parts objectForKey:
+                         NSRuleEditorPredicateComparisonModifier]
+                         unsignedIntegerValue]
+                           type: [operator unsignedIntegerValue]
+                        options: [[parts objectForKey:
+                          NSRuleEditorPredicateOptions] unsignedIntegerValue]];
 }
 
-- (void) setTarget: (id)target
+- (void) _rowsDidChange
 {
-  _target = target;
+  [self _reloadRowViews];
+  [[NSNotificationCenter defaultCenter]
+    postNotificationName: NSRuleEditorRowsDidChangeNotification
+                  object: self];
 }
 
-- (id) target
+/* Lay the display values of each row out in a line, indented by how deep the
+ * row sits.
+ */
+- (void) _reloadRowViews
 {
-  return _target;
+  NSArray *subviews = AUTORELEASE([[self subviews] copy]);
+  NSEnumerator *e = [subviews objectEnumerator];
+  NSView *view;
+  NSUInteger i;
+  NSUInteger count = [_rows count];
+  NSRect bounds = [self bounds];
+
+  while ((view = [e nextObject]) != nil)
+    {
+      [view removeFromSuperview];
+    }
+
+  for (i = 0; i < count; i++)
+    {
+      GSRuleEditorRow *row = [_rows objectAtIndex: i];
+      GSRuleEditorRow *ancestor = row->parent;
+      CGFloat x = rowInset;
+      CGFloat y;
+      NSEnumerator *values;
+      id value;
+
+      while (ancestor != nil)
+        {
+          x += indentPerLevel;
+          ancestor = ancestor->parent;
+        }
+
+      y = NSMaxY(bounds) - (CGFloat)(i + 1) * _rowHeight;
+
+      values = [row->displayValues objectEnumerator];
+      while ((value = [values nextObject]) != nil)
+        {
+          NSView *rowView;
+
+          if ([value isKindOfClass: [NSView class]])
+            {
+              rowView = value;
+            }
+          else
+            {
+              NSTextField *field;
+
+              field = AUTORELEASE([[NSTextField alloc] initWithFrame:
+                NSMakeRect(0.0, 0.0, 80.0, _rowHeight - 2 * rowInset)]);
+              [field setStringValue: [value description]];
+              [field setEditable: NO];
+              [field setBezeled: NO];
+              [field setDrawsBackground: NO];
+              rowView = field;
+            }
+
+          [rowView setFrameOrigin: NSMakePoint(x, y + rowInset)];
+          [self addSubview: rowView];
+          x += NSWidth([rowView frame]) + viewGap;
+        }
+
+      if (_editable)
+        {
+          NSButton *add;
+
+          add = AUTORELEASE([[NSButton alloc] initWithFrame:
+            NSMakeRect(NSMaxX(bounds) - buttonWidth - rowInset, y + rowInset,
+              buttonWidth, _rowHeight - 2 * rowInset)]);
+          [add setTitle: @"+"];
+          [add setTarget: self];
+          [add setAction: @selector(addRow:)];
+          [self addSubview: add];
+        }
+    }
+
+  [self setNeedsDisplay: YES];
 }
 
 @end

--- a/Tests/gui/NSRuleEditor/basic.m
+++ b/Tests/gui/NSRuleEditor/basic.m
@@ -1,0 +1,285 @@
+/* The rule editor asks its delegate for the criteria a row can hold, keeps
+   the rows in a tree, and builds a predicate out of the parts the delegate
+   gives for each criterion.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSArray.h>
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSDictionary.h>
+#include <Foundation/NSException.h>
+#include <Foundation/NSExpression.h>
+#include <Foundation/NSIndexSet.h>
+#include <Foundation/NSNotification.h>
+#include <Foundation/NSPredicate.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSValue.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSRuleEditor.h>
+#include <AppKit/NSTextField.h>
+
+static int notifications = 0;
+
+@interface Delegate : NSObject
+@end
+
+@implementation Delegate
+
+- (NSInteger) ruleEditor: (NSRuleEditor *)editor
+numberOfChildrenForCriterion: (id)criterion
+             withRowType: (NSRuleEditorRowType)rowType
+{
+  if (rowType == NSRuleEditorRowTypeCompound)
+    {
+      return criterion == nil ? 2 : 0;
+    }
+  if (criterion == nil || [criterion isEqual: @"name"]
+    || [criterion isEqual: @"is"])
+    {
+      return 1;
+    }
+  return 0;
+}
+
+- (id) ruleEditor: (NSRuleEditor *)editor
+            child: (NSInteger)index
+     forCriterion: (id)criterion
+      withRowType: (NSRuleEditorRowType)rowType
+{
+  if (rowType == NSRuleEditorRowTypeCompound)
+    {
+      return index == 0 ? @"All" : @"Any";
+    }
+  if (criterion == nil)
+    {
+      return @"name";
+    }
+  if ([criterion isEqual: @"name"])
+    {
+      return @"is";
+    }
+  return @"value";
+}
+
+- (id) ruleEditor: (NSRuleEditor *)editor
+displayValueForCriterion: (id)criterion
+            inRow: (NSInteger)row
+{
+  if ([criterion isEqual: @"value"])
+    {
+      NSTextField *field;
+
+      field = AUTORELEASE([[NSTextField alloc]
+        initWithFrame: NSMakeRect(0.0, 0.0, 100.0, 22.0)]);
+      [field setStringValue: [NSString stringWithFormat: @"v%ld", (long)row]];
+      return field;
+    }
+  return criterion;
+}
+
+- (NSDictionary *) ruleEditor: (NSRuleEditor *)editor
+   predicatePartsForCriterion: (id)criterion
+             withDisplayValue: (id)value
+                        inRow: (NSInteger)row
+{
+  if ([criterion isEqual: @"All"])
+    {
+      return [NSDictionary dictionaryWithObject:
+        [NSNumber numberWithUnsignedInteger: NSAndPredicateType]
+                                         forKey: NSRuleEditorPredicateCompoundType];
+    }
+  if ([criterion isEqual: @"Any"])
+    {
+      return [NSDictionary dictionaryWithObject:
+        [NSNumber numberWithUnsignedInteger: NSOrPredicateType]
+                                         forKey: NSRuleEditorPredicateCompoundType];
+    }
+  if ([criterion isEqual: @"name"])
+    {
+      return [NSDictionary dictionaryWithObject:
+        [NSExpression expressionForKeyPath: @"name"]
+                                         forKey: NSRuleEditorPredicateLeftExpression];
+    }
+  if ([criterion isEqual: @"is"])
+    {
+      return [NSDictionary dictionaryWithObject:
+        [NSNumber numberWithUnsignedInteger: NSEqualToPredicateOperatorType]
+                                         forKey: NSRuleEditorPredicateOperatorType];
+    }
+  return [NSDictionary dictionaryWithObject:
+    [NSExpression expressionForConstantValue: [value stringValue]]
+                                     forKey: NSRuleEditorPredicateRightExpression];
+}
+
+- (void) ruleEditorRowsDidChange: (NSNotification *)notification
+{
+  notifications++;
+}
+
+@end
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("NSRuleEditor")
+
+  NSRuleEditor *editor;
+  Delegate *delegate;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("no GUI backend available")
+    }
+  NS_ENDHANDLER
+
+  editor = AUTORELEASE([[NSRuleEditor alloc]
+    initWithFrame: NSMakeRect(0.0, 0.0, 400.0, 200.0)]);
+
+  /* Defaults. */
+  PASS([editor numberOfRows] == 0, "a fresh editor has no rows");
+  PASS([editor nestingMode] == NSRuleEditorNestingModeCompound,
+       "the nesting mode is compound to start with");
+  PASS([editor rowHeight] == 32.0, "the row height is 32 to start with");
+  PASS([editor isEditable], "a fresh editor is editable");
+  PASS([editor canRemoveAllRows], "all rows can be removed to start with");
+  PASS([editor delegate] == nil, "a fresh editor has no delegate");
+  PASS([editor rowClass] == [NSMutableDictionary class],
+       "rows are dictionaries to start with");
+  PASS_EQUAL([editor criteriaKeyPath], @"criteria", "the criteria key path");
+  PASS_EQUAL([editor displayValuesKeyPath], @"displayValues",
+             "the display values key path");
+  PASS_EQUAL([editor rowTypeKeyPath], @"rowType", "the row type key path");
+  PASS_EQUAL([editor subrowsKeyPath], @"subrows", "the subrows key path");
+  PASS([editor formattingDictionary] == nil,
+       "a fresh editor has no formatting dictionary");
+  PASS([editor predicate] == nil, "an editor with no rows has no predicate");
+  PASS([[editor selectedRowIndexes] count] == 0,
+       "a fresh editor has nothing selected");
+
+  delegate = AUTORELEASE([[Delegate alloc] init]);
+  [editor setDelegate: delegate];
+  PASS([editor delegate] == delegate, "the delegate is the one that was set");
+  PASS([editor numberOfRows] == 0,
+       "setting a delegate does not add a row by itself");
+
+  /* Compound nesting: the first row brings a compound row with it. */
+  notifications = 0;
+  [editor addRow: nil];
+  PASS([editor numberOfRows] == 2,
+       "the first row of a compound editor comes with a row to hold it");
+  PASS([editor rowTypeForRow: 0] == NSRuleEditorRowTypeCompound,
+       "the holding row is a compound row");
+  PASS([editor rowTypeForRow: 1] == NSRuleEditorRowTypeSimple,
+       "the row that was added is a simple row");
+  PASS([editor parentRowForRow: 0] == -1, "the holding row has no parent");
+  PASS([editor parentRowForRow: 1] == 0, "the added row sits under it");
+  PASS([[editor subrowIndexesForRow: 0] containsIndex: 1],
+       "the holding row counts the added row among its subrows");
+  PASS(notifications > 0, "the delegate hears that the rows changed");
+
+  PASS_EQUAL([editor criteriaForRow: 1],
+             ([NSArray arrayWithObjects: @"name", @"is", @"value", nil]),
+             "the criteria of a row are walked from the delegate");
+  PASS([[editor displayValuesForRow: 1] count] == 3,
+       "a display value is kept for each criterion");
+  PASS([[[editor displayValuesForRow: 1] objectAtIndex: 2]
+         isKindOfClass: [NSTextField class]],
+       "the display value the delegate made a view for is that view");
+  PASS([editor rowForDisplayValue:
+         [[editor displayValuesForRow: 1] objectAtIndex: 0]] == 1,
+       "a display value is found in the row that holds it");
+
+  PASS_EQUAL([[editor predicateForRow: 1] predicateFormat],
+             [[NSPredicate predicateWithFormat: @"name == 'v1'"] predicateFormat],
+             "the parts of a row are put together into a comparison");
+  PASS_EQUAL([[editor predicate] predicateFormat],
+             [[NSPredicate predicateWithFormat: @"name == 'v1'"] predicateFormat],
+             "one row under a compound row gives that row's predicate");
+
+  [editor addRow: nil];
+  PASS([editor numberOfRows] == 3, "a second row is added under the same row");
+  PASS_EQUAL([[editor predicate] predicateFormat],
+             [[NSPredicate predicateWithFormat: @"name == 'v1' AND name == 'v2'"]
+               predicateFormat],
+             "the compound row joins its subrows with the type it was given");
+
+  /* Setting a row from outside. */
+  {
+    NSArray *criteria = [editor criteriaForRow: 1];
+    NSMutableArray *values = [[[editor displayValuesForRow: 1] mutableCopy]
+                               autorelease];
+
+    [[values objectAtIndex: 2] setStringValue: @"changed"];
+    [editor setCriteria: criteria
+       andDisplayValues: values
+          forRowAtIndex: 1];
+    PASS_EQUAL([[editor predicateForRow: 1] predicateFormat],
+               [[NSPredicate predicateWithFormat: @"name == 'changed'"]
+                 predicateFormat],
+               "the predicate follows what the row was set to");
+  }
+
+  /* Selection. */
+  [editor selectRowIndexes: [NSIndexSet indexSetWithIndex: 1]
+      byExtendingSelection: NO];
+  PASS([[editor selectedRowIndexes] containsIndex: 1],
+       "a selected row is reported as selected");
+  [editor selectRowIndexes: [NSIndexSet indexSetWithIndex: 2]
+      byExtendingSelection: YES];
+  PASS([[editor selectedRowIndexes] count] == 2,
+       "extending the selection keeps what was selected");
+
+  /* Removing the compound row takes its subrows with it. */
+  [editor removeRowsAtIndexes: [NSIndexSet indexSetWithIndex: 0]
+               includeSubrows: YES];
+  PASS([editor numberOfRows] == 0,
+       "removing the holding row removes the rows under it");
+  PASS([editor predicate] == nil, "an emptied editor has no predicate");
+
+  /* A list of rows, joined with OR. */
+  {
+    NSRuleEditor *list = AUTORELEASE([[NSRuleEditor alloc]
+      initWithFrame: NSMakeRect(0.0, 0.0, 400.0, 200.0)]);
+
+    [list setNestingMode: NSRuleEditorNestingModeList];
+    [list setDelegate: delegate];
+    [list addRow: nil];
+    [list addRow: nil];
+    PASS([list numberOfRows] == 2, "a list holds the rows it is given");
+    PASS([list rowTypeForRow: 0] == NSRuleEditorRowTypeSimple,
+         "a list holds simple rows");
+    PASS([list parentRowForRow: 0] == -1, "a list row has no parent");
+    PASS_EQUAL([[list predicate] predicateFormat],
+               [[NSPredicate predicateWithFormat: @"name == 'v0' OR name == 'v1'"]
+                 predicateFormat],
+               "the rows of a list are joined with or");
+  }
+
+  /* A single row, and no more. */
+  {
+    NSRuleEditor *single = AUTORELEASE([[NSRuleEditor alloc]
+      initWithFrame: NSMakeRect(0.0, 0.0, 400.0, 200.0)]);
+
+    [single setNestingMode: NSRuleEditorNestingModeSingle];
+    [single setDelegate: delegate];
+    [single addRow: nil];
+    [single addRow: nil];
+    PASS([single numberOfRows] == 1, "a single editor holds one row only");
+    PASS_EQUAL([[single predicate] predicateFormat],
+               [[NSPredicate predicateWithFormat: @"name == 'v0'"]
+                 predicateFormat],
+               "the predicate of a single editor is that row's");
+  }
+
+  END_SET("NSRuleEditor")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSRuleEditor/basic.m
+++ b/Tests/gui/NSRuleEditor/basic.m
@@ -122,8 +122,6 @@ displayValueForCriterion: (id)criterion
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSRuleEditor")
 
   NSRuleEditor *editor;
@@ -280,6 +278,5 @@ main(int argc, char **argv)
 
   END_SET("NSRuleEditor")
 
-  DESTROY(arp);
   return 0;
 }


### PR DESCRIPTION
Every method of NSRuleEditor was a stub, so an editor had no rows, asked its delegate for nothing and produced no predicate. NSPredicateEditor is built on it and could not work either.

The editor now keeps its rows in a tree. A new row is filled by walking the delegate from the root of its criteria, taking the first child at each step and asking for a display value, until the delegate offers no more. The display values are laid out a row at a time, indented by how deep the row sits. The predicate of a row is assembled from the parts the delegate gives for each of its criteria, and a compound row joins the rows under it with the compound type its own criterion carries. A single editor holds one row, a list joins its rows with or, and the nesting modes that hold rows under a compound row make that row along with the first row it holds.

Choosing another item in a row does not yet rebuild the criteria under it, the formatting dictionary is kept but not applied, and rows are not animated. The class gains instance variables.

Tests/gui/NSRuleEditor/basic.m. 29 assertions fail before the change and pass after.

Refers to #96.
