### PR TITLE
Fix: use the exception macros instead of hand written handlers in tests. (Part 1)

### DIFF
--- a/Tests/gui/NSNibConnector/basic.m
+++ b/Tests/gui/NSNibConnector/basic.m
@@ -11,8 +11,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("a new connector")
     NSNibConnector	*connector;
 
@@ -99,16 +97,9 @@ main(int argc, char **argv)
 
   START_SET("establishing a connection")
     NSNibConnector	*connector;
-    BOOL		raised;
 
     connector = AUTORELEASE([[NSNibConnector alloc] init]);
-    raised = NO;
-    NS_DURING
-      [connector establishConnection];
-    NS_HANDLER
-      raised = YES;
-    NS_ENDHANDLER
-    PASS(raised == NO,
+    PASS_RUNS([connector establishConnection],
       "establishing a connection with nothing to join does not raise");
   END_SET("establishing a connection")
 
@@ -133,6 +124,5 @@ main(int argc, char **argv)
       "the archived connector keeps its label");
   END_SET("archiving")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPrinter/badPPD.m
+++ b/Tests/gui/NSPrinter/badPPD.m
@@ -16,8 +16,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSPrinter missing PPD")
 
   NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
@@ -25,7 +23,6 @@ main(int argc, char **argv)
   NSDictionary *entry;
   NSDictionary *printers;
   NSPrinter *printer = nil;
-  BOOL raised = NO;
 
   entry = [NSDictionary dictionaryWithObjectsAndKeys:
     @"/does/not/exist/Generic.ppd", @"PPDPath",
@@ -36,18 +33,9 @@ main(int argc, char **argv)
   printers = [NSDictionary dictionaryWithObject: entry forKey: @"MissingPPDPrinter"];
   [ud setObject: printers forKey: @"GSLPRPrinters"];
 
-  NS_DURING
-    {
-      printer = [NSPrinter printerWithName: @"MissingPPDPrinter"];
-    }
-  NS_HANDLER
-    {
-      raised = YES;
-    }
-  NS_ENDHANDLER
-
-  PASS(raised == NO,
-       "loading a printer whose PPD is missing does not raise");
+  PASS_RUNS(({
+    printer = [NSPrinter printerWithName: @"MissingPPDPrinter"];
+  }), "loading a printer whose PPD is missing does not raise");
   PASS(printer != nil,
        "a printer is still returned when its PPD is missing");
 
@@ -58,6 +46,5 @@ main(int argc, char **argv)
 
   END_SET("NSPrinter missing PPD")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextAlternatives/nilPrimaryString.m
+++ b/Tests/gui/NSTextAlternatives/nilPrimaryString.m
@@ -9,42 +9,29 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("a nil primary string")
     NSArray		*alternatives;
     NSTextAlternatives	*alt;
-    BOOL		raised;
 
     alternatives = [NSArray arrayWithObject: @"color"];
 
-    raised = NO;
-    NS_DURING
-      alt = AUTORELEASE([[NSTextAlternatives alloc]
+    PASS_EXCEPTION(({
+      AUTORELEASE([[NSTextAlternatives alloc]
         initWithPrimaryString: nil
            alternativeStrings: alternatives]);
-    NS_HANDLER
-      raised = [[localException name]
-        isEqualToString: NSInvalidArgumentException];
-    NS_ENDHANDLER
-    PASS(raised == YES,
+    }), NSInvalidArgumentException,
       "a nil primary string raises NSInvalidArgumentException");
 
     /* A primary string with no alternatives is still a usable object. */
-    raised = NO;
     alt = nil;
-    NS_DURING
+    PASS_RUNS(({
       alt = AUTORELEASE([[NSTextAlternatives alloc]
         initWithPrimaryString: @"colour"
            alternativeStrings: nil]);
-    NS_HANDLER
-      raised = YES;
-    NS_ENDHANDLER
-    PASS(raised == NO, "a nil alternative strings array does not raise");
+    }), "a nil alternative strings array does not raise");
     PASS([[alt primaryString] isEqualToString: @"colour"],
       "the primary string reads back when there are no alternatives");
   END_SET("a nil primary string")
 
-  DESTROY(arp);
   return 0;
 }


### PR DESCRIPTION
Three test files wrap code in their own NS_DURING handler and set a BOOL to report whether it raised, then check that BOOL with PASS. That is longer than it needs to be, and where a raise is expected it says nothing about which exception arrived.

PASS_EXCEPTION does both in one line: it fails if the code does not raise, and fails if the name is not the one given. PASS_RUNS covers the three places that must not raise. The outer autorelease pool in each file goes with it, since START_SET already creates a pool and END_SET releases it.

Nothing is being tested differently. These are the same assertions written with the macros the test framework already provides, so the files get shorter rather than stricter, apart from the one raise that now has its name checked.

Run gnustep-tests on NSNibConnector, NSPrinter and NSTextAlternatives from Tests/gui. Forty four assertions pass before the change and forty four after.

PASS_EXCEPTION was checked against a deliberately wrong exception name to confirm it is not passing vacuously; it reports "Expected 'NSRangeException' and got 'NSInvalidArgumentException'".
