### PR TITLE
Fix: edit a date picker from the keyboard

### DIFF
--- a/Headers/AppKit/NSDatePickerCell.h
+++ b/Headers/AppKit/NSDatePickerCell.h
@@ -76,6 +76,9 @@ APPKIT_EXPORT_CLASS
   NSDatePickerMode _datePickerMode;
   NSDatePickerStyle _datePickerStyle;
   BOOL _drawsBackground;
+  NSInteger _selectedField;
+  NSInteger _typedValue;
+  NSInteger _typedDigits;
 }
 
 - (NSColor *) backgroundColor;

--- a/Source/NSDatePicker.m
+++ b/Source/NSDatePicker.m
@@ -29,10 +29,16 @@
    Boston, MA 02110-1301, USA.
 */
 
+#import <Foundation/NSDate.h>
 #import <Foundation/NSString.h>
 
 #import "AppKit/NSDatePickerCell.h"
 #import "AppKit/NSDatePicker.h"
+#import "AppKit/NSEvent.h"
+
+@interface NSDatePickerCell (Private)
+- (BOOL) _handleKeyEvent: (NSEvent *)event;
+@end
 
 static id usedCellClass = nil;
 
@@ -55,6 +61,37 @@ static id usedCellClass = nil;
 + (void) setCellClass: (Class)cellClass
 {
   usedCellClass = cellClass;
+}
+
+- (void) keyDown: (NSEvent *)theEvent
+{
+  NSDate *before = [_cell dateValue];
+
+  if ([(NSDatePickerCell *)_cell _handleKeyEvent: theEvent])
+    {
+      NSDate *after = [_cell dateValue];
+
+      [self setNeedsDisplay: YES];
+      if (before == nil || ![before isEqualToDate: after])
+        {
+          [self sendAction: [self action] to: [self target]];
+        }
+      return;
+    }
+
+  [super keyDown: theEvent];
+}
+
+- (BOOL) becomeFirstResponder
+{
+  [self setNeedsDisplay: YES];
+  return YES;
+}
+
+- (BOOL) resignFirstResponder
+{
+  [self setNeedsDisplay: YES];
+  return YES;
 }
 
 - (NSColor *) backgroundColor

--- a/Source/NSDatePickerCell.m
+++ b/Source/NSDatePickerCell.m
@@ -35,6 +35,10 @@
 #import "AppKit/NSDatePickerCell.h"
 #import "AppKit/NSColor.h"
 
+@interface NSDatePickerCell (Private)
+- (void) _updateDateFormat;
+@end
+
 @implementation NSDatePickerCell
 
 - (void) dealloc
@@ -60,9 +64,117 @@
       [self setBezeled: YES];
       _datePickerElements = NSYearMonthDayDatePickerElementFlag
         | NSHourMinuteSecondDatePickerElementFlag;
+      [self _updateDateFormat];
     }
 
   return self;
+}
+
+/* The template holds one letter per element the picker shows.  The pattern
+   generator turns it into the pattern the locale writes those elements in.
+   'j' stands for the hour in the clock the locale uses, twelve or twenty
+   four.
+*/
+- (NSString *) _dateFormatTemplate
+{
+  NSMutableString *template = [NSMutableString stringWithCapacity: 8];
+  NSDatePickerElementFlags elements = _datePickerElements;
+
+  if (elements & NSEraDatePickerElementFlag)
+    {
+      [template appendString: @"G"];
+    }
+  if (elements & NSYearMonthDatePickerElementFlag)
+    {
+      [template appendString: @"yM"];
+    }
+  if ((elements & NSYearMonthDayDatePickerElementFlag)
+    == NSYearMonthDayDatePickerElementFlag)
+    {
+      [template appendString: @"d"];
+    }
+  if (elements & NSHourMinuteDatePickerElementFlag)
+    {
+      [template appendString: @"jm"];
+    }
+  if ((elements & NSHourMinuteSecondDatePickerElementFlag)
+    == NSHourMinuteSecondDatePickerElementFlag)
+    {
+      [template appendString: @"s"];
+    }
+  if (elements & NSTimeZoneDatePickerElementFlag)
+    {
+      [template appendString: @"z"];
+    }
+
+  return template;
+}
+
+/* Used when the pattern generator is unavailable, which is the case in a
+   build without ICU.
+*/
+- (NSString *) _fallbackDateFormat
+{
+  NSMutableString *format = [NSMutableString stringWithCapacity: 24];
+  NSDatePickerElementFlags elements = _datePickerElements;
+
+  if (elements & NSYearMonthDatePickerElementFlag)
+    {
+      [format appendString: @"y-MM"];
+      if ((elements & NSYearMonthDayDatePickerElementFlag)
+        == NSYearMonthDayDatePickerElementFlag)
+        {
+          [format appendString: @"-dd"];
+        }
+    }
+  if (elements & NSHourMinuteDatePickerElementFlag)
+    {
+      if ([format length] > 0)
+        {
+          [format appendString: @" "];
+        }
+      [format appendString: @"HH:mm"];
+      if ((elements & NSHourMinuteSecondDatePickerElementFlag)
+        == NSHourMinuteSecondDatePickerElementFlag)
+        {
+          [format appendString: @":ss"];
+        }
+    }
+  if (elements & NSTimeZoneDatePickerElementFlag)
+    {
+      [format appendString: @" zzz"];
+    }
+  if (elements & NSEraDatePickerElementFlag)
+    {
+      [format appendString: @" G"];
+    }
+
+  return format;
+}
+
+- (void) _updateDateFormat
+{
+  NSDateFormatter *formatter = (NSDateFormatter *)[self formatter];
+  NSString *template;
+  NSString *format = nil;
+
+  if (![formatter isKindOfClass: [NSDateFormatter class]])
+    {
+      return;
+    }
+
+  template = [self _dateFormatTemplate];
+  if ([template length] > 0)
+    {
+      format = [NSDateFormatter dateFormatFromTemplate: template
+                                               options: 0
+                                                locale: [formatter locale]];
+      if (format == nil)
+        {
+          format = [self _fallbackDateFormat];
+        }
+    }
+  [formatter setDateFormat: (format == nil) ? (NSString *)@"" : format];
 }
 
 - (NSColor *) backgroundColor
@@ -93,6 +205,7 @@
 - (void) setDatePickerElements: (NSDatePickerElementFlags)flags
 {
   _datePickerElements = flags;
+  [self _updateDateFormat];
 }
 
 - (NSDatePickerMode) datePickerMode
@@ -142,6 +255,25 @@
   [self setObjectValue: [self _clampedDate: date]];
 }
 
+/* NSCell keeps the text its formatter made when the value was set, which is
+   stale once the elements or the locale change, and -stringForObjectValue:
+   builds that text from a %-style format rather than from the pattern.
+*/
+- (NSString *) stringValue
+{
+  NSDateFormatter *formatter = (NSDateFormatter *)[self formatter];
+  id value = [self objectValue];
+
+  if ([value isKindOfClass: [NSDate class]]
+    && [formatter isKindOfClass: [NSDateFormatter class]]
+    && [[formatter dateFormat] length] > 0)
+    {
+      return [formatter stringFromDate: (NSDate *)value];
+    }
+
+  return [super stringValue];
+}
+
 - (id) delegate
 {
   return _delegate;
@@ -170,6 +302,7 @@
 - (void) setLocale: (NSLocale *)locale
 {
   [[self formatter] setLocale: locale];
+  [self _updateDateFormat];
 }
 
 - (NSDate *) maxDate
@@ -242,6 +375,13 @@
 {
   if ((self = [super initWithCoder: aDecoder]))
     {
+      if (![[self formatter] isKindOfClass: [NSDateFormatter class]])
+        {
+          NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+
+          [self setFormatter: formatter];
+          RELEASE(formatter);
+        }
       if ([aDecoder allowsKeyedCoding])
         {
           [self setTimeInterval: [aDecoder decodeDoubleForKey: @"NSTimeInterval"]];

--- a/Source/NSDatePickerCell.m
+++ b/Source/NSDatePickerCell.m
@@ -29,14 +29,27 @@
    Boston, MA 02110-1301, USA.
 */
 
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAttributedString.h>
+#import <Foundation/NSCalendar.h>
+#import <Foundation/NSEnumerator.h>
+#import <Foundation/NSCharacterSet.h>
 #import <Foundation/NSString.h>
 #import <Foundation/NSDate.h>
 #import <Foundation/NSDateFormatter.h>
+#import <Foundation/NSLocale.h>
+#import <Foundation/NSTimeZone.h>
+#import <Foundation/NSValue.h>
+#import "AppKit/NSAttributedString.h"
 #import "AppKit/NSDatePickerCell.h"
 #import "AppKit/NSColor.h"
+#import "AppKit/NSEvent.h"
+#import "AppKit/NSWindow.h"
 
 @interface NSDatePickerCell (Private)
 - (void) _updateDateFormat;
+- (NSArray *) _editableFields;
+- (NSCalendar *) _pickerCalendar;
 @end
 
 @implementation NSDatePickerCell
@@ -175,6 +188,191 @@
         }
     }
   [formatter setDateFormat: (format == nil) ? (NSString *)@"" : format];
+  _selectedField = 0;
+  _typedValue = 0;
+  _typedDigits = 0;
+}
+
+/* Every run of one pattern letter is a field.  Only the runs standing for a
+   part of the date the user can change are returned, in the order the
+   pattern writes them.  Text between quotes is a literal, not a field.
+*/
+- (NSArray *) _editableFields
+{
+  NSDateFormatter *formatter = (NSDateFormatter *)[self formatter];
+  NSString *pattern;
+  NSMutableArray *fields;
+  NSUInteger index;
+  NSUInteger length;
+  BOOL quoted = NO;
+
+  if (![formatter isKindOfClass: [NSDateFormatter class]])
+    {
+      return [NSArray array];
+    }
+
+  pattern = [formatter dateFormat];
+  length = [pattern length];
+  fields = [NSMutableArray arrayWithCapacity: 8];
+  for (index = 0; index < length; index++)
+    {
+      unichar c = [pattern characterAtIndex: index];
+      NSUInteger run = index;
+
+      if (c == '\'')
+        {
+          quoted = !quoted;
+          continue;
+        }
+      if (quoted)
+        {
+          continue;
+        }
+      if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')))
+        {
+          continue;
+        }
+      while (index + 1 < length && [pattern characterAtIndex: index + 1] == c)
+        {
+          index++;
+        }
+      switch (c)
+        {
+          case 'y': case 'Y': case 'u':
+          case 'M': case 'L':
+          case 'd':
+          case 'h': case 'H': case 'k': case 'K':
+          case 'm':
+          case 's':
+          case 'a': case 'b': case 'B':
+            [fields addObject: [pattern substringWithRange:
+              NSMakeRange(run, index - run + 1)]];
+            break;
+          default:
+            break;
+        }
+    }
+
+  return fields;
+}
+
+/* The calendar the picker counts in.  It has to hold the time zone of the
+   picker, or a day added to a date lands at the wrong hour.
+*/
+- (NSCalendar *) _pickerCalendar
+{
+  NSCalendar *calendar = [self calendar];
+  NSTimeZone *zone = [self timeZone];
+
+  if (calendar == nil)
+    {
+      calendar = [NSCalendar currentCalendar];
+    }
+  calendar = AUTORELEASE([calendar copy]);
+  if (zone != nil)
+    {
+      [calendar setTimeZone: zone];
+    }
+  if ([self locale] != nil)
+    {
+      [calendar setLocale: [self locale]];
+    }
+
+  return calendar;
+}
+
+- (NSCalendarUnit) _unitOfField: (NSString *)field
+{
+  switch ([field characterAtIndex: 0])
+    {
+      case 'y': case 'Y': case 'u': return NSCalendarUnitYear;
+      case 'M': case 'L':           return NSCalendarUnitMonth;
+      case 'd':                     return NSCalendarUnitDay;
+      case 'h': case 'H':
+      case 'k': case 'K':           return NSCalendarUnitHour;
+      case 'm':                     return NSCalendarUnitMinute;
+      case 's':                     return NSCalendarUnitSecond;
+      default:                      return 0;
+    }
+}
+
+- (NSInteger) _selectedFieldIndex
+{
+  NSInteger count = (NSInteger)[[self _editableFields] count];
+
+  if (count == 0)
+    {
+      return -1;
+    }
+  if (_selectedField < 0 || _selectedField >= count)
+    {
+      return 0;
+    }
+
+  return _selectedField;
+}
+
+- (void) _setSelectedFieldIndex: (NSInteger)index
+{
+  NSInteger count = (NSInteger)[[self _editableFields] count];
+
+  if (count > 0)
+    {
+      while (index < 0)
+        {
+          index += count;
+        }
+      _selectedField = index % count;
+    }
+  _typedValue = 0;
+  _typedDigits = 0;
+}
+
+/* The range the field covers in the text the cell shows.  The fields are
+   looked for in the order they are written, so a number that appears twice
+   is still found in its own place.
+*/
+- (NSRange) _rangeOfFieldAtIndex: (NSInteger)wanted
+                        inString: (NSString *)text
+{
+  NSDateFormatter *formatter = (NSDateFormatter *)[self formatter];
+  NSArray *fields = [self _editableFields];
+  NSDateFormatter *scratch;
+  NSRange found = NSMakeRange(NSNotFound, 0);
+  NSUInteger from = 0;
+  NSUInteger index;
+  NSDate *date = [self dateValue];
+
+  if (date == nil || wanted < 0 || wanted >= (NSInteger)[fields count])
+    {
+      return found;
+    }
+
+  scratch = AUTORELEASE([[NSDateFormatter alloc] init]);
+  [scratch setLocale: [formatter locale]];
+  [scratch setTimeZone: [formatter timeZone]];
+  [scratch setCalendar: [formatter calendar]];
+
+  for (index = 0; index <= (NSUInteger)wanted; index++)
+    {
+      NSString *part;
+      NSRange rest = NSMakeRange(from, [text length] - from);
+
+      [scratch setDateFormat: [fields objectAtIndex: index]];
+      part = [scratch stringFromDate: date];
+      if ([part length] == 0)
+        {
+          return NSMakeRange(NSNotFound, 0);
+        }
+      found = [text rangeOfString: part options: 0 range: rest];
+      if (found.location == NSNotFound)
+        {
+          return found;
+        }
+      from = NSMaxRange(found);
+    }
+
+  return found;
 }
 
 - (NSColor *) backgroundColor
@@ -252,7 +450,302 @@
 
 - (void) setDateValue: (NSDate *)date
 {
-  [self setObjectValue: [self _clampedDate: date]];
+  NSDate *proposed = [self _clampedDate: date];
+
+  if (proposed != nil && [_delegate respondsToSelector:
+    @selector(datePickerCell:validateProposedDateValue:timeInterval:)])
+    {
+      NSTimeInterval interval = _timeInterval;
+
+      [_delegate datePickerCell: self
+      validateProposedDateValue: &proposed
+                   timeInterval: &interval];
+      _timeInterval = interval;
+    }
+  [self setObjectValue: proposed];
+}
+
+/* One step of the field the user is on.  The step is a step of the calendar,
+   so it carries into the fields above it, and the day of a month that is too
+   short for it moves back to the last day of that month.
+*/
+- (BOOL) _stepSelectedFieldBy: (NSInteger)delta
+{
+  NSArray *fields = [self _editableFields];
+  NSInteger index = [self _selectedFieldIndex];
+  NSCalendar *calendar = [self _pickerCalendar];
+  NSDate *date = [self dateValue];
+  NSDateComponents *step;
+  NSCalendarUnit unit;
+  NSDate *stepped;
+
+  if (date == nil || index < 0)
+    {
+      return NO;
+    }
+
+  step = AUTORELEASE([[NSDateComponents alloc] init]);
+  unit = [self _unitOfField: [fields objectAtIndex: index]];
+  switch (unit)
+    {
+      case NSCalendarUnitYear:   [step setYear: delta];   break;
+      case NSCalendarUnitMonth:  [step setMonth: delta];  break;
+      case NSCalendarUnitDay:    [step setDay: delta];    break;
+      case NSCalendarUnitHour:   [step setHour: delta];   break;
+      case NSCalendarUnitMinute: [step setMinute: delta]; break;
+      case NSCalendarUnitSecond: [step setSecond: delta]; break;
+      default:
+        {
+          /* The morning and afternoon marker has one other state. */
+          NSDateComponents *now = [calendar components: NSCalendarUnitHour
+                                              fromDate: date];
+
+          [step setHour: ([now hour] < 12) ? 12 : -12];
+        }
+        break;
+    }
+
+  stepped = [calendar dateByAddingComponents: step toDate: date options: 0];
+  if (stepped == nil)
+    {
+      return NO;
+    }
+  _typedValue = 0;
+  _typedDigits = 0;
+  [self setDateValue: stepped];
+
+  return YES;
+}
+
+/* How large the number in a field can grow, so that a digit that cannot be
+   the first of a larger number is taken on its own.
+*/
+- (NSInteger) _highestValueOfField: (NSString *)field
+{
+  NSCalendar *calendar = [self _pickerCalendar];
+  NSDate *date = [self dateValue];
+
+  switch ([self _unitOfField: field])
+    {
+      case NSCalendarUnitYear:
+        return 9999;
+      case NSCalendarUnitMonth:
+        return [calendar rangeOfUnit: NSCalendarUnitMonth
+                              inUnit: NSCalendarUnitYear
+                             forDate: date].length;
+      case NSCalendarUnitDay:
+        return NSMaxRange([calendar rangeOfUnit: NSCalendarUnitDay
+                                         inUnit: NSCalendarUnitMonth
+                                        forDate: date]) - 1;
+      case NSCalendarUnitHour:
+        return ([field characterAtIndex: 0] == 'h'
+          || [field characterAtIndex: 0] == 'K') ? 12 : 23;
+      case NSCalendarUnitMinute:
+      case NSCalendarUnitSecond:
+        return 59;
+      default:
+        return 0;
+    }
+}
+
+- (BOOL) _setSelectedFieldToValue: (NSInteger)value
+{
+  NSArray *fields = [self _editableFields];
+  NSInteger index = [self _selectedFieldIndex];
+  NSCalendar *calendar = [self _pickerCalendar];
+  NSDate *date = [self dateValue];
+  NSString *field;
+  NSDateComponents *parts;
+  NSDate *edited;
+  NSUInteger units = NSCalendarUnitEra | NSCalendarUnitYear
+    | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour
+    | NSCalendarUnitMinute | NSCalendarUnitSecond;
+
+  if (date == nil || index < 0)
+    {
+      return NO;
+    }
+
+  field = [fields objectAtIndex: index];
+  parts = [calendar components: units fromDate: date];
+  switch ([self _unitOfField: field])
+    {
+      case NSCalendarUnitYear:
+        [parts setYear: value];
+        break;
+      case NSCalendarUnitMonth:
+        [parts setMonth: value];
+        break;
+      case NSCalendarUnitDay:
+        [parts setDay: value];
+        break;
+      case NSCalendarUnitHour:
+        if ([field characterAtIndex: 0] == 'h'
+          || [field characterAtIndex: 0] == 'K')
+          {
+            /* A twelve hour field keeps the half of the day it is in. */
+            [parts setHour: (value % 12) + (([parts hour] < 12) ? 0 : 12)];
+          }
+        else
+          {
+            [parts setHour: value];
+          }
+        break;
+      case NSCalendarUnitMinute:
+        [parts setMinute: value];
+        break;
+      case NSCalendarUnitSecond:
+        [parts setSecond: value];
+        break;
+      default:
+        return NO;
+    }
+
+  edited = [calendar dateFromComponents: parts];
+  if (edited == nil)
+    {
+      return NO;
+    }
+  [self setDateValue: edited];
+
+  return YES;
+}
+
+/* A digit joins the digits already typed into the same field while the
+   number they make can still grow.  Once it cannot, the field takes it.
+*/
+- (BOOL) _typeDigit: (NSInteger)digit
+{
+  NSArray *fields = [self _editableFields];
+  NSInteger index = [self _selectedFieldIndex];
+  NSInteger highest;
+  NSInteger value;
+
+  if (index < 0)
+    {
+      return NO;
+    }
+
+  highest = [self _highestValueOfField: [fields objectAtIndex: index]];
+  if (highest == 0)
+    {
+      return NO;
+    }
+
+  value = (_typedDigits > 0) ? (_typedValue * 10 + digit) : digit;
+  if (value > highest)
+    {
+      value = digit;
+    }
+  _typedValue = value;
+  _typedDigits++;
+
+  if (value == 0 || value * 10 <= highest)
+    {
+      /* Another digit could still follow, so wait for it. */
+      return YES;
+    }
+
+  _typedValue = 0;
+  _typedDigits = 0;
+
+  return [self _setSelectedFieldToValue: value];
+}
+
+- (BOOL) _hasMeridiemField
+{
+  NSEnumerator *fields = [[self _editableFields] objectEnumerator];
+  NSString *field;
+
+  while ((field = [fields nextObject]) != nil)
+    {
+      if ([self _unitOfField: field] == 0)
+        {
+          return YES;
+        }
+    }
+
+  return NO;
+}
+
+- (BOOL) _setMeridiemAfterNoon: (BOOL)afternoon
+{
+  NSCalendar *calendar = [self _pickerCalendar];
+  NSDate *date = [self dateValue];
+  NSDateComponents *now;
+  NSDateComponents *step;
+  NSDate *edited;
+
+  if (date == nil)
+    {
+      return NO;
+    }
+  now = [calendar components: NSCalendarUnitHour fromDate: date];
+  if (([now hour] >= 12) == afternoon)
+    {
+      return YES;
+    }
+
+  step = AUTORELEASE([[NSDateComponents alloc] init]);
+  [step setHour: afternoon ? 12 : -12];
+  edited = [calendar dateByAddingComponents: step toDate: date options: 0];
+  if (edited == nil)
+    {
+      return NO;
+    }
+  [self setDateValue: edited];
+
+  return YES;
+}
+
+/* Returns YES when the key belongs to the picker.  The caller looks at the
+   date to see whether it changed.
+*/
+- (BOOL) _handleKeyEvent: (NSEvent *)event
+{
+  NSString *characters = [event charactersIgnoringModifiers];
+  NSArray *fields;
+  unichar c;
+
+  if ([characters length] == 0)
+    {
+      return NO;
+    }
+
+  fields = [self _editableFields];
+  if ([fields count] == 0 || [self dateValue] == nil || ![self isEnabled])
+    {
+      return NO;
+    }
+
+  c = [characters characterAtIndex: 0];
+  switch (c)
+    {
+      case NSUpArrowFunctionKey:
+        return [self _stepSelectedFieldBy: 1];
+      case NSDownArrowFunctionKey:
+        return [self _stepSelectedFieldBy: -1];
+      case NSLeftArrowFunctionKey:
+        [self _setSelectedFieldIndex: [self _selectedFieldIndex] - 1];
+        return YES;
+      case NSRightArrowFunctionKey:
+        [self _setSelectedFieldIndex: [self _selectedFieldIndex] + 1];
+        return YES;
+      default:
+        break;
+    }
+
+  if (c >= '0' && c <= '9')
+    {
+      return [self _typeDigit: c - '0'];
+    }
+  if ((c == 'a' || c == 'A' || c == 'p' || c == 'P')
+    && [self _hasMeridiemField])
+    {
+      return [self _setMeridiemAfterNoon: (c == 'p' || c == 'P')];
+    }
+
+  return NO;
 }
 
 /* NSCell keeps the text its formatter made when the value was set, which is
@@ -272,6 +765,46 @@
     }
 
   return [super stringValue];
+}
+
+/* The field the user is on is shown the way selected text is, and only while
+   the picker holds the keyboard.
+*/
+- (BOOL) _showsSelectedField
+{
+  NSView *view = [self controlView];
+
+  return (view != nil && [[view window] firstResponder] == view
+    && [[view window] isKeyWindow] && [self isEnabled]);
+}
+
+- (NSAttributedString *) attributedStringValue
+{
+  NSAttributedString *text = [super attributedStringValue];
+  NSMutableAttributedString *marked;
+  NSRange range;
+
+  if (![self _showsSelectedField])
+    {
+      return text;
+    }
+
+  range = [self _rangeOfFieldAtIndex: [self _selectedFieldIndex]
+                            inString: [text string]];
+  if (range.location == NSNotFound)
+    {
+      return text;
+    }
+
+  marked = AUTORELEASE([text mutableCopy]);
+  [marked addAttribute: NSBackgroundColorAttributeName
+                 value: [NSColor selectedTextBackgroundColor]
+                 range: range];
+  [marked addAttribute: NSForegroundColorAttributeName
+                 value: [NSColor selectedTextColor]
+                 range: range];
+
+  return marked;
 }
 
 - (id) delegate

--- a/Tests/gui/NSDatePicker/display.m
+++ b/Tests/gui/NSDatePicker/display.m
@@ -30,7 +30,6 @@ has(NSString *string, NSString *part)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSDatePicker *dp;
   NSString *text;
   NSString *american;
@@ -120,6 +119,5 @@ main(int argc, char **argv)
 
   END_SET("NSDatePicker display")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDatePicker/display.m
+++ b/Tests/gui/NSDatePicker/display.m
@@ -1,0 +1,125 @@
+/* The text a date picker shows follows the elements it is configured with,
+   in the order and the form its locale writes them, and in its own time zone.
+   The assertions look for the parts of the date rather than a whole string,
+   so that they hold for the pattern any CLDR version produces.  A build
+   without ICU has no pattern generator and falls back to a fixed order, so
+   the one assertion that compares two locales is made only when the
+   generator answers.  The picker uses the theme and font backend, so the set
+   is skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSDate.h>
+#include <Foundation/NSDateFormatter.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSLocale.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSTimeZone.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSDatePicker.h>
+#include <AppKit/NSDatePickerCell.h>
+
+static BOOL
+has(NSString *string, NSString *part)
+{
+  return [string rangeOfString: part].length > 0;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSDatePicker *dp;
+  NSString *text;
+  NSString *american;
+  NSDate *date;
+  BOOL generator;
+
+  START_SET("NSDatePicker display")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      generator = ([NSDateFormatter dateFormatFromTemplate: @"yMd"
+                                                   options: 0
+                                                    locale: [NSLocale localeWithLocaleIdentifier: @"en_US"]]
+                    != nil);
+
+      /* 8 March 2023, 20:26:40 GMT. */
+      date = [NSDate dateWithTimeIntervalSinceReferenceDate: 700000000.0];
+      dp = AUTORELEASE([[NSDatePicker alloc]
+        initWithFrame: NSMakeRect(0, 0, 260, 26)]);
+      [dp setLocale: [NSLocale localeWithLocaleIdentifier: @"en_US"]];
+      [dp setTimeZone: [NSTimeZone timeZoneWithName: @"GMT"]];
+      [dp setDateValue: date];
+
+      text = [[dp cell] stringValue];
+      PASS(has(text, @"2023") && has(text, @":26:") && has(text, @"40"),
+           "the default elements show the date and the time to the second");
+      PASS(!has(text, @"+0000") && ![text isEqualToString: [date description]],
+           "the shown text is not the description of the date");
+
+      [dp setDatePickerElements: NSYearMonthDayDatePickerElementFlag];
+      text = [[dp cell] stringValue];
+      PASS(has(text, @"2023") && !has(text, @":26"),
+           "the year-month-day elements drop the time");
+
+      [dp setDatePickerElements: NSHourMinuteSecondDatePickerElementFlag];
+      text = [[dp cell] stringValue];
+      PASS(has(text, @":26:") && has(text, @"40") && !has(text, @"2023"),
+           "the hour-minute-second elements drop the date");
+
+      [dp setDatePickerElements: NSHourMinuteDatePickerElementFlag];
+      text = [[dp cell] stringValue];
+      PASS(has(text, @":26") && !has(text, @":26:"),
+           "the hour-minute elements drop the seconds");
+
+      [dp setDatePickerElements: NSYearMonthDatePickerElementFlag];
+      text = [[dp cell] stringValue];
+      PASS(has(text, @"2023") && !has(text, @":"),
+           "the year-month elements drop the day and the time");
+
+      /* The time zone the picker is set to decides the hour it shows. */
+      [dp setDatePickerElements: NSHourMinuteSecondDatePickerElementFlag];
+      text = [[dp cell] stringValue];
+      [dp setTimeZone: [NSTimeZone timeZoneForSecondsFromGMT: 3600 * 5]];
+      PASS(![[[dp cell] stringValue] isEqualToString: text],
+           "the shown time follows the time zone of the picker");
+
+      [dp setTimeZone: [NSTimeZone timeZoneWithName: @"GMT"]];
+      [dp setDatePickerElements: NSYearMonthDayDatePickerElementFlag];
+      american = [[dp cell] stringValue];
+      [dp setLocale: [NSLocale localeWithLocaleIdentifier: @"de_DE"]];
+      if (generator)
+        {
+          PASS(![[[dp cell] stringValue] isEqualToString: american],
+               "the shown date follows the locale of the picker");
+        }
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSDatePicker display")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSDatePicker/keyboard.m
+++ b/Tests/gui/NSDatePicker/keyboard.m
@@ -1,0 +1,290 @@
+/* Editing a date picker from the keyboard.  The arrow keys move between the
+   parts of the date and step the part they are on, and a digit types into
+   it.  The parts are those the locale writes, in the order it writes them,
+   which for en_US is month, day, year, hour, minute, second and the
+   morning/afternoon marker.  Every value here was checked against AppKit on
+   a macOS runner.  The picker uses the theme and font backend, so the set is
+   skipped when the backend is unavailable.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSDate.h>
+#include <Foundation/NSDateFormatter.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSLocale.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSTimeZone.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSDatePicker.h>
+#include <AppKit/NSDatePickerCell.h>
+#include <AppKit/NSEvent.h>
+
+@interface Counter : NSObject
+{
+@public
+  int actions;
+  NSDate *substitute;
+}
+@end
+
+@implementation Counter
+- (void) count: (id)sender
+{
+  actions++;
+}
+- (void) datePickerCell: (NSDatePickerCell *)cell
+validateProposedDateValue: (NSDate **)proposed
+           timeInterval: (NSTimeInterval *)interval
+{
+  if (substitute != nil)
+    {
+      *proposed = substitute;
+    }
+}
+@end
+
+static NSDateFormatter *fmt = nil;
+
+static NSDatePicker *
+picker(NSDatePickerElementFlags elements, NSString *when)
+{
+  NSDatePicker *dp = AUTORELEASE([[NSDatePicker alloc]
+    initWithFrame: NSMakeRect(0, 0, 260, 26)]);
+
+  [dp setLocale: [NSLocale localeWithLocaleIdentifier: @"en_US"]];
+  [dp setTimeZone: [NSTimeZone timeZoneWithName: @"GMT"]];
+  [dp setDatePickerElements: elements];
+  [dp setDateValue: [fmt dateFromString: when]];
+  return dp;
+}
+
+static void
+type(NSDatePicker *dp, NSString *characters)
+{
+  [dp keyDown: [NSEvent keyEventWithType: NSKeyDown
+                                location: NSZeroPoint
+                           modifierFlags: 0
+                               timestamp: 0
+                            windowNumber: 0
+                                 context: nil
+                              characters: characters
+             charactersIgnoringModifiers: characters
+                               isARepeat: NO
+                                 keyCode: 0]];
+}
+
+static void
+key(NSDatePicker *dp, unichar c)
+{
+  type(dp, [NSString stringWithCharacters: &c length: 1]);
+}
+
+static void
+keys(NSDatePicker *dp, unichar c, int times)
+{
+  int i;
+
+  for (i = 0; i < times; i++)
+    {
+      key(dp, c);
+    }
+}
+
+static NSString *
+value(NSDatePicker *dp)
+{
+  return [fmt stringFromDate: [dp dateValue]];
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSDatePicker *dp;
+  NSDatePickerElementFlags all;
+  BOOL generator;
+
+  START_SET("NSDatePicker keyboard")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      fmt = [[NSDateFormatter alloc] init];
+      [fmt setDateFormat: @"yyyy-MM-dd HH:mm:ss"];
+      [fmt setTimeZone: [NSTimeZone timeZoneWithName: @"GMT"]];
+      [fmt setLocale: [NSLocale localeWithLocaleIdentifier: @"en_US_POSIX"]];
+
+      generator = ([NSDateFormatter dateFormatFromTemplate: @"yMd"
+                                                   options: 0
+                                                    locale: [NSLocale localeWithLocaleIdentifier: @"en_US"]]
+                    != nil);
+      all = NSYearMonthDayDatePickerElementFlag
+        | NSHourMinuteSecondDatePickerElementFlag;
+
+      /* The up arrow steps the part the picker is on, starting at the first
+         part the locale writes. */
+      dp = picker(all, @"2023-03-08 20:26:40");
+      key(dp, NSUpArrowFunctionKey);
+      PASS_EQUAL(value(dp), @"2023-04-08 20:26:40",
+                 "the up arrow steps the first part of the date");
+      key(dp, NSDownArrowFunctionKey);
+      PASS_EQUAL(value(dp), @"2023-03-08 20:26:40",
+                 "the down arrow steps it back");
+
+      if (generator)
+        {
+          dp = picker(all, @"2023-03-08 20:26:40");
+          keys(dp, NSRightArrowFunctionKey, 1);
+          key(dp, NSUpArrowFunctionKey);
+          PASS_EQUAL(value(dp), @"2023-03-09 20:26:40",
+                     "the second part of an American date is the day");
+
+          dp = picker(all, @"2023-03-08 20:26:40");
+          keys(dp, NSRightArrowFunctionKey, 2);
+          key(dp, NSUpArrowFunctionKey);
+          PASS_EQUAL(value(dp), @"2024-03-08 20:26:40",
+                     "the third part is the year");
+
+          dp = picker(all, @"2023-03-08 20:26:40");
+          keys(dp, NSRightArrowFunctionKey, 3);
+          key(dp, NSUpArrowFunctionKey);
+          PASS_EQUAL(value(dp), @"2023-03-08 21:26:40",
+                     "the fourth part is the hour");
+
+          dp = picker(all, @"2023-03-08 20:26:40");
+          keys(dp, NSRightArrowFunctionKey, 4);
+          key(dp, NSUpArrowFunctionKey);
+          PASS_EQUAL(value(dp), @"2023-03-08 20:27:40",
+                     "the fifth part is the minute");
+
+          dp = picker(all, @"2023-03-08 20:26:40");
+          keys(dp, NSRightArrowFunctionKey, 5);
+          key(dp, NSUpArrowFunctionKey);
+          PASS_EQUAL(value(dp), @"2023-03-08 20:26:41",
+                     "the sixth part is the second");
+
+          dp = picker(all, @"2023-03-08 20:26:40");
+          keys(dp, NSRightArrowFunctionKey, 6);
+          key(dp, NSUpArrowFunctionKey);
+          PASS_EQUAL(value(dp), @"2023-03-08 08:26:40",
+                     "the seventh part of an American time is the marker");
+
+          dp = picker(all, @"2023-03-08 20:26:40");
+          keys(dp, NSRightArrowFunctionKey, 7);
+          key(dp, NSUpArrowFunctionKey);
+          PASS_EQUAL(value(dp), @"2023-04-08 20:26:40",
+                     "moving past the last part comes back to the first");
+
+          dp = picker(all, @"2023-03-08 20:26:40");
+          key(dp, NSLeftArrowFunctionKey);
+          key(dp, NSUpArrowFunctionKey);
+          PASS_EQUAL(value(dp), @"2023-03-08 08:26:40",
+                     "moving left from the first part goes to the last");
+
+          dp = picker(NSYearMonthDayDatePickerElementFlag,
+                      @"2023-03-08 20:26:40");
+          [dp setLocale: [NSLocale localeWithLocaleIdentifier: @"de_DE"]];
+          key(dp, NSUpArrowFunctionKey);
+          PASS_EQUAL(value(dp), @"2023-03-09 20:26:40",
+                     "the first part of a German date is the day");
+        }
+
+      /* A step is a step of the calendar, so it carries. */
+      dp = picker(all, @"2023-12-08 20:26:40");
+      key(dp, NSUpArrowFunctionKey);
+      PASS_EQUAL(value(dp), @"2024-01-08 20:26:40",
+                 "a step past December carries into the year");
+
+      dp = picker(all, @"2023-01-08 20:26:40");
+      key(dp, NSDownArrowFunctionKey);
+      PASS_EQUAL(value(dp), @"2022-12-08 20:26:40",
+                 "a step before January carries into the year");
+
+      dp = picker(all, @"2023-03-31 20:26:40");
+      key(dp, NSUpArrowFunctionKey);
+      PASS_EQUAL(value(dp), @"2023-04-30 20:26:40",
+                 "a day the next month is too short for moves to its last day");
+
+      /* Typing digits. */
+      dp = picker(all, @"2023-03-08 20:26:40");
+      type(dp, @"5");
+      PASS_EQUAL(value(dp), @"2023-05-08 20:26:40",
+                 "a digit no second digit can follow is taken on its own");
+
+      dp = picker(all, @"2023-03-08 20:26:40");
+      type(dp, @"1");
+      PASS_EQUAL(value(dp), @"2023-03-08 20:26:40",
+                 "a digit a second digit could follow waits for it");
+      type(dp, @"2");
+      PASS_EQUAL(value(dp), @"2023-12-08 20:26:40",
+                 "the second digit completes the month");
+
+      dp = picker(all, @"2023-03-08 20:26:40");
+      type(dp, @"0");
+      PASS_EQUAL(value(dp), @"2023-03-08 20:26:40",
+                 "a leading zero leaves the date alone");
+
+      /* The date limits hold for an edit from the keyboard. */
+      dp = picker(all, @"2023-03-08 20:26:40");
+      [dp setMaxDate: [fmt dateFromString: @"2023-03-20 00:00:00"]];
+      key(dp, NSUpArrowFunctionKey);
+      PASS_EQUAL(value(dp), @"2023-03-20 00:00:00",
+                 "a step beyond the maximum date stops at it");
+
+      dp = picker(all, @"2023-03-08 20:26:40");
+      [dp setMinDate: [fmt dateFromString: @"2023-03-01 00:00:00"]];
+      key(dp, NSDownArrowFunctionKey);
+      PASS_EQUAL(value(dp), @"2023-03-01 00:00:00",
+                 "a step before the minimum date stops at it");
+
+      /* The action goes out for an edit, and not for a date set in code. */
+      {
+        Counter *counter = AUTORELEASE([[Counter alloc] init]);
+
+        dp = picker(all, @"2023-03-08 20:26:40");
+        [dp setTarget: counter];
+        [dp setAction: @selector(count:)];
+        [dp setDateValue: [fmt dateFromString: @"2023-05-08 20:26:40"]];
+        PASS(counter->actions == 0,
+             "setting the date in code sends no action");
+        key(dp, NSUpArrowFunctionKey);
+        PASS(counter->actions == 1, "an edit sends the action once");
+        type(dp, @"q");
+        PASS(counter->actions == 1,
+             "a key that means nothing to the picker sends no action");
+
+        /* The delegate has the last word on the value. */
+        [dp setDelegate: counter];
+        counter->substitute = [fmt dateFromString: @"1999-09-09 09:09:09"];
+        key(dp, NSUpArrowFunctionKey);
+        PASS_EQUAL(value(dp), @"1999-09-09 09:09:09",
+                   "the delegate can put another date in place of the edit");
+      }
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSDatePicker keyboard")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSDatePicker/keyboard.m
+++ b/Tests/gui/NSDatePicker/keyboard.m
@@ -101,7 +101,6 @@ value(NSDatePicker *dp)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSDatePicker *dp;
   NSDatePickerElementFlags all;
   BOOL generator;
@@ -285,6 +284,5 @@ main(int argc, char **argv)
 
   END_SET("NSDatePicker keyboard")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDatePicker/selection.m
+++ b/Tests/gui/NSDatePicker/selection.m
@@ -1,0 +1,156 @@
+/* While a date picker holds the keyboard it shows the part of the date the
+   arrow keys act on the way selected text is shown, and the marking follows
+   the arrow keys.  The picker has to be in a key window for that, so the set
+   needs a display.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSAttributedString.h>
+#include <Foundation/NSDate.h>
+#include <Foundation/NSDateFormatter.h>
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSLocale.h>
+#include <Foundation/NSRange.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSTimeZone.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSAttributedString.h>
+#include <AppKit/NSDatePicker.h>
+#include <AppKit/NSDatePickerCell.h>
+#include <AppKit/NSEvent.h>
+#include <AppKit/NSWindow.h>
+
+static void
+key(NSDatePicker *dp, unichar c)
+{
+  NSString *characters = [NSString stringWithCharacters: &c length: 1];
+
+  [dp keyDown: [NSEvent keyEventWithType: NSKeyDown
+                                location: NSZeroPoint
+                           modifierFlags: 0
+                               timestamp: 0
+                            windowNumber: 0
+                                 context: nil
+                              characters: characters
+             charactersIgnoringModifiers: characters
+                               isARepeat: NO
+                                 keyCode: 0]];
+}
+
+/* The range the cell marks as selected, or a range of length zero. */
+static NSRange
+marked(NSDatePicker *dp)
+{
+  NSAttributedString *text = [[dp cell] attributedStringValue];
+  NSRange range = NSMakeRange(0, 0);
+
+  if ([text length] > 0)
+    {
+      NSUInteger index;
+
+      for (index = 0; index < [text length]; index++)
+        {
+          if ([text attribute: NSBackgroundColorAttributeName
+                      atIndex: index
+               effectiveRange: NULL] != nil)
+            {
+              NSUInteger end = index;
+
+              while (end < [text length]
+                && [text attribute: NSBackgroundColorAttributeName
+                           atIndex: end
+                    effectiveRange: NULL] != nil)
+                {
+                  end++;
+                }
+              range = NSMakeRange(index, end - index);
+              break;
+            }
+        }
+    }
+
+  return range;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSWindow *window;
+  NSDatePicker *dp;
+  NSString *text;
+  NSRange range;
+
+  START_SET("NSDatePicker selection")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      window = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 300, 60)
+                  styleMask: NSWindowStyleMaskTitled
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      dp = AUTORELEASE([[NSDatePicker alloc]
+        initWithFrame: NSMakeRect(10, 10, 260, 26)]);
+      [dp setLocale: [NSLocale localeWithLocaleIdentifier: @"en_US"]];
+      [dp setTimeZone: [NSTimeZone timeZoneWithName: @"GMT"]];
+      [dp setDatePickerElements: NSYearMonthDayDatePickerElementFlag];
+      [dp setDateValue: [NSDate dateWithTimeIntervalSinceReferenceDate:
+        700000000.0]];
+      [[window contentView] addSubview: dp];
+
+      PASS(marked(dp).length == 0,
+           "a picker outside a key window marks nothing");
+
+      [window makeKeyAndOrderFront: nil];
+      [window makeFirstResponder: dp];
+      if (![window isKeyWindow] || [window firstResponder] != dp)
+        {
+          SKIP("The window did not take the keyboard")
+        }
+
+      text = [[dp cell] stringValue];
+      range = marked(dp);
+      PASS(range.length > 0 && NSMaxRange(range) <= [text length],
+           "the picker marks the part the arrow keys act on");
+      PASS_EQUAL([text substringWithRange: range], @"3",
+                 "the marked part of an American date is the month");
+
+      key(dp, NSRightArrowFunctionKey);
+      range = marked(dp);
+      PASS_EQUAL([text substringWithRange: range], @"8",
+                 "the right arrow marks the day");
+
+      key(dp, NSRightArrowFunctionKey);
+      range = marked(dp);
+      PASS_EQUAL([text substringWithRange: range], @"2023",
+                 "another right arrow marks the year");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSDatePicker selection")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/gui/NSDatePicker/selection.m
+++ b/Tests/gui/NSDatePicker/selection.m
@@ -77,7 +77,6 @@ marked(NSDatePicker *dp)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSWindow *window;
   NSDatePicker *dp;
   NSString *text;
@@ -151,6 +150,5 @@ main(int argc, char **argv)
 
   END_SET("NSDatePicker selection")
 
-  DESTROY(arp);
   return 0;
 }


### PR DESCRIPTION
A date picker took no keys at all, so the date it held could only be changed in code.

The pattern the cell shows is split into the parts the locale writes. The left and right arrow keys move between those parts, the up and down arrow keys step the part they are on, and a digit types into it. A step is a step of the calendar, so it carries into the parts above it, a day the next month is too short for moves back to that month's last day, and the result stays inside the minimum and maximum dates. The part being edited is drawn the way selected text is while the picker holds the keyboard. An edit sends the action of the control, and the delegate is asked to validate the proposed date. The values are those AppKit produces for the same keys.

NSDatePickerCell holds three more ivars. Clicking a part, the stepper, and the clock and calendar style are not part of this. The branch is cut off #858 and needs it.

Tests/gui/NSDatePicker/keyboard.m and selection.m: 24 assertions fail before the change and 0 after, 77 green across the two picker directories.

Refers to #95
