### PR TITLE
Fix: clear the display mark on a view with no area

### DIFF
--- a/Source/NSView.m
+++ b/Source/NSView.m
@@ -2601,6 +2601,16 @@ static void autoresize(CGFloat oldContainerSize,
                       isect = [subview convertRect: isect fromView: self];
                       [subview displayIfNeededInRectIgnoringOpacity: isect];
                     }
+                  else if (NSIsEmptyRect(subviewFrame))
+                    {
+                      /* A subview with no area has nothing to draw, and is
+                         never reached by the line above, so it would keep
+                         itself and every view over it waiting for a display
+                         that cannot happen.  Let it settle its own flag.
+                      */
+                      [subview displayIfNeededInRectIgnoringOpacity:
+                        NSZeroRect];
+                    }
 
                   if (subview->_rFlags.needs_display)
                     {
@@ -2727,6 +2737,17 @@ static void autoresize(CGFloat oldContainerSize,
                 {
                   isect = [subview convertRect: isect fromView: self];
                   [subview displayRectIgnoringOpacity: isect
+                                            inContext: context];
+                }
+              else if (NSIsEmptyRect(subviewFrame)
+                && subview->_rFlags.needs_display == YES)
+                {
+                  /* A subview with no area has nothing to draw and is never
+                     reached by the line above, so it would keep itself and
+                     every view over it waiting for a display that cannot
+                     happen.  Let it settle its own flag.
+                  */
+                  [subview displayRectIgnoringOpacity: NSZeroRect
                                             inContext: context];
                 }
               /*

--- a/Tests/gui/NSView/emptyViewNeedsDisplay.m
+++ b/Tests/gui/NSView/emptyViewNeedsDisplay.m
@@ -18,7 +18,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSWindow *window;
   NSView *content;
   NSView *flat;
@@ -98,6 +97,5 @@ main(int argc, char **argv)
 
   END_SET("NSView empty view needs display")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSView/emptyViewNeedsDisplay.m
+++ b/Tests/gui/NSView/emptyViewNeedsDisplay.m
@@ -1,0 +1,103 @@
+/* A view with no area cannot draw anything.  Marking it for display and
+   then displaying the window has to leave it, and every view above it,
+   clear again; otherwise nothing in that branch of the tree ever reports
+   itself as drawn.  A view that has an area but falls outside the rectangle
+   being displayed is a different matter and keeps its mark.  Drawing needs
+   the backend, so the set is skipped without one.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSGeometry.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSBox.h>
+#include <AppKit/NSView.h>
+#include <AppKit/NSWindow.h>
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+  NSWindow *window;
+  NSView *content;
+  NSView *flat;
+  NSView *aside;
+  NSBox *box;
+
+  START_SET("NSView empty view needs display")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+        SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  NS_DURING
+    {
+      window = AUTORELEASE([[NSWindow alloc]
+        initWithContentRect: NSMakeRect(0, 0, 200, 200)
+                  styleMask: NSWindowStyleMaskBorderless
+                    backing: NSBackingStoreBuffered
+                      defer: NO]);
+      content = [window contentView];
+
+      flat = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(10, 10, 100, 0)]);
+      [content addSubview: flat];
+      [flat setNeedsDisplay: YES];
+      [window orderFront: nil];
+      [window display];
+
+      PASS([flat needsDisplay] == NO,
+           "a view with no area does not wait for a display");
+      PASS([content needsDisplay] == NO,
+           "the view holding it does not wait either");
+      PASS([window viewsNeedDisplay] == NO,
+           "the window has nothing left to display");
+
+      /* A box two pixels high gives its content view no room at all, which
+         is how this turns up in a real window. */
+      box = AUTORELEASE([[NSBox alloc]
+        initWithFrame: NSMakeRect(10, 100, 180, 2)]);
+      [box setTitlePosition: NSNoTitle];
+      [content addSubview: box];
+      [window display];
+
+      PASS([[box contentView] needsDisplay] == NO,
+           "the content view of a box too short for it is not left waiting");
+      PASS([box needsDisplay] == NO, "nor is the box");
+      PASS([content needsDisplay] == NO, "nor is the view holding the box");
+
+      /* A view with an area that the displayed rectangle does not reach
+         keeps its mark, since it still has something to draw. */
+      aside = AUTORELEASE([[NSView alloc]
+        initWithFrame: NSMakeRect(150, 150, 20, 20)]);
+      [content addSubview: aside];
+      [window display];
+      [aside setNeedsDisplay: YES];
+      [content displayIfNeededInRect: NSMakeRect(0, 0, 40, 40)];
+
+      PASS([aside needsDisplay] == YES,
+           "a view outside the rectangle being displayed still waits");
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+        || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+        SKIP("No display available")
+      else
+        [localException raise];
+    }
+  NS_ENDHANDLER
+
+  END_SET("NSView empty view needs display")
+
+  DESTROY(arp);
+  return 0;
+}


### PR DESCRIPTION
Both of NSView's display walks reach a subview only when the rectangle being displayed and the subview's frame overlap. A subview with no width or height never overlaps anything, so it is never displayed, its mark is never cleared, and both walks copy that mark up to every view above it. An NSBox two pixels high is enough: it leaves its content view a height of zero, and from then on that view, the box, the window's content view and the frame view all answer YES to -needsDisplay for good.

When the overlap is empty because the subview has no area, it is now asked to display an empty rectangle, which clears its mark. A subview that has an area and merely falls outside the rectangle keeps its mark, and there is an assertion for that.

This turned up in the alert panel of #80, whose separator is such a box. The symptom reported there, contents invisible until the panel is moved, does not reproduce on Windows against current master, whether the alert is raised before the application loop starts or from inside a running one. This mark is the only defect found on that path.

Tests/gui/NSView/emptyViewNeedsDisplay.m: 5 of its 7 assertions fail before the change and none after. Tests/gui runs 4345 assertions green.

Closes #80
