### PR TITLE
Fix: give a xib appearance font element the system font

### DIFF
--- a/Source/GSXib5KeyedUnarchiver.m
+++ b/Source/GSXib5KeyedUnarchiver.m
@@ -1522,6 +1522,8 @@ didStartElement: (NSString*)elementName
         size = [NSFont smallSystemFontSize];
       else if (metaFont)
         NSWarnMLog(@"unknown meta font value: %@", metaFont);
+      else if ([[attributes objectForKey: @"usesAppearanceFont"] boolValue])
+        size = [NSFont systemFontSize];
     }
 
   return [NSNumber numberWithFloat: size];
@@ -3576,7 +3578,15 @@ didStartElement: (NSString*)elementName
   if (hasValue == NO)
     {
       // Try reinterpreting the request...
-      if ([XmlKeyMapTable objectForKey: key])
+      if ([@"IBIsSystemFont" isEqualToString: key])
+        {
+          // A font element left on the appearance font carries no metaFont,
+          // and the appearance font is the system font.
+          hasValue  = [currentElement attributeForKey: @"metaFont"] != nil;
+          hasValue |= [[currentElement attributeForKey: @"usesAppearanceFont"]
+                        boolValue];
+        }
+      else if ([XmlKeyMapTable objectForKey: key])
         {
           hasValue = [self containsValueForKey: [XmlKeyMapTable objectForKey: key]];
         }

--- a/Tests/gui/GSXib5KeyedUnarchiver/AppearanceFont.xib
+++ b/Tests/gui/GSXib5KeyedUnarchiver/AppearanceFont.xib
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication"/>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+
+        <!-- Interface Builder writes this for a control left on the standard
+             appearance font: no name and no metaFont. -->
+        <textField id="appearance">
+            <rect key="frame" x="18" y="110" width="320" height="17"/>
+            <textFieldCell key="cell" lineBreakMode="clipping" title="APPEARANCE" id="appearance-cell">
+                <font key="font" usesAppearanceFont="YES"/>
+            </textFieldCell>
+        </textField>
+
+        <textField id="metasystem">
+            <rect key="frame" x="18" y="80" width="320" height="17"/>
+            <textFieldCell key="cell" lineBreakMode="clipping" title="METASYSTEM" id="metasystem-cell">
+                <font key="font" metaFont="system"/>
+            </textFieldCell>
+        </textField>
+
+        <textField id="nofont">
+            <rect key="frame" x="18" y="50" width="320" height="17"/>
+            <textFieldCell key="cell" lineBreakMode="clipping" title="NOFONT" id="nofont-cell"/>
+        </textField>
+    </objects>
+</document>

--- a/Tests/gui/GSXib5KeyedUnarchiver/appearanceFont.m
+++ b/Tests/gui/GSXib5KeyedUnarchiver/appearanceFont.m
@@ -1,0 +1,105 @@
+/* A xib font element that carries neither a name nor a metaFont, which is what
+ * Interface Builder writes for a control left on the standard appearance font,
+ * has to give the system font at the system font size. AppKit gives such a
+ * cell the same font as one written metaFont="system", while a cell with no
+ * font element at all keeps NSCell's own default instead.
+ *
+ * The system font size is moved off its default here so that the size the
+ * element resolves to is distinguishable.
+ */
+#import "ObjectTesting.h"
+
+#import <Foundation/NSData.h>
+#import <Foundation/NSUserDefaults.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSCell.h>
+#import <AppKit/NSFont.h>
+#import <AppKit/NSTextField.h>
+#import <Additions/GNUstepGUI/GSXibKeyedUnarchiver.h>
+
+static NSCell *
+cellTitled(NSArray *objects, NSString *title)
+{
+  NSEnumerator *enumerator = [objects objectEnumerator];
+  id element;
+
+  while ((element = [enumerator nextObject]) != nil)
+    {
+      if ([element isKindOfClass: [NSTextField class]]
+          && [[[element cell] title] isEqualToString: title])
+        {
+          return [element cell];
+        }
+    }
+  return nil;
+}
+
+int main()
+{
+  START_SET("GSXib5KeyedUnarchiver appearance font tests")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name]
+	isEqualToString: NSInternalInconsistencyException ])
+	{
+	  SKIP("It looks like GNUstep backend is not yet installed")
+	}
+    }
+  NS_ENDHANDLER
+
+  NSData	*data;
+  id		unarchiver;
+  NSArray	*rootObjects;
+  NSCell	*appearance;
+  NSCell	*metaSystem;
+  NSCell	*noFont;
+  NSFont	*systemFont;
+
+  [[NSUserDefaults standardUserDefaults] setObject: @"16"
+					   forKey: @"NSFontSize"];
+  PASS([NSFont systemFontSize] == 16.0,
+    "the system font size is moved off its default for the test")
+
+  data = [NSData dataWithContentsOfFile: @"AppearanceFont.xib"];
+  unarchiver = [GSXibKeyedUnarchiver unarchiverForReadingWithData: data];
+  rootObjects = [unarchiver decodeObjectForKey: @"IBDocument.RootObjects"];
+
+  appearance = cellTitled(rootObjects, @"APPEARANCE");
+  metaSystem = cellTitled(rootObjects, @"METASYSTEM");
+  noFont = cellTitled(rootObjects, @"NOFONT");
+
+  PASS(appearance != nil && metaSystem != nil && noFont != nil,
+    "the three text field cells were decoded")
+
+  systemFont = [NSFont systemFontOfSize: [NSFont systemFontSize]];
+
+  /* The element resolves to a font at all. */
+  PASS([appearance font] != nil, "the appearance font element gives a font")
+
+  /* And it is the system font, at the system font size. */
+  PASS_EQUAL([[appearance font] fontName], [systemFont fontName],
+    "the appearance font element gives the system font")
+  PASS([[appearance font] pointSize] == [NSFont systemFontSize],
+    "the appearance font element gives the system font size")
+
+  /* Which is what metaFont=\"system\" gives, as on AppKit. */
+  PASS_EQUAL([[appearance font] fontName], [[metaSystem font] fontName],
+    "the appearance font matches a metaFont system font")
+  PASS([[appearance font] pointSize] == [[metaSystem font] pointSize],
+    "the appearance font size matches a metaFont system font")
+
+  /* A cell with no font element is a different case and keeps its own
+     default, so the two must not be collapsed. */
+  PASS([noFont font] != nil, "a cell with no font element still has a font")
+
+  [[NSUserDefaults standardUserDefaults] removeObjectForKey: @"NSFontSize"];
+
+  END_SET("GSXib5KeyedUnarchiver appearance font tests")
+
+  return 0;
+}


### PR DESCRIPTION
Interface Builder writes `<font key="font" usesAppearanceFont="YES"/>` for a control left on the standard appearance font. Such an element carries neither a name nor a metaFont, so NSName decodes nil and IBIsSystemFont is absent, and -[NSFont initWithCoder:] therefore evaluates [NSFont fontWithName: nil size: 12]. Where that lookup fails the cell recovers through NSFont's own fallback, so on a freetype build nothing is visibly wrong. Where it succeeds the cell keeps a font with no name: on Windows with the win32 graphics such a label reports advance 11.00 for M where the system font reports 10.00, and a string that should be 99 points wide measures 104.

The element now reports a system font at the system font size. On a macOS 26 runner a cell written that way gets the system font at systemFontSize, property for property the same font as one written metaFont="system", while a cell with no font element at all keeps Helvetica 12 instead, so the two cases stay distinct.

Tests/gui/GSXib5KeyedUnarchiver/appearanceFont.m, which moves the system font size off its default so the size is distinguishable. Two of its assertions fail before the change and none after. Tests/gui runs 4361 assertions green.

Refers to #77
