### PR TITLE
Fix: use the exception macros instead of hand written handlers in tests. (Part 2)

### DIFF
--- a/Tests/gui/GSCodingFlags/GSCellFlags.m
+++ b/Tests/gui/GSCodingFlags/GSCellFlags.m
@@ -7,7 +7,6 @@
 
 int main()
 {
-    CREATE_AUTORELEASE_POOL(arp);
     GSCellFlagsUnion mask = { { 0 } };
 
     START_SET("GSCodingFlags GNUstep CellFlags Union")
@@ -40,6 +39,5 @@ int main()
     
     END_SET("GSCodingFlags GNUstep CellFlags Union")
 
-    DESTROY(arp);
     return 0;
 }

--- a/Tests/gui/GSHorizontalTypesetter/longRun.m
+++ b/Tests/gui/GSHorizontalTypesetter/longRun.m
@@ -22,8 +22,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("GSHorizontalTypesetter longRun")
 
   NS_DURING
@@ -82,6 +80,5 @@ main(int argc, char **argv)
 
   END_SET("GSHorizontalTypesetter longRun")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/GSHorizontalTypesetter/paragraphSpacing.m
+++ b/Tests/gui/GSHorizontalTypesetter/paragraphSpacing.m
@@ -51,8 +51,6 @@ secondParagraphY(CGFloat spacing)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("GSHorizontalTypesetter paragraphSpacing")
 
   NS_DURING
@@ -88,6 +86,5 @@ main(int argc, char **argv)
 
   END_SET("GSHorizontalTypesetter paragraphSpacing")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/GSWindowDecorationView/menuPosition.m
+++ b/Tests/gui/GSWindowDecorationView/menuPosition.m
@@ -37,7 +37,6 @@ contentRectOf(GSWindowDecorationView *wv, NSUInteger style)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("GSWindowDecorationView menu position")
 
   NS_DURING
@@ -85,6 +84,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("GSWindowDecorationView menu position")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSActionCell/basic.m
+++ b/Tests/gui/NSActionCell/basic.m
@@ -10,8 +10,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSActionCell basic")
 
   NS_DURING
@@ -62,6 +60,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSActionCell basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAffineTransform/basic.m
+++ b/Tests/gui/NSAffineTransform/basic.m
@@ -12,8 +12,6 @@
 
 int main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   /* Use a symbol from the GUI library to force the linker to link it and include the
    * categories for NSAffineTransform.
    */
@@ -134,6 +132,5 @@ int main(int argc, char **argv)
       "takeMatrixFromTransform: copies another transform");
   END_SET("makeIdentityMatrix and takeMatrixFromTransform")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAlert/contract.m
+++ b/Tests/gui/NSAlert/contract.m
@@ -18,7 +18,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSAlert *a;
 
   START_SET("NSAlert contract")
@@ -81,6 +80,5 @@ main(int argc, const char **argv)
 
   END_SET("NSAlert contract")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAppearance/accessibilityNames.m
+++ b/Tests/gui/NSAppearance/accessibilityNames.m
@@ -8,8 +8,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("the accessibility appearance names")
     PASS([NSAppearanceNameAccessibilityHighContrastAqua
       isEqualToString: @"NSAppearanceNameAccessibilityAqua"],
@@ -33,6 +31,5 @@ main(int argc, char **argv)
       "the vibrant light name is unchanged");
   END_SET("the other appearance names are unchanged")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAppearance/appearanceNamedOwnership.m
+++ b/Tests/gui/NSAppearance/appearanceNamedOwnership.m
@@ -9,8 +9,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("appearanceNamed: ownership")
     NSAutoreleasePool	*pool;
     NSAppearance	*appearance;
@@ -38,6 +36,5 @@ main(int argc, char **argv)
       "the appearance keeps its name");
   END_SET("appearanceNamed: still works")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAppearance/basic.m
+++ b/Tests/gui/NSAppearance/basic.m
@@ -10,8 +10,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("the appearance names")
     PASS([NSAppearanceNameAqua isEqualToString: @"NSAppearanceNameAqua"],
       "the aqua appearance name is the documented one");
@@ -65,6 +63,5 @@ main(int argc, char **argv)
       "the current appearance reads back");
   END_SET("the current appearance")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAppearance/bestMatch.m
+++ b/Tests/gui/NSAppearance/bestMatch.m
@@ -9,8 +9,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("an exact name wins")
     NSAppearance	*aqua;
     NSAppearance	*dark;
@@ -87,6 +85,5 @@ main(int argc, char **argv)
       "one vibrant appearance does not match the other");
   END_SET("no match")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAppearance/coding.m
+++ b/Tests/gui/NSAppearance/coding.m
@@ -8,8 +8,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("keyed coding")
     NSAppearance	*appearance;
     NSAppearance	*decoded;
@@ -38,6 +36,5 @@ main(int argc, char **argv)
       "the old style archived appearance keeps its name");
   END_SET("old style coding")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAppearance/currentAppearance.m
+++ b/Tests/gui/NSAppearance/currentAppearance.m
@@ -9,8 +9,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   /* This has to come before anything sets the current appearance. */
   START_SET("before anything sets one")
     NSAppearance	*current;
@@ -33,6 +31,5 @@ main(int argc, char **argv)
       "the current appearance keeps its name");
   END_SET("setting one")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAppearance/vibrancy.m
+++ b/Tests/gui/NSAppearance/vibrancy.m
@@ -8,8 +8,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("vibrancy")
     PASS([[NSAppearance appearanceNamed: NSAppearanceNameVibrantLight]
       allowsVibrancy] == YES, "the vibrant light appearance is vibrant");
@@ -24,6 +22,5 @@ main(int argc, char **argv)
       allowsVibrancy] == NO, "an unknown appearance is not vibrant");
   END_SET("vibrancy")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSApplication/applicationIconImage.m
+++ b/Tests/gui/NSApplication/applicationIconImage.m
@@ -19,8 +19,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSApplication applicationIconImage")
 
   NS_DURING
@@ -82,6 +80,5 @@ main(int argc, char **argv)
 
   END_SET("NSApplication applicationIconImage")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAttributedString/NSAttributedString_itemNumberInTextList.m
+++ b/Tests/gui/NSAttributedString/NSAttributedString_itemNumberInTextList.m
@@ -7,8 +7,6 @@
 
 int main(int argc, char **argv)
 {  
-  CREATE_AUTORELEASE_POOL(arp);
-  
   START_SET("NSAttributedString itemNumberInTextList:atIndex: category method");
   
   NSTextList *list1 = AUTORELEASE(
@@ -77,7 +75,6 @@ int main(int argc, char **argv)
   
   END_SET("NSAttributedString itemNumberInTextList:atIndex: category method");
   
-  DESTROY(arp);
   
   return 0;
 }

--- a/Tests/gui/NSAttributedString/NSAttributedString_mergingAttributes.m
+++ b/Tests/gui/NSAttributedString/NSAttributedString_mergingAttributes.m
@@ -7,8 +7,6 @@
 
 int main(int argc, char **argv)
 {  
-  CREATE_AUTORELEASE_POOL(arp);
-  
   START_SET("NSAttributedString attribute merging");
   
   NSMutableParagraphStyle *style1 = AUTORELEASE([[NSParagraphStyle defaultParagraphStyle] mutableCopy]);
@@ -69,7 +67,6 @@ int main(int argc, char **argv)
   
   END_SET("NSAttributedString attribute merging");
   
-  DESTROY(arp);
   
   return 0;
 }

--- a/Tests/gui/NSAttributedString/NSAttributedString_rangeOfTextBlock.m
+++ b/Tests/gui/NSAttributedString/NSAttributedString_rangeOfTextBlock.m
@@ -7,8 +7,6 @@
 
 int main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSAttributedString rangeOfTextBlock:atIndex: category method");
 
   NSTextBlock *block1 = AUTORELEASE([[NSTextBlock alloc] init]);
@@ -165,7 +163,6 @@ int main(int argc, char **argv)
 
   END_SET("NSAttributedString rangeOfTextTable:atIndex: category method");
 
-  DESTROY(arp);
 
   return 0;
 }

--- a/Tests/gui/NSAttributedString/NSAttributedString_rangeOfTextList.m
+++ b/Tests/gui/NSAttributedString/NSAttributedString_rangeOfTextList.m
@@ -7,8 +7,6 @@
 
 int main(int argc, char **argv)
 {  
-  CREATE_AUTORELEASE_POOL(arp);
-  
   START_SET("NSAttributedString rangeOfTextList:atIndex: category method");
   
   NSTextList *list1 = AUTORELEASE(
@@ -90,7 +88,6 @@ int main(int argc, char **argv)
   
   END_SET("NSAttributedString rangeOfTextList:atIndex: category method");
   
-  DESTROY(arp);
   
   return 0;
 }

--- a/Tests/gui/NSAttributedString/attributeQueries.m
+++ b/Tests/gui/NSAttributedString/attributeQueries.m
@@ -19,8 +19,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSAttributedString attribute queries")
 
   NS_DURING
@@ -114,6 +112,5 @@ main(int argc, char **argv)
 
   END_SET("NSAttributedString attribute queries")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAttributedString/headIndentBounding.m
+++ b/Tests/gui/NSAttributedString/headIndentBounding.m
@@ -38,7 +38,6 @@ noteString(CGFloat indent)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSRect r0, r20;
 
   START_SET("NSAttributedString head indent bounding rect")
@@ -68,6 +67,5 @@ main(int argc, char **argv)
 
   END_SET("NSAttributedString head indent bounding rect")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAttributedString/headIndentDrawing.m
+++ b/Tests/gui/NSAttributedString/headIndentDrawing.m
@@ -95,7 +95,6 @@ rowHasContent(NSBitmapImageRep *rep, int y)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSAttributedString head indent drawing")
 
   NS_DURING
@@ -152,6 +151,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSAttributedString head indent drawing")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAttributedString/headIndentWrapped.m
+++ b/Tests/gui/NSAttributedString/headIndentWrapped.m
@@ -48,7 +48,6 @@ bounds(NSAttributedString *s, CGFloat w)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSRect indented, narrowed, full;
 
   START_SET("NSAttributedString wrapped head indent")
@@ -77,6 +76,5 @@ main(int argc, char **argv)
 
   END_SET("NSAttributedString wrapped head indent")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSAttributedString/mutation.m
+++ b/Tests/gui/NSAttributedString/mutation.m
@@ -32,8 +32,6 @@ superAt(NSAttributedString *s, NSUInteger i)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSAttributedString mutation")
 
   NS_DURING
@@ -133,6 +131,5 @@ main(int argc, char **argv)
 
   END_SET("NSAttributedString mutation")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSBezierPath/appendingAndContainment.m
+++ b/Tests/gui/NSBezierPath/appendingAndContainment.m
@@ -15,8 +15,6 @@
 
 int main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("appendBezierPathWithRect:")
     NSBezierPath	*p = [NSBezierPath bezierPath];
     NSPoint		pts[3];
@@ -153,6 +151,5 @@ int main(int argc, char **argv)
       "appending a path adds its elements to the receiver");
   END_SET("appendBezierPath:")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSBox/contentView.m
+++ b/Tests/gui/NSBox/contentView.m
@@ -8,7 +8,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSBox content view")
 
   NS_DURING
@@ -39,6 +38,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSBox content view")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSBox/rendering.m
+++ b/Tests/gui/NSBox/rendering.m
@@ -11,7 +11,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSBox rendering")
 
   NS_DURING
@@ -59,6 +58,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSBox rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSBox/state.m
+++ b/Tests/gui/NSBox/state.m
@@ -8,7 +8,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSBox state")
 
   NS_DURING
@@ -53,6 +52,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSBox state")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSBrowser/behaviour.m
+++ b/Tests/gui/NSBrowser/behaviour.m
@@ -50,7 +50,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSBrowser *browser;
   BrowserContent *content;
 
@@ -143,6 +142,5 @@ main(int argc, char **argv)
 
   END_SET("NSBrowser behaviour")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSBrowser/binding.m
+++ b/Tests/gui/NSBrowser/binding.m
@@ -60,7 +60,6 @@ node(NSString *aName)
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSBrowser		*br;
   NSTreeController	*tc;
   NSObjectController	*oc;
@@ -123,7 +122,6 @@ withKeyPath: @"arrangedObjects"
 
   END_SET("NSBrowser content binding")
 
-  DESTROY(arp);
 
   return 0;
 }

--- a/Tests/gui/NSBrowser/config.m
+++ b/Tests/gui/NSBrowser/config.m
@@ -18,7 +18,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSBrowser *browser;
 
   START_SET("NSBrowser config")
@@ -96,6 +95,5 @@ main(int argc, char **argv)
 
   END_SET("NSBrowser config")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSBrowser/path.m
+++ b/Tests/gui/NSBrowser/path.m
@@ -46,7 +46,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSBrowser *browser;
   BrowserContent *content;
 
@@ -91,6 +90,5 @@ main(int argc, char **argv)
 
   END_SET("NSBrowser path")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSBrowserCell/basic.m
+++ b/Tests/gui/NSBrowserCell/basic.m
@@ -13,8 +13,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSBrowserCell basic")
 
   NS_DURING
@@ -62,6 +60,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSBrowserCell basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSBrowserCell/copy.m
+++ b/Tests/gui/NSBrowserCell/copy.m
@@ -9,8 +9,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSBrowserCell copy")
 
   NS_DURING
@@ -39,6 +37,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSBrowserCell copy")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSButton/bezelColor.m
+++ b/Tests/gui/NSButton/bezelColor.m
@@ -31,7 +31,6 @@ centerColor(NSButton *b)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSButton *b;
 
   START_SET("NSButton bezelColor")
@@ -103,6 +102,5 @@ main(int argc, char **argv)
 
   END_SET("NSButton bezelColor")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSButton/convenienceConstructors.m
+++ b/Tests/gui/NSButton/convenienceConstructors.m
@@ -23,7 +23,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   CtorTarget *t;
   NSImage *image;
 
@@ -80,6 +79,5 @@ main(int argc, const char **argv)
 
   END_SET("NSButton convenience constructors")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSButton/interact.m
+++ b/Tests/gui/NSButton/interact.m
@@ -31,7 +31,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   ClickCounter *c;
   NSButton *b;
 
@@ -92,6 +91,5 @@ main(int argc, const char **argv)
 
   END_SET("NSButton interaction")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSButton/rendering.m
+++ b/Tests/gui/NSButton/rendering.m
@@ -14,7 +14,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSButton rendering")
 
   NS_DURING
@@ -52,6 +51,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSButton rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSButton/state.m
+++ b/Tests/gui/NSButton/state.m
@@ -18,7 +18,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSButton *b;
 
   START_SET("NSButton state")
@@ -88,6 +87,5 @@ main(int argc, char **argv)
 
   END_SET("NSButton state")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSButtonCell/mixedState.m
+++ b/Tests/gui/NSButtonCell/mixedState.m
@@ -64,7 +64,6 @@ pixelDifference(NSBitmapImageRep *a, NSBitmapImageRep *b, int side)
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   int side = 20;
 
   START_SET("NSButtonCell mixed state")
@@ -98,6 +97,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSButtonCell mixed state")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSButtonCell/pushInOffset.m
+++ b/Tests/gui/NSButtonCell/pushInOffset.m
@@ -11,8 +11,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSButtonCell push-in offset")
 
   NS_DURING
@@ -49,6 +47,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSButtonCell push-in offset")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSButtonCell/stateValue.m
+++ b/Tests/gui/NSButtonCell/stateValue.m
@@ -13,7 +13,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSButtonCell *cell;
 
   START_SET("NSButtonCell state and value coupling")
@@ -86,6 +85,5 @@ main(int argc, char **argv)
 
   END_SET("NSButtonCell state and value coupling")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSButtonCell/stringValue.m
+++ b/Tests/gui/NSButtonCell/stringValue.m
@@ -11,7 +11,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSButtonCell *cell;
 
   START_SET("NSButtonCell stringValue")
@@ -39,6 +38,5 @@ main(int argc, char **argv)
 
   END_SET("NSButtonCell stringValue")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCell/basic.m
+++ b/Tests/gui/NSCell/basic.m
@@ -7,7 +7,6 @@
 
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
   id testObject;
   id testObject1;
   id testObject2;
@@ -42,7 +41,6 @@ int main()
 		 testObjects, NO, NO);
 
   END_SET("NSCell GNUstep basic")
-  [arp release];
   return 0;
 }
 

--- a/Tests/gui/NSCell/cellDefaults.m
+++ b/Tests/gui/NSCell/cellDefaults.m
@@ -9,7 +9,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSCell *cell;
   NSRect frame = NSMakeRect(10, 20, 100, 40);
   NSRect r;
@@ -48,6 +47,5 @@ int main()
 
   END_SET("NSCell defaults")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCell/drawingDefaults.m
+++ b/Tests/gui/NSCell/drawingDefaults.m
@@ -46,7 +46,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   ForwardCell *cell;
   MaskView *view;
   NSBitmapImageRep *rep;
@@ -83,6 +82,5 @@ main(int argc, const char **argv)
 
   END_SET("NSCell drawing defaults")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCell/objectValue.m
+++ b/Tests/gui/NSCell/objectValue.m
@@ -9,7 +9,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSCell *cell;
   NSNumber *num;
 
@@ -44,7 +43,6 @@ int main()
  
   END_SET("NSCell GNUstep objectValue")
 
-  DESTROY(arp);
   return 0;
 }
 

--- a/Tests/gui/NSCell/properties.m
+++ b/Tests/gui/NSCell/properties.m
@@ -12,7 +12,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSImageCell *imgCell;
   NSActionCell *actCell;
   NSButtonCell *buttCell;
@@ -52,6 +51,5 @@ int main()
 
   END_SET("NSCell RefusesResponder")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCell/state.m
+++ b/Tests/gui/NSCell/state.m
@@ -11,7 +11,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSCell *cell;
 
   START_SET("NSCell state")
@@ -89,6 +88,5 @@ main(int argc, char **argv)
 
   END_SET("NSCell state")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSClipView/constrain.m
+++ b/Tests/gui/NSClipView/constrain.m
@@ -8,7 +8,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSClipView constrain")
 
   NS_DURING
@@ -49,6 +48,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSClipView constrain")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSClipView/rendering.m
+++ b/Tests/gui/NSClipView/rendering.m
@@ -11,7 +11,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSClipView rendering")
 
   NS_DURING
@@ -56,6 +55,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSClipView rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSClipView/scroll.m
+++ b/Tests/gui/NSClipView/scroll.m
@@ -8,7 +8,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSClipView scroll")
 
   NS_DURING
@@ -38,6 +37,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSClipView scroll")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSClipView/state.m
+++ b/Tests/gui/NSClipView/state.m
@@ -9,7 +9,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSClipView state")
 
   NS_DURING
@@ -47,6 +46,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSClipView state")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCollectionView/data.m
+++ b/Tests/gui/NSCollectionView/data.m
@@ -52,7 +52,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSCollectionView *cv;
   TwoSections *two;
   OneSection *one;
@@ -107,6 +106,5 @@ main(int argc, char **argv)
 
   END_SET("NSCollectionView data")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCollectionView/defaults.m
+++ b/Tests/gui/NSCollectionView/defaults.m
@@ -16,7 +16,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSCollectionView *cv;
 
   START_SET("NSCollectionView defaults")
@@ -59,6 +58,5 @@ main(int argc, char **argv)
 
   END_SET("NSCollectionView defaults")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCollectionView/selection.m
+++ b/Tests/gui/NSCollectionView/selection.m
@@ -17,7 +17,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSCollectionView *cv;
 
   START_SET("NSCollectionView selection")
@@ -62,6 +61,5 @@ main(int argc, char **argv)
 
   END_SET("NSCollectionView selection")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCollectionView/state.m
+++ b/Tests/gui/NSCollectionView/state.m
@@ -16,7 +16,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSCollectionView *cv;
 
   START_SET("NSCollectionView state")
@@ -72,6 +71,5 @@ main(int argc, char **argv)
 
   END_SET("NSCollectionView state")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCollectionViewFlowLayout/basic.m
+++ b/Tests/gui/NSCollectionViewFlowLayout/basic.m
@@ -13,7 +13,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSCollectionViewFlowLayout *l;
   NSEdgeInsets inset;
 
@@ -77,6 +76,5 @@ int main()
 
   END_SET("NSCollectionViewFlowLayout basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCollectionViewFlowLayout/defaultMetrics.m
+++ b/Tests/gui/NSCollectionViewFlowLayout/defaultMetrics.m
@@ -10,7 +10,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSCollectionViewFlowLayout *l;
 
   START_SET("NSCollectionViewFlowLayout defaultMetrics")
@@ -31,6 +30,5 @@ int main()
 
   END_SET("NSCollectionViewFlowLayout defaultMetrics")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCollectionViewItem/config.m
+++ b/Tests/gui/NSCollectionViewItem/config.m
@@ -16,7 +16,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSCollectionViewItem *item;
   NSTextField *tf;
   NSImageView *iv;
@@ -76,6 +75,5 @@ int main()
 
   END_SET("NSCollectionViewItem config")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCollectionViewItem/draggingimage.m
+++ b/Tests/gui/NSCollectionViewItem/draggingimage.m
@@ -18,7 +18,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSCollectionViewItem *item;
   NSArray *components;
   NSDraggingImageComponent *component;
@@ -69,6 +68,5 @@ int main()
 
   END_SET("NSCollectionViewItem draggingImageComponents")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSCollectionViewItem/headeronly.m
+++ b/Tests/gui/NSCollectionViewItem/headeronly.m
@@ -10,7 +10,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSCollectionViewItem *item;
 
   START_SET("NSCollectionViewItem header")
@@ -28,6 +27,5 @@ int main()
 
   END_SET("NSCollectionViewItem header")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColor/basic.m
+++ b/Tests/gui/NSColor/basic.m
@@ -13,8 +13,6 @@
 
 int main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("calibrated RGB components")
     NSColor *c = [NSColor colorWithCalibratedRed: 0.2 green: 0.4
 					    blue: 0.6 alpha: 0.8];
@@ -195,6 +193,5 @@ int main(int argc, char **argv)
     PASS(![a isEqual: d], "colours differing only in alpha are not equal");
   END_SET("equality")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColorList/addRemove.m
+++ b/Tests/gui/NSColorList/addRemove.m
@@ -19,8 +19,6 @@ rgb(CGFloat r, CGFloat g, CGFloat b)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSColorList editing")
 
   NSColor *red = rgb(1, 0, 0);
@@ -102,6 +100,5 @@ main(int argc, char **argv)
 
   END_SET("NSColorList editing")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColorPanel/colorNotification.m
+++ b/Tests/gui/NSColorPanel/colorNotification.m
@@ -36,7 +36,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   Recorder *r;
   NSColorPanel *cp;
   NSNotificationCenter *nc;
@@ -97,6 +96,5 @@ main(int argc, char **argv)
 
   END_SET("NSColorPanel color notification")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColorPanel/config.m
+++ b/Tests/gui/NSColorPanel/config.m
@@ -12,7 +12,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSColorPanel config")
 
   NS_DURING
@@ -84,6 +83,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSColorPanel config")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColorPanel/continuous.m
+++ b/Tests/gui/NSColorPanel/continuous.m
@@ -8,7 +8,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSColorPanel continuous")
 
   NS_DURING
@@ -32,6 +31,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSColorPanel continuous")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColorPanel/pickerMode.m
+++ b/Tests/gui/NSColorPanel/pickerMode.m
@@ -12,7 +12,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSColorPanel picker mode")
 
   NS_DURING
@@ -49,6 +48,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSColorPanel picker mode")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColorPanel/render.m
+++ b/Tests/gui/NSColorPanel/render.m
@@ -9,7 +9,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSColorPanel render")
 
   NS_DURING
@@ -49,6 +48,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSColorPanel render")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColorPanel/showsalpha.m
+++ b/Tests/gui/NSColorPanel/showsalpha.m
@@ -8,8 +8,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSColorPanel showsAlpha")
 
   NS_DURING
@@ -24,6 +22,5 @@ int main()
 
   END_SET("NSColorPanel showsAlpha")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColorPicker/backend.m
+++ b/Tests/gui/NSColorPicker/backend.m
@@ -15,7 +15,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSColorPicker *picker;
   NSColorPanel *panel;
   NSButtonCell *cell;
@@ -44,6 +43,5 @@ int main()
 
   END_SET("NSColorPicker backend")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColorSpace/basic.m
+++ b/Tests/gui/NSColorSpace/basic.m
@@ -14,8 +14,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("model enum values")
     PASS(NSUnknownColorSpaceModel == -1 && NSGrayColorSpaceModel == 0
       && NSRGBColorSpaceModel == 1 && NSCMYKColorSpaceModel == 2
@@ -68,6 +66,5 @@ main(int argc, char **argv)
       "the generic and device RGB spaces are different objects");
   END_SET("standard spaces are shared")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColorWell/colorwell.m
+++ b/Tests/gui/NSColorWell/colorwell.m
@@ -17,7 +17,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSColorWell *cw;
 
   START_SET("NSColorWell state")
@@ -67,6 +66,5 @@ main(int argc, char **argv)
 
   END_SET("NSColorWell state")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColorWell/defaultColor.m
+++ b/Tests/gui/NSColorWell/defaultColor.m
@@ -15,7 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSColorWell *cw;
 
   START_SET("NSColorWell default colour")
@@ -55,6 +54,5 @@ main(int argc, char **argv)
 
   END_SET("NSColorWell default colour")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSColorWell/rendering.m
+++ b/Tests/gui/NSColorWell/rendering.m
@@ -16,7 +16,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSColorWell rendering")
 
   NS_DURING
@@ -63,6 +62,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSColorWell rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSComboBox/config.m
+++ b/Tests/gui/NSComboBox/config.m
@@ -15,7 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSComboBox *cb;
 
   START_SET("NSComboBox config")
@@ -68,6 +67,5 @@ main(int argc, char **argv)
 
   END_SET("NSComboBox config")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSComboBox/items.m
+++ b/Tests/gui/NSComboBox/items.m
@@ -15,7 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSComboBox *cb;
 
   START_SET("NSComboBox items")
@@ -72,6 +71,5 @@ main(int argc, char **argv)
 
   END_SET("NSComboBox items")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSComboBox/selection.m
+++ b/Tests/gui/NSComboBox/selection.m
@@ -29,7 +29,6 @@ threeItemComboBox(void)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSComboBox *cb;
 
   START_SET("NSComboBox selection")
@@ -103,6 +102,5 @@ main(int argc, char **argv)
 
   END_SET("NSComboBox selection")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSComboBox/selectionNotification.m
+++ b/Tests/gui/NSComboBox/selectionNotification.m
@@ -33,7 +33,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   Recorder *r;
   NSComboBox *cb;
   NSNotificationCenter *nc;
@@ -101,6 +100,5 @@ main(int argc, char **argv)
 
   END_SET("NSComboBox selection notification")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSComboBox/visibleItems.m
+++ b/Tests/gui/NSComboBox/visibleItems.m
@@ -15,7 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSComboBox *cb;
 
   START_SET("NSComboBox visible items")
@@ -59,6 +58,5 @@ main(int argc, char **argv)
 
   END_SET("NSComboBox visible items")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSComboBoxCell/completedStringNoMatch.m
+++ b/Tests/gui/NSComboBoxCell/completedStringNoMatch.m
@@ -11,8 +11,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSComboBoxCell completedString: no match")
 
   NS_DURING
@@ -39,6 +37,5 @@ main(int argc, char **argv)
 
   END_SET("NSComboBoxCell completedString: no match")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSComboBoxCell/list.m
+++ b/Tests/gui/NSComboBoxCell/list.m
@@ -15,7 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSComboBoxCell *cell;
 
   START_SET("NSComboBoxCell item list")
@@ -98,6 +97,5 @@ main(int argc, char **argv)
 
   END_SET("NSComboBoxCell item list")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSControl/continuousBinding.m
+++ b/Tests/gui/NSControl/continuousBinding.m
@@ -44,7 +44,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   Recorder *model;
   NSWindow *win;
   NSTextField *field;
@@ -143,7 +142,6 @@ main(int argc, const char **argv)
 
   END_SET("NSControl continuous value binding")
 
-  DESTROY(arp);
 
   return 0;
 }

--- a/Tests/gui/NSControl/interact.m
+++ b/Tests/gui/NSControl/interact.m
@@ -42,7 +42,6 @@ makeControl(void)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   ClickCounter *r;
   NSControl *c;
 
@@ -100,6 +99,5 @@ main(int argc, const char **argv)
 
   END_SET("NSControl interaction")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSControl/rendering.m
+++ b/Tests/gui/NSControl/rendering.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSControl rendering")
 
   NS_DURING
@@ -51,6 +50,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSControl rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSControl/sendAction.m
+++ b/Tests/gui/NSControl/sendAction.m
@@ -19,7 +19,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSControl sendAction")
 
   NS_DURING
@@ -54,6 +53,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSControl sendAction")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSControl/state.m
+++ b/Tests/gui/NSControl/state.m
@@ -16,7 +16,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSControl state")
 
   NS_DURING
@@ -61,6 +60,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSControl state")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSControl/value.m
+++ b/Tests/gui/NSControl/value.m
@@ -9,7 +9,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSControl value")
 
   NS_DURING
@@ -64,6 +63,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSControl value")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDataAsset/loading.m
+++ b/Tests/gui/NSDataAsset/loading.m
@@ -54,7 +54,6 @@ buildBundle(void)
 int
 main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSString *root;
   NSBundle *bundle;
   NSDataAsset *a;
@@ -88,6 +87,5 @@ main()
 
   END_SET("NSDataAsset loading")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDataLink/basic.m
+++ b/Tests/gui/NSDataLink/basic.m
@@ -11,7 +11,6 @@
 
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
   id testObject;
   id testObject1;
   id testObject2;
@@ -80,7 +79,6 @@ int main()
 
   END_SET("NSDataLink GNUstep basic")
 
-  [arp release];
   return 0;
 }
 

--- a/Tests/gui/NSDataLink/initFailure.m
+++ b/Tests/gui/NSDataLink/initFailure.m
@@ -16,7 +16,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSDataLink init failure")
 
   NSFileManager *fm = [NSFileManager defaultManager];
@@ -57,6 +56,5 @@ main(int argc, const char **argv)
   [fm removeFileAtPath: corrupt handler: nil];
 
   END_SET("NSDataLink init failure")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDataLink/updateDestination.m
+++ b/Tests/gui/NSDataLink/updateDestination.m
@@ -55,7 +55,6 @@ static NSSelection *aSelection(void)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSDataLink updateDestination")
 
   // A link with no destination manager cannot update anything.
@@ -120,6 +119,5 @@ main(int argc, const char **argv)
 
   END_SET("NSDataLink updateDestination")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDatePicker/bezeled.m
+++ b/Tests/gui/NSDatePicker/bezeled.m
@@ -14,7 +14,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSDatePicker *dp;
 
   START_SET("NSDatePicker bezeled")
@@ -54,6 +53,5 @@ main(int argc, char **argv)
 
   END_SET("NSDatePicker bezeled")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDatePicker/config.m
+++ b/Tests/gui/NSDatePicker/config.m
@@ -20,7 +20,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSDatePicker *dp;
 
   START_SET("NSDatePicker config")
@@ -94,6 +93,5 @@ main(int argc, char **argv)
 
   END_SET("NSDatePicker config")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDatePicker/rendering.m
+++ b/Tests/gui/NSDatePicker/rendering.m
@@ -15,7 +15,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSDatePicker rendering")
 
   NS_DURING
@@ -53,6 +52,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSDatePicker rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDatePickerCell/basic.m
+++ b/Tests/gui/NSDatePickerCell/basic.m
@@ -13,7 +13,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSDatePickerCell *cell;
   NSDate *inRange;
 
@@ -63,6 +62,5 @@ int main()
 
   END_SET("NSDatePickerCell basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDatePickerCell/clamping.m
+++ b/Tests/gui/NSDatePickerCell/clamping.m
@@ -10,7 +10,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSDatePickerCell *cell;
   NSDate *minD, *maxD;
 
@@ -52,6 +51,5 @@ int main()
 
   END_SET("NSDatePickerCell clamping")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDatePickerCell/defaultColors.m
+++ b/Tests/gui/NSDatePickerCell/defaultColors.m
@@ -10,7 +10,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSDatePickerCell *cell;
 
   START_SET("NSDatePickerCell defaultColors")
@@ -30,6 +29,5 @@ int main()
 
   END_SET("NSDatePickerCell defaultColors")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDatePickerCell/defaultDateValue.m
+++ b/Tests/gui/NSDatePickerCell/defaultDateValue.m
@@ -10,7 +10,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSDatePickerCell *cell;
 
   START_SET("NSDatePickerCell defaultDateValue")
@@ -30,6 +29,5 @@ int main()
 
   END_SET("NSDatePickerCell defaultDateValue")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDatePickerCell/defaultElements.m
+++ b/Tests/gui/NSDatePickerCell/defaultElements.m
@@ -9,7 +9,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSDatePickerCell *cell;
 
   START_SET("NSDatePickerCell defaultElements")
@@ -29,6 +28,5 @@ int main()
 
   END_SET("NSDatePickerCell defaultElements")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDiffableDataSource/NSDiffableDataSource_collectionView.m
+++ b/Tests/gui/NSDiffableDataSource/NSDiffableDataSource_collectionView.m
@@ -41,8 +41,6 @@
 
 int main()
 {
-  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-  
   START_SET("NSDiffableDataSource with NSCollectionView")
     
     // Test 1: Create collection view and data source
@@ -106,6 +104,5 @@ int main()
     
   END_SET("NSDiffableDataSource with NSCollectionView")
   
-  [pool drain];
   return 0;
 }

--- a/Tests/gui/NSDiffableDataSource/NSDiffableDataSource_snapshot.m
+++ b/Tests/gui/NSDiffableDataSource/NSDiffableDataSource_snapshot.m
@@ -15,8 +15,6 @@
 
 int main()
 {
-  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-  
   START_SET("NSDiffableDataSourceSnapshot basic functionality")
     
     // Test 1: Create empty snapshot
@@ -98,6 +96,5 @@ int main()
     
   END_SET("NSDiffableDataSourceSnapshot basic functionality")
   
-  [pool drain];
   return 0;
 }

--- a/Tests/gui/NSDockTile/basic.m
+++ b/Tests/gui/NSDockTile/basic.m
@@ -15,8 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("the application dock tile")
 
   NS_DURING
@@ -57,6 +55,5 @@ main(int argc, char **argv)
 
   END_SET("the application dock tile")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDockTile/owner.m
+++ b/Tests/gui/NSDockTile/owner.m
@@ -11,8 +11,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("the dock tile owner")
 
   NS_DURING
@@ -38,6 +36,5 @@ main(int argc, char **argv)
 
   END_SET("the dock tile owner")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDockTile/ownership.m
+++ b/Tests/gui/NSDockTile/ownership.m
@@ -13,8 +13,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("a balancing release keeps the tile whole")
 
   NS_DURING
@@ -52,6 +50,5 @@ main(int argc, char **argv)
 
   END_SET("a balancing release keeps the tile whole")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDrawer/config.m
+++ b/Tests/gui/NSDrawer/config.m
@@ -11,7 +11,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSDrawer config")
 
   NS_DURING
@@ -74,6 +73,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSDrawer config")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDrawer/contentSizeDefaults.m
+++ b/Tests/gui/NSDrawer/contentSizeDefaults.m
@@ -9,7 +9,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSDrawer content size defaults")
 
   NS_DURING
@@ -37,6 +36,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSDrawer content size defaults")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDrawer/render.m
+++ b/Tests/gui/NSDrawer/render.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSDrawer render")
 
   NS_DURING
@@ -58,6 +57,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSDrawer render")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSDrawer/windowDrawers.m
+++ b/Tests/gui/NSDrawer/windowDrawers.m
@@ -32,7 +32,6 @@ drawer(void)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSWindow *w1, *w2;
   NSDrawer *d1, *d2, *d3;
   NSArray *list;
@@ -86,6 +85,5 @@ main(int argc, const char **argv)
 
   END_SET("NSWindow drawers")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSEvent/delta.m
+++ b/Tests/gui/NSEvent/delta.m
@@ -9,7 +9,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSEvent *ev;
 
   START_SET("NSEvent GNUstep delta")
@@ -54,6 +53,5 @@ int main()
 
   END_SET("NSEvent GNUstep delta")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFont/constants.m
+++ b/Tests/gui/NSFont/constants.m
@@ -13,8 +13,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("font weight constants")
     PASS(EQ(NSFontWeightUltraLight, -0.8), "NSFontWeightUltraLight is -0.8");
     PASS(EQ(NSFontWeightThin, -0.6), "NSFontWeightThin is -0.6");
@@ -56,6 +54,5 @@ main(int argc, char **argv)
       "NSFontAntialiasedIntegerAdvancementsRenderingMode is 3");
   END_SET("rendering mode values")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFont/named.m
+++ b/Tests/gui/NSFont/named.m
@@ -19,7 +19,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSFont creation")
 
   NS_DURING
@@ -76,6 +75,5 @@ main(int argc, char **argv)
   NS_ENDHANDLER
 
   END_SET("NSFont creation")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFont/sizes.m
+++ b/Tests/gui/NSFont/sizes.m
@@ -16,14 +16,14 @@
 int
 main(int argc, char **argv)
 {
-  CGFloat system = [NSFont systemFontSize];
-  CGFloat small = [NSFont smallSystemFontSize];
-  CGFloat label = [NSFont labelFontSize];
-  CGFloat mini = [NSFont systemFontSizeForControlSize: NSMiniControlSize];
-  CGFloat cSmall = [NSFont systemFontSizeForControlSize: NSSmallControlSize];
-  CGFloat cRegular = [NSFont systemFontSizeForControlSize: NSRegularControlSize];
-
   START_SET("system font sizes")
+    CGFloat system = [NSFont systemFontSize];
+    CGFloat small = [NSFont smallSystemFontSize];
+    CGFloat label = [NSFont labelFontSize];
+    CGFloat mini = [NSFont systemFontSizeForControlSize: NSMiniControlSize];
+    CGFloat cSmall = [NSFont systemFontSizeForControlSize: NSSmallControlSize];
+    CGFloat cRegular = [NSFont systemFontSizeForControlSize: NSRegularControlSize];
+
     PASS(system > 0, "the system font size is positive");
     PASS(small > 0, "the small system font size is positive");
     PASS(label > 0, "the label font size is positive");

--- a/Tests/gui/NSFont/sizes.m
+++ b/Tests/gui/NSFont/sizes.m
@@ -16,8 +16,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   CGFloat system = [NSFont systemFontSize];
   CGFloat small = [NSFont smallSystemFontSize];
   CGFloat label = [NSFont labelFontSize];
@@ -42,6 +40,5 @@ main(int argc, char **argv)
       "the control sizes are ordered mini < small < regular");
   END_SET("control sizes")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFont/sizes.m
+++ b/Tests/gui/NSFont/sizes.m
@@ -16,7 +16,7 @@
 int
 main(int argc, char **argv)
 {
-  START_SET("system font sizes")
+  START_SET("control sizes")
     CGFloat system = [NSFont systemFontSize];
     CGFloat small = [NSFont smallSystemFontSize];
     CGFloat label = [NSFont labelFontSize];
@@ -28,9 +28,7 @@ main(int argc, char **argv)
     PASS(small > 0, "the small system font size is positive");
     PASS(label > 0, "the label font size is positive");
     PASS(small < system, "the small system font size is below the system size");
-  END_SET("system font sizes")
 
-  START_SET("control sizes")
     PASS(EQ(cRegular, system),
       "the regular control size is the system font size");
     PASS(EQ(cSmall, small),

--- a/Tests/gui/NSFont/systemfonts.m
+++ b/Tests/gui/NSFont/systemfonts.m
@@ -16,7 +16,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("standard role fonts")
 
   NS_DURING
@@ -59,6 +58,5 @@ main(int argc, char **argv)
   NS_ENDHANDLER
 
   END_SET("standard role fonts")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFontCollection/config.m
+++ b/Tests/gui/NSFontCollection/config.m
@@ -14,8 +14,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("collection name constants")
     PASS(NSFontCollectionAllFonts != nil, "NSFontCollectionAllFonts is defined");
     PASS(NSFontCollectionUser != nil, "NSFontCollectionUser is defined");
@@ -47,6 +45,5 @@ main(int argc, char **argv)
       "an empty descriptor list gives no query descriptors");
   END_SET("query descriptors")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFontCollection/mutable.m
+++ b/Tests/gui/NSFontCollection/mutable.m
@@ -12,12 +12,12 @@
 int
 main(int argc, char **argv)
 {
-  NSFontDescriptor *fd = [NSFontDescriptor fontDescriptorWithFontAttributes:
-    [NSDictionary dictionaryWithObject: @"Helvetica" forKey: NSFontFamilyAttribute]];
-  NSFontDescriptor *fd2 = [NSFontDescriptor fontDescriptorWithFontAttributes:
-    [NSDictionary dictionaryWithObject: @"Courier" forKey: NSFontFamilyAttribute]];
-
   START_SET("set query and exclusion descriptors")
+    NSFontDescriptor *fd = [NSFontDescriptor fontDescriptorWithFontAttributes:
+      [NSDictionary dictionaryWithObject: @"Helvetica" forKey: NSFontFamilyAttribute]];
+    NSFontDescriptor *fd2 = [NSFontDescriptor fontDescriptorWithFontAttributes:
+      [NSDictionary dictionaryWithObject: @"Courier" forKey: NSFontFamilyAttribute]];
+
     NSMutableFontCollection *mc = [NSMutableFontCollection
       fontCollectionWithDescriptors: [NSArray arrayWithObject: fd]];
 

--- a/Tests/gui/NSFontCollection/mutable.m
+++ b/Tests/gui/NSFontCollection/mutable.m
@@ -12,8 +12,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   NSFontDescriptor *fd = [NSFontDescriptor fontDescriptorWithFontAttributes:
     [NSDictionary dictionaryWithObject: @"Helvetica" forKey: NSFontFamilyAttribute]];
   NSFontDescriptor *fd2 = [NSFontDescriptor fontDescriptorWithFontAttributes:
@@ -45,6 +43,5 @@ main(int argc, char **argv)
       "removeQueryForDescriptors: removes from the query");
   END_SET("add and remove query descriptors")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFontCollection/mutable.m
+++ b/Tests/gui/NSFontCollection/mutable.m
@@ -29,15 +29,15 @@ main(int argc, char **argv)
           && [[mc exclusionDescriptors] containsObject: fd2]),
       "setExclusionDescriptors: stores the exclusion descriptors");
 
-    NSMutableFontCollection *mc = [NSMutableFontCollection
+    NSMutableFontCollection *mc2 = [NSMutableFontCollection
       fontCollectionWithDescriptors: [NSArray array]];
 
-    PASS(([mc addQueryForDescriptors: [NSArray arrayWithObject: fd]],
-          [[mc queryDescriptors] count] == 1
-          && [[mc queryDescriptors] containsObject: fd]),
+    PASS(([mc2 addQueryForDescriptors: [NSArray arrayWithObject: fd]],
+          [[mc2 queryDescriptors] count] == 1
+          && [[mc2 queryDescriptors] containsObject: fd]),
       "addQueryForDescriptors: adds to the query");
-    PASS(([mc removeQueryForDescriptors: [NSArray arrayWithObject: fd]],
-          [[mc queryDescriptors] count] == 0),
+    PASS(([mc2 removeQueryForDescriptors: [NSArray arrayWithObject: fd]],
+          [[mc2 queryDescriptors] count] == 0),
       "removeQueryForDescriptors: removes from the query");
   END_SET("query and exclusion descriptors")
 

--- a/Tests/gui/NSFontCollection/mutable.m
+++ b/Tests/gui/NSFontCollection/mutable.m
@@ -12,7 +12,7 @@
 int
 main(int argc, char **argv)
 {
-  START_SET("set query and exclusion descriptors")
+  START_SET("query and exclusion descriptors")
     NSFontDescriptor *fd = [NSFontDescriptor fontDescriptorWithFontAttributes:
       [NSDictionary dictionaryWithObject: @"Helvetica" forKey: NSFontFamilyAttribute]];
     NSFontDescriptor *fd2 = [NSFontDescriptor fontDescriptorWithFontAttributes:
@@ -28,9 +28,7 @@ main(int argc, char **argv)
           [[mc exclusionDescriptors] count] == 1
           && [[mc exclusionDescriptors] containsObject: fd2]),
       "setExclusionDescriptors: stores the exclusion descriptors");
-  END_SET("set query and exclusion descriptors")
 
-  START_SET("add and remove query descriptors")
     NSMutableFontCollection *mc = [NSMutableFontCollection
       fontCollectionWithDescriptors: [NSArray array]];
 
@@ -41,7 +39,7 @@ main(int argc, char **argv)
     PASS(([mc removeQueryForDescriptors: [NSArray arrayWithObject: fd]],
           [[mc queryDescriptors] count] == 0),
       "removeQueryForDescriptors: removes from the query");
-  END_SET("add and remove query descriptors")
+  END_SET("query and exclusion descriptors")
 
   return 0;
 }

--- a/Tests/gui/NSFontDescriptor/basic.m
+++ b/Tests/gui/NSFontDescriptor/basic.m
@@ -16,11 +16,11 @@
 int
 main(int argc, char **argv)
 {
-  NSDictionary *attrs = [NSDictionary dictionaryWithObjectsAndKeys:
+  START_SET("attributes and extractors")
+    NSDictionary *attrs = [NSDictionary dictionaryWithObjectsAndKeys:
     @"Helvetica", NSFontNameAttribute,
     [NSNumber numberWithDouble: 12.0], NSFontSizeAttribute, nil];
 
-  START_SET("attributes and extractors")
     NSFontDescriptor *fd =
       [NSFontDescriptor fontDescriptorWithFontAttributes: attrs];
 

--- a/Tests/gui/NSFontDescriptor/basic.m
+++ b/Tests/gui/NSFontDescriptor/basic.m
@@ -16,7 +16,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSDictionary *attrs = [NSDictionary dictionaryWithObjectsAndKeys:
     @"Helvetica", NSFontNameAttribute,
     [NSNumber numberWithDouble: 12.0], NSFontSizeAttribute, nil];
@@ -96,6 +95,5 @@ main(int argc, char **argv)
       "fontDescriptorWithFamily: adds the family attribute");
   END_SET("fontDescriptorWithFamily:")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFontDescriptor/basic.m
+++ b/Tests/gui/NSFontDescriptor/basic.m
@@ -16,11 +16,11 @@
 int
 main(int argc, char **argv)
 {
-  START_SET("attributes and extractors")
-    NSDictionary *attrs = [NSDictionary dictionaryWithObjectsAndKeys:
+  NSDictionary *attrs = [NSDictionary dictionaryWithObjectsAndKeys:
     @"Helvetica", NSFontNameAttribute,
     [NSNumber numberWithDouble: 12.0], NSFontSizeAttribute, nil];
 
+  START_SET("attributes and extractors")
     NSFontDescriptor *fd =
       [NSFontDescriptor fontDescriptorWithFontAttributes: attrs];
 

--- a/Tests/gui/NSFontManager/config.m
+++ b/Tests/gui/NSFontManager/config.m
@@ -12,7 +12,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("shared font manager")
 
   NS_DURING
@@ -51,6 +50,5 @@ main(int argc, char **argv)
   NS_ENDHANDLER
 
   END_SET("shared font manager")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFontManager/constants.m
+++ b/Tests/gui/NSFontManager/constants.m
@@ -9,8 +9,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("trait mask values")
     PASS(NSItalicFontMask == 1, "NSItalicFontMask is 1");
     PASS(NSBoldFontMask == 2, "NSBoldFontMask is 2");
@@ -37,6 +35,5 @@ main(int argc, char **argv)
     PASS(NSAddTraitFontAction == 2, "NSAddTraitFontAction is 2");
   END_SET("font action values")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFontManager/convert.m
+++ b/Tests/gui/NSFontManager/convert.m
@@ -19,7 +19,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("convertFont:toSize:")
 
   NS_DURING
@@ -49,6 +48,5 @@ main(int argc, char **argv)
   NS_ENDHANDLER
 
   END_SET("convertFont:toSize:")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFontManager/enabled.m
+++ b/Tests/gui/NSFontManager/enabled.m
@@ -11,7 +11,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("font manager enabled state")
 
   NS_DURING
@@ -37,6 +36,5 @@ main(int argc, char **argv)
   NS_ENDHANDLER
 
   END_SET("font manager enabled state")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFontPanel/config.m
+++ b/Tests/gui/NSFontPanel/config.m
@@ -11,7 +11,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSFontPanel config")
 
   NS_DURING
@@ -68,6 +67,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSFontPanel config")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFontPanel/render.m
+++ b/Tests/gui/NSFontPanel/render.m
@@ -9,7 +9,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSFontPanel render")
 
   NS_DURING
@@ -49,6 +48,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSFontPanel render")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSForm/defaults.m
+++ b/Tests/gui/NSForm/defaults.m
@@ -9,7 +9,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSForm *f;
 
   START_SET("NSForm defaults")
@@ -39,6 +38,5 @@ int main()
 
   END_SET("NSForm defaults")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSForm/form.m
+++ b/Tests/gui/NSForm/form.m
@@ -16,7 +16,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSForm *f;
 
   START_SET("NSForm form")
@@ -68,6 +67,5 @@ main(int argc, char **argv)
 
   END_SET("NSForm form")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSForm/rendering.m
+++ b/Tests/gui/NSForm/rendering.m
@@ -14,7 +14,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSForm rendering")
 
   NS_DURING
@@ -53,6 +52,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSForm rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSFormCell/title.m
+++ b/Tests/gui/NSFormCell/title.m
@@ -17,7 +17,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSFormCell *cell;
 
   START_SET("NSFormCell title")
@@ -101,6 +100,5 @@ int main()
 
   END_SET("NSFormCell title")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSGlyphInfo/basic.m
+++ b/Tests/gui/NSGlyphInfo/basic.m
@@ -13,7 +13,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSGlyphInfo *g;
   NSFont *font;
 
@@ -47,6 +46,5 @@ int main()
 
   END_SET("NSGlyphInfo basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSGlyphInfo/nameFactory.m
+++ b/Tests/gui/NSGlyphInfo/nameFactory.m
@@ -47,7 +47,6 @@ fontThatNamesGlyphs(NSString **outName)
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSGlyphInfo *g;
   NSFont *font;
   NSFont *namedFont;
@@ -102,6 +101,5 @@ int main()
 
   END_SET("NSGlyphInfo name factory")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSGradient/basic.m
+++ b/Tests/gui/NSGradient/basic.m
@@ -18,7 +18,6 @@ rgb(CGFloat r, CGFloat g, CGFloat b)
 
 int main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSColor	*red = rgb(1, 0, 0);
   NSColor	*green = rgb(0, 1, 0);
   NSColor	*blue = rgb(0, 0, 1);
@@ -114,6 +113,5 @@ int main(int argc, char **argv)
       "copy interpolates like the original");
   END_SET("copy")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSGradient/customLocations.m
+++ b/Tests/gui/NSGradient/customLocations.m
@@ -20,7 +20,6 @@ rgb(CGFloat r, CGFloat g, CGFloat b)
 
 int main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSColor	*red = rgb(1, 0, 0);
   NSColor	*green = rgb(0, 1, 0);
   NSColor	*blue = rgb(0, 0, 1);
@@ -113,6 +112,5 @@ int main(int argc, char **argv)
       "interpolation within the first segment follows the explicit locations");
   END_SET("initWithColors:atLocations:colorSpace: honours the locations")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSGridView/defaults.m
+++ b/Tests/gui/NSGridView/defaults.m
@@ -14,7 +14,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSGridView *g;
 
   START_SET("NSGridView defaults")
@@ -53,6 +52,5 @@ main(int argc, char **argv)
 
   END_SET("NSGridView defaults")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSGridView/grid.m
+++ b/Tests/gui/NSGridView/grid.m
@@ -17,7 +17,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSGridView *g;
 
   START_SET("NSGridView grid")
@@ -64,6 +63,5 @@ main(int argc, char **argv)
 
   END_SET("NSGridView grid")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSHelpManager/basic.m
+++ b/Tests/gui/NSHelpManager/basic.m
@@ -9,8 +9,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("shared instance")
     NSHelpManager	*hm = [NSHelpManager sharedHelpManager];
 
@@ -50,6 +48,5 @@ main(int argc, char **argv)
       "setContextHelpModeActive: turns the mode off");
   END_SET("context help mode")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSImage/basic.m
+++ b/Tests/gui/NSImage/basic.m
@@ -6,7 +6,6 @@
 
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
   id testObject;
   id testObject1;
   id testObject2;
@@ -43,7 +42,6 @@ int main()
 
   END_SET("NSImage GNUstep basic")
 
-  [arp release];
   return 0;
 }
 

--- a/Tests/gui/NSImage/customImageRep.m
+++ b/Tests/gui/NSImage/customImageRep.m
@@ -63,8 +63,6 @@ renderCentre(NSImage *img)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSImage customImageRep")
 
   NS_DURING
@@ -114,6 +112,5 @@ main(int argc, char **argv)
 
   END_SET("NSImage customImageRep")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSImageCell/basic.m
+++ b/Tests/gui/NSImageCell/basic.m
@@ -10,16 +10,18 @@
 
 int main(int argc, const char **argv)
 {
-  /* Enum values match AppKit; these need no backend. */
-  PASS(NSImageAlignCenter == 0, "NSImageAlignCenter is 0");
-  PASS(NSImageAlignTop == 1, "NSImageAlignTop is 1");
-  PASS(NSImageAlignRight == 8, "NSImageAlignRight is 8");
-  PASS(NSImageFrameNone == 0, "NSImageFrameNone is 0");
-  PASS(NSImageFramePhoto == 1, "NSImageFramePhoto is 1");
-  PASS(NSImageFrameButton == 4, "NSImageFrameButton is 4");
-  PASS(NSImageScaleProportionallyDown == 0,
+  START_SET("NSImageCell enum")
+    /* Enum values match AppKit; these need no backend. */
+    PASS(NSImageAlignCenter == 0, "NSImageAlignCenter is 0");
+    PASS(NSImageAlignTop == 1, "NSImageAlignTop is 1");
+    PASS(NSImageAlignRight == 8, "NSImageAlignRight is 8");
+    PASS(NSImageFrameNone == 0, "NSImageFrameNone is 0");
+    PASS(NSImageFramePhoto == 1, "NSImageFramePhoto is 1");
+    PASS(NSImageFrameButton == 4, "NSImageFrameButton is 4");
+    PASS(NSImageScaleProportionallyDown == 0,
        "NSImageScaleProportionallyDown is 0");
-  PASS(NSImageScaleNone == 2, "NSImageScaleNone is 2");
+    PASS(NSImageScaleNone == 2, "NSImageScaleNone is 2");
+  END_SET("NSImageCell enum")
 
   START_SET("NSImageCell basic")
 

--- a/Tests/gui/NSImageCell/basic.m
+++ b/Tests/gui/NSImageCell/basic.m
@@ -10,8 +10,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   /* Enum values match AppKit; these need no backend. */
   PASS(NSImageAlignCenter == 0, "NSImageAlignCenter is 0");
   PASS(NSImageAlignTop == 1, "NSImageAlignTop is 1");
@@ -60,6 +58,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSImageCell basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSImageRep/registration.m
+++ b/Tests/gui/NSImageRep/registration.m
@@ -22,8 +22,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSImageRep registration")
 
   NS_DURING
@@ -101,6 +99,5 @@ main(int argc, char **argv)
 
   END_SET("NSImageRep registration")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSImageView/animates.m
+++ b/Tests/gui/NSImageView/animates.m
@@ -15,7 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSImageView *iv;
 
   START_SET("NSImageView animates")
@@ -55,6 +54,5 @@ main(int argc, char **argv)
 
   END_SET("NSImageView animates")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSImageView/rendering.m
+++ b/Tests/gui/NSImageView/rendering.m
@@ -15,7 +15,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSImageView rendering")
 
   NS_DURING
@@ -53,6 +52,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSImageView rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSImageView/state.m
+++ b/Tests/gui/NSImageView/state.m
@@ -19,7 +19,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSImageView *iv;
 
   START_SET("NSImageView state")
@@ -86,6 +85,5 @@ main(int argc, char **argv)
 
   END_SET("NSImageView state")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLayoutAnchor/viewanchors.m
+++ b/Tests/gui/NSLayoutAnchor/viewanchors.m
@@ -10,8 +10,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSView layout anchors")
 
   NS_DURING
@@ -60,6 +58,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSView layout anchors")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLayoutConstraint/basic.m
+++ b/Tests/gui/NSLayoutConstraint/basic.m
@@ -14,7 +14,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSView *v1, *v2;
   NSLayoutConstraint *c;
 
@@ -57,6 +56,5 @@ int main()
 
   END_SET("NSLayoutConstraint basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLayoutConstraint/identifier.m
+++ b/Tests/gui/NSLayoutConstraint/identifier.m
@@ -17,7 +17,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSView *v1, *v2;
   NSLayoutConstraint *c;
 
@@ -52,6 +51,5 @@ int main()
 
   END_SET("NSLayoutConstraint identifier")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLayoutConstraint/setConstant.m
+++ b/Tests/gui/NSLayoutConstraint/setConstant.m
@@ -16,7 +16,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSView *v1, *v2;
   NSLayoutConstraint *c;
 
@@ -48,6 +47,5 @@ int main()
 
   END_SET("NSLayoutConstraint setConstant")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLayoutConstraint/shouldBeArchived.m
+++ b/Tests/gui/NSLayoutConstraint/shouldBeArchived.m
@@ -16,7 +16,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSView *v1, *v2;
   NSLayoutConstraint *c;
 
@@ -50,6 +49,5 @@ int main()
 
   END_SET("NSLayoutConstraint shouldBeArchived")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLevelIndicator/levels.m
+++ b/Tests/gui/NSLevelIndicator/levels.m
@@ -18,7 +18,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSLevelIndicator *li;
 
   START_SET("NSLevelIndicator levels")
@@ -106,6 +105,5 @@ main(int argc, char **argv)
 
   END_SET("NSLevelIndicator levels")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLevelIndicator/rendering.m
+++ b/Tests/gui/NSLevelIndicator/rendering.m
@@ -14,7 +14,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSLevelIndicator rendering")
 
   NS_DURING
@@ -54,6 +53,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSLevelIndicator rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLevelIndicatorCell/basic.m
+++ b/Tests/gui/NSLevelIndicatorCell/basic.m
@@ -13,7 +13,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSLevelIndicatorCell *cell;
   NSLevelIndicatorStyle styles[4];
   double maxes[4];
@@ -119,6 +118,5 @@ int main()
 
   END_SET("NSLevelIndicatorCell basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLevelIndicatorCell/initStyle.m
+++ b/Tests/gui/NSLevelIndicatorCell/initStyle.m
@@ -9,7 +9,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSLevelIndicatorCell *cell;
 
   START_SET("NSLevelIndicatorCell initStyle")
@@ -27,6 +26,5 @@ int main()
 
   END_SET("NSLevelIndicatorCell initStyle")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLevelIndicatorCell/levelIndicatorStyle.m
+++ b/Tests/gui/NSLevelIndicatorCell/levelIndicatorStyle.m
@@ -15,7 +15,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSLevelIndicatorCell *cell;
 
   START_SET("NSLevelIndicatorCell levelIndicatorStyle")
@@ -39,6 +38,5 @@ int main()
 
   END_SET("NSLevelIndicatorCell levelIndicatorStyle")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSLevelIndicatorCell/tickMarkValue.m
+++ b/Tests/gui/NSLevelIndicatorCell/tickMarkValue.m
@@ -13,7 +13,6 @@ static BOOL eq(double a, double b) { return fabs(a - b) < 1e-9; }
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSLevelIndicatorCell *cell;
 
   START_SET("NSLevelIndicatorCell tickMarkValue")
@@ -43,6 +42,5 @@ int main()
 
   END_SET("NSLevelIndicatorCell tickMarkValue")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMatrix/action.m
+++ b/Tests/gui/NSMatrix/action.m
@@ -39,7 +39,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   Recorder *r;
   NSMatrix *m;
   NSActionCell *proto;
@@ -101,6 +100,5 @@ main(int argc, const char **argv)
 
   END_SET("NSMatrix action")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMatrix/cellClassPrototype.m
+++ b/Tests/gui/NSMatrix/cellClassPrototype.m
@@ -13,8 +13,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSMatrix cell class vs prototype")
 
   NS_DURING
@@ -61,6 +59,5 @@ main(int argc, char **argv)
 
   END_SET("NSMatrix cell class vs prototype")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMatrix/click.m
+++ b/Tests/gui/NSMatrix/click.m
@@ -32,7 +32,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   Hit *h;
   NSMatrix *m;
   NSButtonCell *proto;
@@ -85,6 +84,5 @@ main(int argc, const char **argv)
 
   END_SET("NSMatrix click")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMatrix/flagDefaults.m
+++ b/Tests/gui/NSMatrix/flagDefaults.m
@@ -10,7 +10,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSMatrix *m;
 
   START_SET("NSMatrix flagDefaults")
@@ -45,6 +44,5 @@ int main()
 
   END_SET("NSMatrix flagDefaults")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMatrix/grid.m
+++ b/Tests/gui/NSMatrix/grid.m
@@ -17,8 +17,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSMatrix grid")
 
   NS_DURING
@@ -105,6 +103,5 @@ main(int argc, char **argv)
 
   END_SET("NSMatrix grid")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMatrix/listSingleSelect.m
+++ b/Tests/gui/NSMatrix/listSingleSelect.m
@@ -12,8 +12,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSMatrix list single selection")
 
   NS_DURING
@@ -45,6 +43,5 @@ main(int argc, char **argv)
 
   END_SET("NSMatrix list single selection")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMatrix/radio.m
+++ b/Tests/gui/NSMatrix/radio.m
@@ -14,7 +14,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSMatrix *r;
   NSButtonCell *proto;
 
@@ -73,6 +72,5 @@ int main()
 
   END_SET("NSMatrix radio")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMatrix/rendering.m
+++ b/Tests/gui/NSMatrix/rendering.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSMatrix rendering")
 
   NS_DURING
@@ -55,6 +54,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSMatrix rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMatrix/selection.m
+++ b/Tests/gui/NSMatrix/selection.m
@@ -32,8 +32,6 @@ matrix(NSMatrixMode mode)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSMatrix cell selection")
 
   NS_DURING
@@ -129,6 +127,5 @@ main(int argc, char **argv)
 
   END_SET("NSMatrix cell selection")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMatrix/state.m
+++ b/Tests/gui/NSMatrix/state.m
@@ -12,7 +12,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSMatrix *m;
 
   START_SET("NSMatrix state")
@@ -67,6 +66,5 @@ int main()
 
   END_SET("NSMatrix state")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMatrix/toolTips.m
+++ b/Tests/gui/NSMatrix/toolTips.m
@@ -12,7 +12,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSMatrix *m;
   NSCell *c0, *c1;
 
@@ -56,6 +55,5 @@ int main()
 
   END_SET("NSMatrix toolTips")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMenu/performAction.m
+++ b/Tests/gui/NSMenu/performAction.m
@@ -47,7 +47,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   Recorder *r;
   NSMenu *menu;
   NSMenuItem *item;
@@ -113,6 +112,5 @@ main(int argc, const char **argv)
 
   END_SET("NSMenu performAction")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMenu/submenuTitle.m
+++ b/Tests/gui/NSMenu/submenuTitle.m
@@ -11,8 +11,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSMenu submenu title")
 
   NS_DURING
@@ -58,6 +56,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSMenu submenu title")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMenuItemCell/backgroundRadius.m
+++ b/Tests/gui/NSMenuItemCell/backgroundRadius.m
@@ -94,8 +94,6 @@ isRed(NSColor *c)
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSMenuItemCell background radius")
 
   NS_DURING
@@ -135,6 +133,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSMenuItemCell background radius")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMenuItemCell/basic.m
+++ b/Tests/gui/NSMenuItemCell/basic.m
@@ -11,8 +11,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSMenuItemCell basic")
 
   NS_DURING
@@ -55,6 +53,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSMenuItemCell basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMenuItemCell/textColor.m
+++ b/Tests/gui/NSMenuItemCell/textColor.m
@@ -37,8 +37,6 @@ isRed(NSColor *c)
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSMenuItemCell text colour")
 
   NS_DURING
@@ -75,6 +73,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSMenuItemCell text colour")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMenuToolbarItem/basic.m
+++ b/Tests/gui/NSMenuToolbarItem/basic.m
@@ -15,8 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSMenuToolbarItem basic")
 
   NS_DURING
@@ -50,6 +48,5 @@ main(int argc, char **argv)
 
   END_SET("NSMenuToolbarItem basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMenuToolbarItem/showsIndicator.m
+++ b/Tests/gui/NSMenuToolbarItem/showsIndicator.m
@@ -13,8 +13,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("showsIndicator default")
 
   NS_DURING
@@ -40,6 +38,5 @@ main(int argc, char **argv)
 
   END_SET("showsIndicator default")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMenuView/menuBorderRadius.m
+++ b/Tests/gui/NSMenuView/menuBorderRadius.m
@@ -93,8 +93,6 @@ isWhite(NSColor *c)
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSMenuView border radius")
 
   NS_DURING
@@ -132,6 +130,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSMenuView border radius")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSMenuView/menuItemAreaInsets.m
+++ b/Tests/gui/NSMenuView/menuItemAreaInsets.m
@@ -26,8 +26,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSMenuView item area insets")
 
   NS_DURING
@@ -80,6 +78,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSMenuView item area insets")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSNibConnector/basic.m
+++ b/Tests/gui/NSNibConnector/basic.m
@@ -11,8 +11,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("a new connector")
     NSNibConnector	*connector;
 
@@ -133,6 +131,5 @@ main(int argc, char **argv)
       "the archived connector keeps its label");
   END_SET("archiving")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSNibLoading/basic.m
+++ b/Tests/gui/NSNibLoading/basic.m
@@ -16,7 +16,6 @@
 
 int main()
 {
-  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
   NSArray		**testObjects = NULL;
   BOOL 			success = NO;
   NSFileManager		*mgr = [NSFileManager defaultManager];
@@ -77,6 +76,5 @@ int main()
   
   END_SET("NSNibLoading GNUstep basic")
 
-  [arp release];
   return 0;
 }

--- a/Tests/gui/NSNibLoading/basic.m
+++ b/Tests/gui/NSNibLoading/basic.m
@@ -16,13 +16,13 @@
 
 int main()
 {
+  START_SET("NSNibLoading GNUstep basic")
+
   NSArray		**testObjects = NULL;
   BOOL 			success = NO;
   NSFileManager		*mgr = [NSFileManager defaultManager];
   NSString 		*path = [mgr currentDirectoryPath];
   NSBundle 		*bundle = [[NSBundle alloc] initWithPath: path];
-
-  START_SET("NSNibLoading GNUstep basic")
 
   NS_DURING
     {

--- a/Tests/gui/NSObjectController/basic.m
+++ b/Tests/gui/NSObjectController/basic.m
@@ -10,8 +10,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("defaults")
     NSObjectController	*oc = AUTORELEASE([[NSObjectController alloc] init]);
 
@@ -68,6 +66,5 @@ main(int argc, char **argv)
     PASS([oc content] == nil, "removeObject: clears the content");
   END_SET("addObject: and removeObject:")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSOpenGLView/config.m
+++ b/Tests/gui/NSOpenGLView/config.m
@@ -11,7 +11,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSOpenGLView config")
 
   NS_DURING
@@ -52,6 +51,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSOpenGLView config")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSOpenPanel/canChooseDirectories.m
+++ b/Tests/gui/NSOpenPanel/canChooseDirectories.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSOpenPanel canChooseDirectories default")
 
   NS_DURING
@@ -35,6 +34,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSOpenPanel canChooseDirectories default")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSOpenPanel/config.m
+++ b/Tests/gui/NSOpenPanel/config.m
@@ -11,7 +11,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSOpenPanel config")
 
   NS_DURING
@@ -48,6 +47,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSOpenPanel config")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSOpenPanel/interact.m
+++ b/Tests/gui/NSOpenPanel/interact.m
@@ -16,7 +16,6 @@ dummyDir(void)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSOpenPanel interaction")
 
   NS_DURING
@@ -62,6 +61,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSOpenPanel interaction")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSOpenPanel/render.m
+++ b/Tests/gui/NSOpenPanel/render.m
@@ -16,7 +16,6 @@ dummyDir(void)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSOpenPanel render")
 
   NS_DURING
@@ -63,6 +62,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSOpenPanel render")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSOpenPanel/resolvesAliases.m
+++ b/Tests/gui/NSOpenPanel/resolvesAliases.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSOpenPanel resolvesAliases")
 
   NS_DURING
@@ -38,6 +37,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSOpenPanel resolvesAliases")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSOutlineView/autoresizesOutlineColumnDefault.m
+++ b/Tests/gui/NSOutlineView/autoresizesOutlineColumnDefault.m
@@ -9,7 +9,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSOutlineView *ov;
 
   START_SET("NSOutlineView autoresizesOutlineColumnDefault")
@@ -40,6 +39,5 @@ int main()
 
   END_SET("NSOutlineView autoresizesOutlineColumnDefault")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSOutlineView/binding.m
+++ b/Tests/gui/NSOutlineView/binding.m
@@ -62,7 +62,6 @@ node(NSString *aName)
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSOutlineView		*ov;
   NSTableColumn		*col;
   NSTreeController	*tc;
@@ -133,7 +132,6 @@ withKeyPath: @"arrangedObjects"
 
   END_SET("NSOutlineView content binding")
 
-  DESTROY(arp);
 
   return 0;
 }

--- a/Tests/gui/NSOutlineView/expandNotification.m
+++ b/Tests/gui/NSOutlineView/expandNotification.m
@@ -73,7 +73,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   Tree *ds;
   Recorder *r;
   NSOutlineView *ov;
@@ -151,6 +150,5 @@ main(int argc, char **argv)
 
   END_SET("NSOutlineView expand notification")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSOutlineView/exposedBindings.m
+++ b/Tests/gui/NSOutlineView/exposedBindings.m
@@ -34,7 +34,6 @@ occurrences(NSArray *array, NSString *name)
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSOutlineView	*ov;
   NSArray	*exposed;
 
@@ -64,7 +63,6 @@ int main()
 
   END_SET("NSOutlineView exposed bindings are not repeated")
 
-  DESTROY(arp);
 
   return 0;
 }

--- a/Tests/gui/NSOutlineView/rendering.m
+++ b/Tests/gui/NSOutlineView/rendering.m
@@ -33,7 +33,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSOutlineView rendering")
 
   NS_DURING
@@ -81,6 +80,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSOutlineView rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSOutlineView/state.m
+++ b/Tests/gui/NSOutlineView/state.m
@@ -12,7 +12,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSOutlineView *ov;
 
   START_SET("NSOutlineView state")
@@ -53,6 +52,5 @@ int main()
 
   END_SET("NSOutlineView state")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSOutlineView/tree.m
+++ b/Tests/gui/NSOutlineView/tree.m
@@ -37,7 +37,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSOutlineView *ov;
   NSTableColumn *col;
   Tree *ds;
@@ -93,6 +92,5 @@ int main()
 
   END_SET("NSOutlineView tree")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSOutlineView/variableRowHeights.m
+++ b/Tests/gui/NSOutlineView/variableRowHeights.m
@@ -148,7 +148,6 @@
 
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
   NSOutlineView *outlineView;
   TestDataSource *dataSource;
   TestDelegate *delegate;
@@ -287,6 +286,5 @@ int main()
 
   END_SET("NSOutlineView variable row heights")
 
-  [arp release];
   return 0;
 }

--- a/Tests/gui/NSPageController/basic.m
+++ b/Tests/gui/NSPageController/basic.m
@@ -15,8 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSPageController basic")
 
   NS_DURING
@@ -76,6 +74,5 @@ main(int argc, char **argv)
 
   END_SET("NSPageController basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPageController/selection.m
+++ b/Tests/gui/NSPageController/selection.m
@@ -91,8 +91,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("selection")
 
   NS_DURING
@@ -207,6 +205,5 @@ main(int argc, char **argv)
 
   END_SET("selection")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPanel/behaviour.m
+++ b/Tests/gui/NSPanel/behaviour.m
@@ -12,7 +12,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSPanel behaviour")
 
   NS_DURING
@@ -57,6 +56,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSPanel behaviour")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPanel/config.m
+++ b/Tests/gui/NSPanel/config.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSPanel config")
 
   NS_DURING
@@ -75,6 +74,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSPanel config")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPanel/interact.m
+++ b/Tests/gui/NSPanel/interact.m
@@ -27,7 +27,6 @@ escapeFor(NSWindow *w)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSPanel interact")
 
   NS_DURING
@@ -69,6 +68,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSPanel interact")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPanel/render.m
+++ b/Tests/gui/NSPanel/render.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSPanel render")
 
   NS_DURING
@@ -64,6 +63,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSPanel render")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSParagraphStyle/NSParagraphStyle_equalityTesting.m
+++ b/Tests/gui/NSParagraphStyle/NSParagraphStyle_equalityTesting.m
@@ -7,8 +7,6 @@
 
 int main(int argc, char **argv)
 {    
-  CREATE_AUTORELEASE_POOL(arp);
-    
   START_SET("NSParagraphStyle equality tests");
   
   NSMutableParagraphStyle *default1 = [NSParagraphStyle defaultParagraphStyle];
@@ -71,7 +69,6 @@ int main(int argc, char **argv)
 
   END_SET("NSParagraphStyle equality tests");
   
-  DESTROY(arp);
   
   return 0;
 }

--- a/Tests/gui/NSParagraphStyle/tabStopOrder.m
+++ b/Tests/gui/NSParagraphStyle/tabStopOrder.m
@@ -26,8 +26,6 @@ tab(CGFloat loc)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSParagraphStyle tab stop order")
 
   {
@@ -41,6 +39,5 @@ main(int argc, char **argv)
 
   END_SET("NSParagraphStyle tab stop order")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSParagraphStyle/tabStops.m
+++ b/Tests/gui/NSParagraphStyle/tabStops.m
@@ -33,8 +33,6 @@ tab(CGFloat loc)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSParagraphStyle tab stops")
 
   /* The default paragraph style has twelve tab stops every 28 points and a
@@ -97,6 +95,5 @@ main(int argc, char **argv)
 
   END_SET("NSParagraphStyle tab stops")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPathCell/basic.m
+++ b/Tests/gui/NSPathCell/basic.m
@@ -14,14 +14,16 @@
 
 int main(int argc, const char **argv)
 {
-  /* Enum values match AppKit; these need no backend. */
-  PASS(NSPathStyleStandard == 0, "NSPathStyleStandard is 0");
-  PASS(NSPathStyleNavigationBar == 1, "NSPathStyleNavigationBar is 1");
-  PASS(NSPathStylePopUp == 2, "NSPathStylePopUp is 2");
+  START_SET("NSPathCell enum")
+    /* Enum values match AppKit; these need no backend. */
+    PASS(NSPathStyleStandard == 0, "NSPathStyleStandard is 0");
+    PASS(NSPathStyleNavigationBar == 1, "NSPathStyleNavigationBar is 1");
+    PASS(NSPathStylePopUp == 2, "NSPathStylePopUp is 2");
 
   /* Class method; needs no backend. */
   PASS([NSPathCell pathComponentCellClass] == [NSPathComponentCell class],
        "+pathComponentCellClass is NSPathComponentCell");
+  END_SET("NSPathCell enum")
 
   START_SET("NSPathCell basic")
 

--- a/Tests/gui/NSPathCell/basic.m
+++ b/Tests/gui/NSPathCell/basic.m
@@ -14,8 +14,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   /* Enum values match AppKit; these need no backend. */
   PASS(NSPathStyleStandard == 0, "NSPathStyleStandard is 0");
   PASS(NSPathStyleNavigationBar == 1, "NSPathStyleNavigationBar is 1");
@@ -70,6 +68,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSPathCell basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPathCell/pathcomponentcells.m
+++ b/Tests/gui/NSPathCell/pathcomponentcells.m
@@ -7,8 +7,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSPathCell pathComponentCells")
 
   NS_DURING
@@ -29,6 +27,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSPathCell pathComponentCells")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPathComponentCell/basic.m
+++ b/Tests/gui/NSPathComponentCell/basic.m
@@ -15,7 +15,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSPathComponentCell *cell;
   NSImage *img;
   NSURL *url;
@@ -54,6 +53,5 @@ int main()
 
   END_SET("NSPathComponentCell basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPathComponentCell/imageRetain.m
+++ b/Tests/gui/NSPathComponentCell/imageRetain.m
@@ -11,7 +11,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSPathComponentCell *cell;
   NSImage *img;
 
@@ -31,6 +30,5 @@ int main()
 
   END_SET("NSPathComponentCell imageRetain")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPathControl/basic.m
+++ b/Tests/gui/NSPathControl/basic.m
@@ -11,8 +11,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   /* Enum values match AppKit; these need no backend. */
   PASS(NSPathStyleStandard == 0, "NSPathStyleStandard is 0");
   PASS(NSPathStyleNavigationBar == 1, "NSPathStyleNavigationBar is 1");
@@ -55,6 +53,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSPathControl basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPathControl/basic.m
+++ b/Tests/gui/NSPathControl/basic.m
@@ -11,10 +11,12 @@
 
 int main(int argc, const char **argv)
 {
-  /* Enum values match AppKit; these need no backend. */
-  PASS(NSPathStyleStandard == 0, "NSPathStyleStandard is 0");
-  PASS(NSPathStyleNavigationBar == 1, "NSPathStyleNavigationBar is 1");
-  PASS(NSPathStylePopUp == 2, "NSPathStylePopUp is 2");
+  START_SET("NSPathControl enum")
+    /* Enum values match AppKit; these need no backend. */
+    PASS(NSPathStyleStandard == 0, "NSPathStyleStandard is 0");
+    PASS(NSPathStyleNavigationBar == 1, "NSPathStyleNavigationBar is 1");
+    PASS(NSPathStylePopUp == 2, "NSPathStylePopUp is 2");
+  END_SET("NSPathControl enum")
 
   START_SET("NSPathControl basic")
 

--- a/Tests/gui/NSPathControl/editable.m
+++ b/Tests/gui/NSPathControl/editable.m
@@ -7,8 +7,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSPathControl editable")
 
   NS_DURING
@@ -33,6 +31,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSPathControl editable")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPathControl/pathitems.m
+++ b/Tests/gui/NSPathControl/pathitems.m
@@ -8,8 +8,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSPathControl pathItems")
 
   NS_DURING
@@ -29,6 +27,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSPathControl pathItems")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPopUpButton/defaultSelection.m
+++ b/Tests/gui/NSPopUpButton/defaultSelection.m
@@ -9,7 +9,6 @@ copyright 2005 Alexander Malmberg <alexander@malmberg.org>
 
 int main(int argc, char **argv)
 {
-  ENTER_POOL
   NSPopUpButton *b;
 
   START_SET("NSPopupButton GNUstep defaultSelection")
@@ -34,7 +33,6 @@ int main(int argc, char **argv)
 
   END_SET("NSPopupButton GNUstep defaultSelection")
 
-  LEAVE_POOL
 
   return 0;
 }

--- a/Tests/gui/NSPopUpButton/interact.m
+++ b/Tests/gui/NSPopUpButton/interact.m
@@ -15,7 +15,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSPopUpButton *b;
 
   START_SET("NSPopUpButton interaction")
@@ -59,6 +58,5 @@ main(int argc, const char **argv)
 
   END_SET("NSPopUpButton interaction")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPopUpButtonCell/menu.m
+++ b/Tests/gui/NSPopUpButtonCell/menu.m
@@ -23,7 +23,6 @@ popup(void)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSPopUpButtonCell *cell;
 
   START_SET("NSPopUpButtonCell menu")
@@ -118,6 +117,5 @@ main(int argc, char **argv)
 
   END_SET("NSPopUpButtonCell menu")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPopUpButtonCell/removeSelected.m
+++ b/Tests/gui/NSPopUpButtonCell/removeSelected.m
@@ -23,8 +23,6 @@ popup(void)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSPopUpButtonCell remove selected")
 
   NS_DURING
@@ -84,6 +82,5 @@ main(int argc, char **argv)
 
   END_SET("NSPopUpButtonCell remove selected")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPrintInfo/dictionary.m
+++ b/Tests/gui/NSPrintInfo/dictionary.m
@@ -18,7 +18,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSPrintInfo *info;
   NSSize size;
 
@@ -118,6 +117,5 @@ int main()
 
   END_SET("NSPrintInfo dictionary")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSPrinter/badPPD.m
+++ b/Tests/gui/NSPrinter/badPPD.m
@@ -16,8 +16,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSPrinter missing PPD")
 
   NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
@@ -58,6 +56,5 @@ main(int argc, char **argv)
 
   END_SET("NSPrinter missing PPD")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSProgressIndicator/progress.m
+++ b/Tests/gui/NSProgressIndicator/progress.m
@@ -18,7 +18,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSProgressIndicator *pi;
 
   START_SET("NSProgressIndicator progress")
@@ -102,6 +101,5 @@ main(int argc, char **argv)
 
   END_SET("NSProgressIndicator progress")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSProgressIndicator/rendering.m
+++ b/Tests/gui/NSProgressIndicator/rendering.m
@@ -14,7 +14,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSProgressIndicator rendering")
 
   NS_DURING
@@ -55,6 +54,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSProgressIndicator rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSResponder/chain.m
+++ b/Tests/gui/NSResponder/chain.m
@@ -19,7 +19,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSResponder chain")
 
   NSResponder *r = AUTORELEASE([NSResponder new]);
@@ -64,6 +63,5 @@ main(int argc, const char **argv)
     "default keyDown: forwards the event to nextResponder");
 
   END_SET("NSResponder chain")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSResponder/firstResponder.m
+++ b/Tests/gui/NSResponder/firstResponder.m
@@ -6,7 +6,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSResponder first responder")
 
   NSResponder *r = AUTORELEASE([NSResponder new]);
@@ -25,6 +24,5 @@ main(int argc, const char **argv)
     "validRequestorForSendType:returnType: defaults to nil");
 
   END_SET("NSResponder first responder")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSResponder/firstResponderValidation.m
+++ b/Tests/gui/NSResponder/firstResponderValidation.m
@@ -5,7 +5,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSResponder first responder validation")
 
   NSResponder *r = AUTORELEASE([NSResponder new]);
@@ -20,6 +19,5 @@ main(int argc, const char **argv)
     "supplementalTargetForAction:sender: returns nil by default");
 
   END_SET("NSResponder first responder validation")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSResponder/gestureEvents.m
+++ b/Tests/gui/NSResponder/gestureEvents.m
@@ -27,7 +27,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSResponder gesture events")
 
   /* NSResponder implements the gesture, touch, cursor-update and pressure
@@ -88,6 +87,5 @@ main(int argc, const char **argv)
     "default pressureChangeWithEvent: forwards to nextResponder");
 
   END_SET("NSResponder gesture events")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSRulerMarker/basic.m
+++ b/Tests/gui/NSRulerMarker/basic.m
@@ -18,7 +18,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSScrollView *sv;
   NSRulerView *rv;
   NSImage *img;
@@ -97,6 +96,5 @@ int main()
 
   END_SET("NSRulerMarker basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSRulerView/render.m
+++ b/Tests/gui/NSRulerView/render.m
@@ -12,7 +12,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSRulerView render")
 
   NS_DURING
@@ -62,6 +61,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSRulerView render")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSavePanel/canCreateDirectories.m
+++ b/Tests/gui/NSSavePanel/canCreateDirectories.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSavePanel canCreateDirectories default")
 
   NS_DURING
@@ -34,6 +33,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSavePanel canCreateDirectories default")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSavePanel/config.m
+++ b/Tests/gui/NSSavePanel/config.m
@@ -14,7 +14,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSavePanel config")
 
   NS_DURING
@@ -69,6 +68,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSavePanel config")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSavePanel/interact.m
+++ b/Tests/gui/NSSavePanel/interact.m
@@ -17,7 +17,6 @@ dummyDir(void)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSavePanel interaction")
 
   NS_DURING
@@ -59,6 +58,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSavePanel interaction")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSavePanel/message.m
+++ b/Tests/gui/NSSavePanel/message.m
@@ -11,7 +11,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSavePanel message")
 
   NS_DURING
@@ -41,6 +40,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSavePanel message")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSavePanel/render.m
+++ b/Tests/gui/NSSavePanel/render.m
@@ -19,7 +19,6 @@ dummyDir(void)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSavePanel render")
 
   NS_DURING
@@ -79,6 +78,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSavePanel render")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSavePanel/setDelegate_reload.m
+++ b/Tests/gui/NSSavePanel/setDelegate_reload.m
@@ -57,7 +57,6 @@ shouldShowFilename: (NSString *)fname
 
 int main(int argc, char **argv)
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
   NSSavePanel *p;
   NSMatrix *m;
 
@@ -115,6 +114,5 @@ int main(int argc, char **argv)
 
   END_SET("NSSavePanel GNUstep setDelegate")
 
-  [arp release];
   return 0;
 }

--- a/Tests/gui/NSScrollView/autohidesScrollers.m
+++ b/Tests/gui/NSScrollView/autohidesScrollers.m
@@ -44,7 +44,6 @@ layoutScrollView(NSSize frame, NSSize document, BOOL wantHoriz, BOOL wantVert,
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSScrollView autohidesScrollers")
 
   NS_DURING
@@ -125,6 +124,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSScrollView autohidesScrollers")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSScrollView/geometry.m
+++ b/Tests/gui/NSScrollView/geometry.m
@@ -7,7 +7,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSScrollView geometry")
 
   NS_DURING
@@ -49,6 +48,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSScrollView geometry")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSScrollView/rendering.m
+++ b/Tests/gui/NSScrollView/rendering.m
@@ -12,7 +12,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSScrollView rendering")
 
   NS_DURING
@@ -60,6 +59,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSScrollView rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSScrollView/scroll.m
+++ b/Tests/gui/NSScrollView/scroll.m
@@ -8,7 +8,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSScrollView scroll")
 
   NS_DURING
@@ -42,6 +41,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSScrollView scroll")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSScrollView/structure.m
+++ b/Tests/gui/NSScrollView/structure.m
@@ -9,7 +9,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSScrollView structure")
 
   NS_DURING
@@ -54,6 +53,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSScrollView structure")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSScroller/clampFloatValue.m
+++ b/Tests/gui/NSScroller/clampFloatValue.m
@@ -19,8 +19,6 @@ eq(CGFloat a, CGFloat b)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSScroller clamp float value")
 
   NS_DURING
@@ -50,6 +48,5 @@ main(int argc, char **argv)
 
   END_SET("NSScroller clamp float value")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSScroller/value.m
+++ b/Tests/gui/NSScroller/value.m
@@ -23,8 +23,6 @@ eq(CGFloat a, CGFloat b)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSScroller value")
 
   NS_DURING
@@ -88,6 +86,5 @@ main(int argc, char **argv)
 
   END_SET("NSScroller value")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSearchField/searchfield.m
+++ b/Tests/gui/NSSearchField/searchfield.m
@@ -19,7 +19,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSearchField *sf;
 
   START_SET("NSSearchField search")
@@ -78,6 +77,5 @@ main(int argc, char **argv)
 
   END_SET("NSSearchField search")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSearchFieldCell/autosaveName.m
+++ b/Tests/gui/NSSearchFieldCell/autosaveName.m
@@ -15,8 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("the recents autosave name")
 
   NS_DURING
@@ -62,6 +60,5 @@ main(int argc, char **argv)
 
   END_SET("the recents autosave name")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSearchFieldCell/basic.m
+++ b/Tests/gui/NSSearchFieldCell/basic.m
@@ -16,8 +16,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSSearchFieldCell basic")
 
   NS_DURING
@@ -97,6 +95,5 @@ main(int argc, char **argv)
 
   END_SET("NSSearchFieldCell basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSearchFieldCell/recentSearchesEmpty.m
+++ b/Tests/gui/NSSearchFieldCell/recentSearchesEmpty.m
@@ -13,8 +13,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("empty recent searches")
 
   NS_DURING
@@ -44,6 +42,5 @@ main(int argc, char **argv)
 
   END_SET("empty recent searches")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSecureTextField/echo.m
+++ b/Tests/gui/NSSecureTextField/echo.m
@@ -19,7 +19,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSecureTextField *field;
   NSSecureTextFieldCell *cell;
 
@@ -99,6 +98,5 @@ int main()
 
   END_SET("NSSecureTextField echo")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSecureTextField/echosBulletsDefault.m
+++ b/Tests/gui/NSSecureTextField/echosBulletsDefault.m
@@ -12,8 +12,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSSecureTextFieldCell default echosBullets")
 
   NS_DURING
@@ -34,6 +32,5 @@ int main()
 
   END_SET("NSSecureTextFieldCell default echosBullets")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSegmentedCell/model.m
+++ b/Tests/gui/NSSegmentedCell/model.m
@@ -15,7 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSegmentedCell *cell;
 
   START_SET("NSSegmentedCell model")
@@ -86,6 +85,5 @@ main(int argc, char **argv)
 
   END_SET("NSSegmentedCell model")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSegmentedCell/selectAny.m
+++ b/Tests/gui/NSSegmentedCell/selectAny.m
@@ -16,7 +16,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSegmentedCell *cell;
 
   START_SET("NSSegmentedCell selectAny")
@@ -61,6 +60,5 @@ main(int argc, char **argv)
 
   END_SET("NSSegmentedCell selectAny")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSegmentedControl/convenienceConstructors.m
+++ b/Tests/gui/NSSegmentedControl/convenienceConstructors.m
@@ -24,7 +24,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   SegTarget *t;
 
   START_SET("NSSegmentedControl convenience constructors")
@@ -78,6 +77,5 @@ main(int argc, const char **argv)
 
   END_SET("NSSegmentedControl convenience constructors")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSegmentedControl/multiSelect.m
+++ b/Tests/gui/NSSegmentedControl/multiSelect.m
@@ -24,7 +24,6 @@ control(NSInteger count)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSegmentedControl *sc;
 
   START_SET("NSSegmentedControl multiSelect")
@@ -84,6 +83,5 @@ main(int argc, char **argv)
 
   END_SET("NSSegmentedControl multiSelect")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSegmentedControl/rendering.m
+++ b/Tests/gui/NSSegmentedControl/rendering.m
@@ -14,7 +14,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSegmentedControl rendering")
 
   NS_DURING
@@ -54,6 +53,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSegmentedControl rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSegmentedControl/segments.m
+++ b/Tests/gui/NSSegmentedControl/segments.m
@@ -18,7 +18,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSegmentedControl *sc;
 
   START_SET("NSSegmentedControl segments")
@@ -96,6 +95,5 @@ main(int argc, char **argv)
 
   END_SET("NSSegmentedControl segments")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSegmentedControl/sizeToFit.m
+++ b/Tests/gui/NSSegmentedControl/sizeToFit.m
@@ -26,7 +26,6 @@ control(NSInteger count)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSegmentedControl *three;
   NSSegmentedControl *one;
   NSSegmentedControl *longLabels;
@@ -90,6 +89,5 @@ main(int argc, char **argv)
 
   END_SET("NSSegmentedControl sizeToFit")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSShadow/basic.m
+++ b/Tests/gui/NSShadow/basic.m
@@ -12,8 +12,6 @@
 
 int main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("defaults")
     NSShadow	*s = [[[NSShadow alloc] init] autorelease];
     NSSize	off = [s shadowOffset];
@@ -105,6 +103,5 @@ int main(int argc, char **argv)
       "non-keyed archiving preserves the colour");
   END_SET("non-keyed archiving round-trip")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSlider/convenienceConstructors.m
+++ b/Tests/gui/NSSlider/convenienceConstructors.m
@@ -22,7 +22,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   SliderTarget *t;
 
   START_SET("NSSlider convenience constructors")
@@ -60,6 +59,5 @@ main(int argc, const char **argv)
 
   END_SET("NSSlider convenience constructors")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSlider/interact.m
+++ b/Tests/gui/NSSlider/interact.m
@@ -31,7 +31,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   SlideTarget *t;
   NSSlider *sl;
   NSWindow *w;
@@ -91,6 +90,5 @@ main(int argc, const char **argv)
 
   END_SET("NSSlider interaction")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSlider/rendering.m
+++ b/Tests/gui/NSSlider/rendering.m
@@ -14,7 +14,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSlider rendering")
 
   NS_DURING
@@ -54,6 +53,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSlider rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSlider/slider.m
+++ b/Tests/gui/NSSlider/slider.m
@@ -17,7 +17,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSlider *s;
 
   START_SET("NSSlider slider")
@@ -90,6 +89,5 @@ main(int argc, char **argv)
 
   END_SET("NSSlider slider")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSliderCell/minMax.m
+++ b/Tests/gui/NSSliderCell/minMax.m
@@ -9,7 +9,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSliderCell *cell;
 
   START_SET("NSSliderCell GNUstep minMax")
@@ -134,7 +133,6 @@ int main()
 
   END_SET("NSSliderCell GNUstep minMax")
 
-  DESTROY(arp);
   return 0;
 }
 

--- a/Tests/gui/NSSliderCell/tickMarks.m
+++ b/Tests/gui/NSSliderCell/tickMarks.m
@@ -19,7 +19,6 @@ eq(double a, double b)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSliderCell *cell;
 
   START_SET("NSSliderCell tick marks")
@@ -112,6 +111,5 @@ main(int argc, char **argv)
 
   END_SET("NSSliderCell tick marks")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSliderCell/tickRounding.m
+++ b/Tests/gui/NSSliderCell/tickRounding.m
@@ -18,7 +18,6 @@ eq(double a, double b)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSliderCell *cell;
 
   START_SET("NSSliderCell tick rounding")
@@ -50,6 +49,5 @@ main(int argc, char **argv)
 
   END_SET("NSSliderCell tick rounding")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSplitView/rendering.m
+++ b/Tests/gui/NSSplitView/rendering.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSplitView rendering")
 
   NS_DURING
@@ -55,6 +54,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSplitView rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSplitView/resizeNotification.m
+++ b/Tests/gui/NSSplitView/resizeNotification.m
@@ -53,7 +53,6 @@ observe(NSNotificationCenter *nc, Recorder *r, NSSplitView *sv)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   Recorder *r, *r2;
   NSSplitView *sv, *empty;
   NSNotificationCenter *nc;
@@ -115,6 +114,5 @@ main(int argc, char **argv)
 
   END_SET("NSSplitView resize notification")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSplitView/state.m
+++ b/Tests/gui/NSSplitView/state.m
@@ -14,7 +14,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSplitView *sv;
 
   START_SET("NSSplitView state")
@@ -64,6 +63,5 @@ int main()
 
   END_SET("NSSplitView state")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSplitView/structure.m
+++ b/Tests/gui/NSSplitView/structure.m
@@ -12,7 +12,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSplitView *sv;
   NSView *a, *b;
 
@@ -51,6 +50,5 @@ int main()
 
   END_SET("NSSplitView structure")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSplitViewController/addItems.m
+++ b/Tests/gui/NSSplitViewController/addItems.m
@@ -24,7 +24,6 @@ anItem(void)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSplitViewController add items")
 
   NS_DURING
@@ -62,6 +61,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSplitViewController add items")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSplitViewController/coding.m
+++ b/Tests/gui/NSSplitViewController/coding.m
@@ -14,7 +14,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSplitViewController *svc;
   NSSplitViewController *decoded;
   NSSplitView *before;
@@ -45,6 +44,5 @@ int main()
 
   END_SET("NSSplitViewController coding")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSplitViewController/items.m
+++ b/Tests/gui/NSSplitViewController/items.m
@@ -28,7 +28,6 @@ itemForController(NSViewController **outVC)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSplitViewController items")
 
   NS_DURING
@@ -70,6 +69,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSplitViewController items")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSplitViewController/loadView.m
+++ b/Tests/gui/NSSplitViewController/loadView.m
@@ -11,7 +11,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSplitViewController loadView")
 
   NS_DURING
@@ -36,6 +35,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSplitViewController loadView")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSplitViewController/render.m
+++ b/Tests/gui/NSSplitViewController/render.m
@@ -11,7 +11,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSplitViewController render")
 
   NS_DURING
@@ -60,6 +59,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSplitViewController render")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSplitViewItem/behavior.m
+++ b/Tests/gui/NSSplitViewItem/behavior.m
@@ -27,7 +27,6 @@ controllerWithView(void)
 int
 main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSViewController *vc;
   NSSplitViewItem *item;
   NSSplitViewItem *side;
@@ -91,6 +90,5 @@ main()
 
   END_SET("NSSplitViewItem behavior")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSStackView/coding.m
+++ b/Tests/gui/NSStackView/coding.m
@@ -19,7 +19,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSStackView *sv;
   NSStackView *decoded;
   NSView *v1;
@@ -70,6 +69,5 @@ int main()
 
   END_SET("NSStackView coding")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSStackView/defaults.m
+++ b/Tests/gui/NSStackView/defaults.m
@@ -11,7 +11,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSStackView *sv;
 
   START_SET("NSStackView defaults")
@@ -47,6 +46,5 @@ int main()
 
   END_SET("NSStackView defaults")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSStackView/emptyMutation.m
+++ b/Tests/gui/NSStackView/emptyMutation.m
@@ -13,7 +13,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSStackView *sv;
 
   START_SET("NSStackView emptyMutation")
@@ -56,6 +55,5 @@ int main()
 
   END_SET("NSStackView emptyMutation")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSStackView/membership.m
+++ b/Tests/gui/NSStackView/membership.m
@@ -18,7 +18,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSStackView *sv;
   NSView *a, *b, *c, *d;
 
@@ -89,6 +88,5 @@ int main()
 
   END_SET("NSStackView membership")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSStackView/rendering.m
+++ b/Tests/gui/NSStackView/rendering.m
@@ -10,7 +10,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSStackView rendering")
 
   NS_DURING
@@ -50,6 +49,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSStackView rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSStackView/state.m
+++ b/Tests/gui/NSStackView/state.m
@@ -13,7 +13,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSStackView *sv;
 
   START_SET("NSStackView state")
@@ -45,6 +44,5 @@ int main()
 
   END_SET("NSStackView state")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSStatusBarButton/statusbarbutton.m
+++ b/Tests/gui/NSStatusBarButton/statusbarbutton.m
@@ -15,7 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSStatusBarButton *b;
 
   START_SET("NSStatusBarButton statusbarbutton")
@@ -58,6 +57,5 @@ main(int argc, char **argv)
 
   END_SET("NSStatusBarButton statusbarbutton")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSStepper/control.m
+++ b/Tests/gui/NSStepper/control.m
@@ -16,7 +16,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSStepper *stepper;
 
   START_SET("NSStepper control")
@@ -70,6 +69,5 @@ main(int argc, char **argv)
 
   END_SET("NSStepper control")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSStepper/interact.m
+++ b/Tests/gui/NSStepper/interact.m
@@ -27,7 +27,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   StepTarget *t;
   NSStepper *st;
   NSWindow *w;
@@ -79,6 +78,5 @@ main(int argc, const char **argv)
 
   END_SET("NSStepper interaction")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSStepperCell/valueLogic.m
+++ b/Tests/gui/NSStepperCell/valueLogic.m
@@ -17,7 +17,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSStepperCell *cell;
 
   START_SET("NSStepperCell value logic")
@@ -145,6 +144,5 @@ int main()
 
   END_SET("NSStepperCell value logic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSwitch/interact.m
+++ b/Tests/gui/NSSwitch/interact.m
@@ -29,7 +29,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSwitch *sw;
   SwitchTarget *t;
 
@@ -84,6 +83,5 @@ main(int argc, char **argv)
 
   END_SET("NSSwitch interaction")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSwitch/rendering.m
+++ b/Tests/gui/NSSwitch/rendering.m
@@ -15,7 +15,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSSwitch rendering")
 
   NS_DURING
@@ -53,6 +52,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSSwitch rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSSwitch/switch.m
+++ b/Tests/gui/NSSwitch/switch.m
@@ -15,7 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSSwitch *sw;
 
   START_SET("NSSwitch switch")
@@ -60,6 +59,5 @@ main(int argc, char **argv)
 
   END_SET("NSSwitch switch")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabView/backgroundDefault.m
+++ b/Tests/gui/NSTabView/backgroundDefault.m
@@ -9,7 +9,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTabView *tv;
 
   START_SET("NSTabView backgroundDefault")
@@ -38,6 +37,5 @@ int main()
 
   END_SET("NSTabView backgroundDefault")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabView/controlSizeTint.m
+++ b/Tests/gui/NSTabView/controlSizeTint.m
@@ -11,7 +11,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTabView *tv;
 
   START_SET("NSTabView controlSizeTint")
@@ -46,6 +45,5 @@ int main()
 
   END_SET("NSTabView controlSizeTint")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabView/defaults.m
+++ b/Tests/gui/NSTabView/defaults.m
@@ -12,7 +12,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTabView *tv;
 
   START_SET("NSTabView defaults")
@@ -64,6 +63,5 @@ int main()
 
   END_SET("NSTabView defaults")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabView/delegate.m
+++ b/Tests/gui/NSTabView/delegate.m
@@ -51,7 +51,6 @@ mk(NSString *ident, NSString *label)
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTabView *tv;
   Recorder *rec;
 
@@ -101,6 +100,5 @@ int main()
 
   END_SET("NSTabView delegate")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabView/rendering.m
+++ b/Tests/gui/NSTabView/rendering.m
@@ -22,7 +22,6 @@ mk(NSString *ident, NSString *label)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSTabView rendering")
 
   NS_DURING
@@ -64,6 +63,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSTabView rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabView/selection.m
+++ b/Tests/gui/NSTabView/selection.m
@@ -25,7 +25,6 @@ mk(NSString *ident, NSString *label)
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTabView *tv;
   NSTabViewItem *a, *b, *c;
 
@@ -90,6 +89,5 @@ int main()
 
   END_SET("NSTabView selection")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabView/structure.m
+++ b/Tests/gui/NSTabView/structure.m
@@ -25,7 +25,6 @@ mk(NSString *ident, NSString *label)
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTabView *tv;
   NSTabViewItem *a, *b, *c, *d;
 
@@ -89,6 +88,5 @@ int main()
 
   END_SET("NSTabView structure")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabViewController/items.m
+++ b/Tests/gui/NSTabViewController/items.m
@@ -27,7 +27,6 @@ itemForController(NSString *ident, NSViewController **outVC)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSTabViewController items")
 
   NS_DURING
@@ -79,6 +78,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSTabViewController items")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabViewController/loadView.m
+++ b/Tests/gui/NSTabViewController/loadView.m
@@ -13,7 +13,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSTabViewController loadView")
 
   NS_DURING
@@ -44,6 +43,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSTabViewController loadView")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabViewController/render.m
+++ b/Tests/gui/NSTabViewController/render.m
@@ -25,7 +25,6 @@ labelledItem(NSString *ident, NSString *label)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSTabViewController render")
 
   NS_DURING
@@ -71,6 +70,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSTabViewController render")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabViewController/selectedIndex.m
+++ b/Tests/gui/NSTabViewController/selectedIndex.m
@@ -9,7 +9,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSTabViewController selected index")
 
   NS_DURING
@@ -36,6 +35,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSTabViewController selected index")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabViewController/titlePropagation.m
+++ b/Tests/gui/NSTabViewController/titlePropagation.m
@@ -13,7 +13,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSTabViewController title propagation")
 
   NS_DURING
@@ -51,6 +50,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSTabViewController title propagation")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabViewItem/basic.m
+++ b/Tests/gui/NSTabViewItem/basic.m
@@ -13,7 +13,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTabViewItem *item;
 
   START_SET("NSTabViewItem basic")
@@ -47,6 +46,5 @@ int main()
 
   END_SET("NSTabViewItem basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTabViewItem/labelDefault.m
+++ b/Tests/gui/NSTabViewItem/labelDefault.m
@@ -9,7 +9,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTabViewItem *item;
 
   START_SET("NSTabViewItem labelDefault")
@@ -27,6 +26,5 @@ int main()
 
   END_SET("NSTabViewItem labelDefault")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableCellView/basic.m
+++ b/Tests/gui/NSTableCellView/basic.m
@@ -20,8 +20,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSTableCellView basic")
 
   NS_DURING
@@ -81,6 +79,5 @@ main(int argc, char **argv)
 
   END_SET("NSTableCellView basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableCellView/rowSizeStyle.m
+++ b/Tests/gui/NSTableCellView/rowSizeStyle.m
@@ -13,8 +13,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("the default row size style")
 
   NS_DURING
@@ -43,6 +41,5 @@ main(int argc, char **argv)
 
   END_SET("the default row size style")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableColumn/model.m
+++ b/Tests/gui/NSTableColumn/model.m
@@ -18,7 +18,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTableColumn *col;
 
   START_SET("NSTableColumn model")
@@ -87,6 +86,5 @@ main(int argc, char **argv)
 
   END_SET("NSTableColumn model")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableColumn/resizableMask.m
+++ b/Tests/gui/NSTableColumn/resizableMask.m
@@ -12,8 +12,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSTableColumn resizable / mask")
 
   NS_DURING
@@ -53,6 +51,5 @@ main(int argc, char **argv)
 
   END_SET("NSTableColumn resizable / mask")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableHeaderCell/headerCell.m
+++ b/Tests/gui/NSTableHeaderCell/headerCell.m
@@ -18,7 +18,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTableHeaderCell *cell;
 
   START_SET("NSTableHeaderCell")
@@ -72,6 +71,5 @@ main(int argc, char **argv)
 
   END_SET("NSTableHeaderCell")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableHeaderView/tableheader.m
+++ b/Tests/gui/NSTableHeaderView/tableheader.m
@@ -20,7 +20,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTableView *tv;
 
   START_SET("NSTableHeaderView tableheader")
@@ -79,6 +78,5 @@ main(int argc, char **argv)
 
   END_SET("NSTableHeaderView tableheader")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableRowView/basic.m
+++ b/Tests/gui/NSTableRowView/basic.m
@@ -16,8 +16,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSTableRowView basic")
 
   NS_DURING
@@ -87,6 +85,5 @@ main(int argc, char **argv)
 
   END_SET("NSTableRowView basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableRowView/selectorNames.m
+++ b/Tests/gui/NSTableRowView/selectorNames.m
@@ -23,8 +23,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("the AppKit selector names")
 
   NS_DURING
@@ -85,6 +83,5 @@ main(int argc, char **argv)
 
   END_SET("the AppKit selector names")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableView/click.m
+++ b/Tests/gui/NSTableView/click.m
@@ -41,7 +41,6 @@ clickRow(NSWindow *w, NSTableView *tv, NSInteger row)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   Source *ds;
   NSTableView *tv;
   NSTableColumn *col;
@@ -95,6 +94,5 @@ main(int argc, const char **argv)
 
   END_SET("NSTableView click")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableView/columnNotification.m
+++ b/Tests/gui/NSTableView/columnNotification.m
@@ -52,7 +52,6 @@ column(NSString *ident)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   Recorder *r;
   NSTableView *tv;
   NSTableColumn *c0;
@@ -124,6 +123,5 @@ main(int argc, char **argv)
 
   END_SET("NSTableView column notification")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableView/columnSelectionDefault.m
+++ b/Tests/gui/NSTableView/columnSelectionDefault.m
@@ -9,7 +9,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTableView *tv;
 
   START_SET("NSTableView columnSelectionDefault")
@@ -40,6 +39,5 @@ int main()
 
   END_SET("NSTableView columnSelectionDefault")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableView/columns.m
+++ b/Tests/gui/NSTableView/columns.m
@@ -22,7 +22,6 @@ mkcol(NSString *ident)
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTableView *tv;
   NSTableColumn *c1, *c2;
 
@@ -70,6 +69,5 @@ int main()
 
   END_SET("NSTableView columns")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableView/gridStyle.m
+++ b/Tests/gui/NSTableView/gridStyle.m
@@ -12,7 +12,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTableView *tv;
 
   START_SET("NSTableView gridStyle")
@@ -57,6 +56,5 @@ int main()
 
   END_SET("NSTableView gridStyle")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableView/indicatorImage.m
+++ b/Tests/gui/NSTableView/indicatorImage.m
@@ -33,7 +33,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTableView *tv;
   NSTableColumn *col;
   ProbeImage *img;
@@ -113,6 +112,5 @@ main(int argc, const char **argv)
 
   END_SET("NSTableView indicator image")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableView/rendering.m
+++ b/Tests/gui/NSTableView/rendering.m
@@ -21,7 +21,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSTableView rendering")
 
   NS_DURING
@@ -67,6 +66,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSTableView rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableView/selection.m
+++ b/Tests/gui/NSTableView/selection.m
@@ -24,7 +24,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTableView *tv;
   TVDS *ds;
   NSTableColumn *col;
@@ -76,6 +75,5 @@ int main()
 
   END_SET("NSTableView selection")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableView/selectionNotification.m
+++ b/Tests/gui/NSTableView/selectionNotification.m
@@ -53,7 +53,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   Source *ds;
   Recorder *r;
   NSTableView *tv;
@@ -128,6 +127,5 @@ main(int argc, char **argv)
 
   END_SET("NSTableView selection notification")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTableView/state.m
+++ b/Tests/gui/NSTableView/state.m
@@ -13,7 +13,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTableView *tv;
 
   START_SET("NSTableView state")
@@ -76,6 +75,5 @@ int main()
 
   END_SET("NSTableView state")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSText/config.m
+++ b/Tests/gui/NSText/config.m
@@ -20,7 +20,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSText *t;
   id delegate;
 
@@ -76,6 +75,5 @@ int main()
 
   END_SET("NSText config")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextAlternatives/basic.m
+++ b/Tests/gui/NSTextAlternatives/basic.m
@@ -48,8 +48,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("a new object")
     NSArray		*alternatives;
     NSTextAlternatives	*alt;
@@ -106,6 +104,5 @@ main(int argc, char **argv)
       "the user info carries the selected alternative string");
   END_SET("noteSelectedAlternativeString:")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextAlternatives/copiesStrings.m
+++ b/Tests/gui/NSTextAlternatives/copiesStrings.m
@@ -10,8 +10,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("mutable strings are copied")
     NSMutableString	*primary;
     NSMutableArray	*alternatives;
@@ -69,6 +67,5 @@ main(int argc, char **argv)
       "copying an immutable array keeps the array passed in");
   END_SET("immutable strings are kept")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextAlternatives/nilPrimaryString.m
+++ b/Tests/gui/NSTextAlternatives/nilPrimaryString.m
@@ -9,8 +9,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("a nil primary string")
     NSArray		*alternatives;
     NSTextAlternatives	*alt;
@@ -45,6 +43,5 @@ main(int argc, char **argv)
       "the primary string reads back when there are no alternatives");
   END_SET("a nil primary string")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextAttachment/basic.m
+++ b/Tests/gui/NSTextAttachment/basic.m
@@ -11,11 +11,11 @@
 int
 main(int argc, char **argv)
 {
+  START_SET("NSTextAttachment")
+
   NSData *data = [@"hello" dataUsingEncoding: NSUTF8StringEncoding];
   NSFileWrapper *fw = AUTORELEASE([[NSFileWrapper alloc]
     initRegularFileWithContents: data]);
-
-  START_SET("NSTextAttachment")
 
   NS_DURING
   {

--- a/Tests/gui/NSTextAttachment/basic.m
+++ b/Tests/gui/NSTextAttachment/basic.m
@@ -11,7 +11,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSData *data = [@"hello" dataUsingEncoding: NSUTF8StringEncoding];
   NSFileWrapper *fw = AUTORELEASE([[NSFileWrapper alloc]
     initRegularFileWithContents: data]);
@@ -66,6 +65,5 @@ main(int argc, char **argv)
 
   END_SET("NSTextAttachment")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextBlock/basic.m
+++ b/Tests/gui/NSTextBlock/basic.m
@@ -15,8 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSTextBlock basic")
 
   NS_DURING
@@ -97,6 +95,5 @@ main(int argc, char **argv)
 
   END_SET("NSTextBlock basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextContainer/basic.m
+++ b/Tests/gui/NSTextContainer/basic.m
@@ -14,8 +14,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("defaults")
     NSTextContainer	*t = AUTORELEASE([[NSTextContainer alloc] init]);
     NSSize		size = [t containerSize];
@@ -76,6 +74,5 @@ main(int argc, char **argv)
       "the far corner is not contained");
   END_SET("containsPoint:")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextField/constructors.m
+++ b/Tests/gui/NSTextField/constructors.m
@@ -23,7 +23,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTextField *label, *field, *wrap, *attr;
 
   START_SET("NSTextField constructors")
@@ -99,6 +98,5 @@ main(int argc, char **argv)
 
   END_SET("NSTextField constructors")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextField/rendering.m
+++ b/Tests/gui/NSTextField/rendering.m
@@ -16,7 +16,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSTextField rendering")
 
   NS_DURING
@@ -65,6 +64,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSTextField rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextField/state.m
+++ b/Tests/gui/NSTextField/state.m
@@ -21,7 +21,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTextField *tf;
 
   START_SET("NSTextField state")
@@ -99,6 +98,5 @@ main(int argc, char **argv)
 
   END_SET("NSTextField state")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextFieldCell/attributes.m
+++ b/Tests/gui/NSTextFieldCell/attributes.m
@@ -17,7 +17,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTextFieldCell *cell;
 
   START_SET("NSTextFieldCell attributes")
@@ -74,6 +73,5 @@ main(int argc, char **argv)
 
   END_SET("NSTextFieldCell attributes")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextFieldCell/defaultTextColor.m
+++ b/Tests/gui/NSTextFieldCell/defaultTextColor.m
@@ -12,8 +12,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSTextFieldCell default text colour")
 
   NS_DURING
@@ -36,6 +34,5 @@ main(int argc, char **argv)
 
   END_SET("NSTextFieldCell default text colour")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextList/basic.m
+++ b/Tests/gui/NSTextList/basic.m
@@ -16,8 +16,6 @@ marker(NSString *fmt, int item)
 
 int main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("accessors")
     NSTextList	*l = [[[NSTextList alloc]
       initWithMarkerFormat: @"{decimal}." options: 7] autorelease];
@@ -101,6 +99,5 @@ int main(int argc, char **argv)
       && 3 == [c listOptions], "copy preserves the marker format and options");
   END_SET("copy")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextStorage/editing.m
+++ b/Tests/gui/NSTextStorage/editing.m
@@ -18,7 +18,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTextStorage *ts;
   NSLayoutManager *lm;
 
@@ -61,6 +60,5 @@ int main()
 
   END_SET("NSTextStorage editing")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextTab/basic.m
+++ b/Tests/gui/NSTextTab/basic.m
@@ -13,8 +13,6 @@
 
 int main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("initWithType:location: maps type to alignment")
     NSTextTab	*t;
 
@@ -139,6 +137,5 @@ int main(int argc, char **argv)
     PASS([c isEqual: t], "the copy is equal to the original");
   END_SET("copy")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextTable/basic.m
+++ b/Tests/gui/NSTextTable/basic.m
@@ -14,8 +14,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("dimension constant values")
     PASS(NSTextBlockWidth == 0 && NSTextBlockMinimumWidth == 1
       && NSTextBlockMaximumWidth == 2 && NSTextBlockHeight == 4
@@ -135,6 +133,5 @@ main(int argc, char **argv)
     PASS([tb table] == t, "the table is stored");
   END_SET("NSTextTableBlock position")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextTableBlock/basic.m
+++ b/Tests/gui/NSTextTableBlock/basic.m
@@ -13,8 +13,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSTextTableBlock basic")
 
   NS_DURING
@@ -71,6 +69,5 @@ main(int argc, char **argv)
 
   END_SET("NSTextTableBlock basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextTableBlock/integerTypes.m
+++ b/Tests/gui/NSTextTableBlock/integerTypes.m
@@ -55,8 +55,6 @@ takesNSIntegerAt(const char *name, unsigned index)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("the row and column types")
 
   NS_DURING
@@ -104,6 +102,5 @@ main(int argc, char **argv)
 
   END_SET("the row and column types")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextView/changeNotification.m
+++ b/Tests/gui/NSTextView/changeNotification.m
@@ -39,7 +39,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   Recorder *r;
   NSTextView *tv;
   NSWindow *w;
@@ -108,6 +107,5 @@ main(int argc, char **argv)
 
   END_SET("NSTextView change notification")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextView/characterShape.m
+++ b/Tests/gui/NSTextView/characterShape.m
@@ -18,7 +18,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTextView *tv;
 
   START_SET("NSTextView character shape")
@@ -69,6 +68,5 @@ main(int argc, char **argv)
 
   END_SET("NSTextView character shape")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextView/config.m
+++ b/Tests/gui/NSTextView/config.m
@@ -21,7 +21,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTextView *tv;
   NSSize inset;
 
@@ -80,6 +79,5 @@ int main()
 
   END_SET("NSTextView config")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextView/defaults.m
+++ b/Tests/gui/NSTextView/defaults.m
@@ -10,7 +10,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTextView *tv;
 
   START_SET("NSTextView defaults")
@@ -31,6 +30,5 @@ int main()
 
   END_SET("NSTextView defaults")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTextView/typingAttributes.m
+++ b/Tests/gui/NSTextView/typingAttributes.m
@@ -25,7 +25,6 @@ textView(void)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTextView *tv;
 
   START_SET("NSTextView typing attributes")
@@ -106,6 +105,5 @@ main(int argc, char **argv)
 
   END_SET("NSTextView typing attributes")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTokenField/defaults.m
+++ b/Tests/gui/NSTokenField/defaults.m
@@ -19,7 +19,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTokenField *tf;
 
   START_SET("NSTokenField defaults")
@@ -73,6 +72,5 @@ main(int argc, char **argv)
 
   END_SET("NSTokenField defaults")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTokenFieldCell/basic.m
+++ b/Tests/gui/NSTokenFieldCell/basic.m
@@ -14,8 +14,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSTokenFieldCell basic")
 
   NS_DURING
@@ -66,6 +64,5 @@ main(int argc, char **argv)
 
   END_SET("NSTokenFieldCell basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTokenFieldCell/coding.m
+++ b/Tests/gui/NSTokenFieldCell/coding.m
@@ -29,8 +29,6 @@ cellToArchive(void)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("coding")
 
   NS_DURING
@@ -73,6 +71,5 @@ main(int argc, char **argv)
 
   END_SET("coding")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTokenFieldCell/defaultTokenizingCharacterSet.m
+++ b/Tests/gui/NSTokenFieldCell/defaultTokenizingCharacterSet.m
@@ -13,8 +13,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("the default tokenizing character set")
 
   NS_DURING
@@ -50,6 +48,5 @@ main(int argc, char **argv)
 
   END_SET("the default tokenizing character set")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSToolbar/basicInit.m
+++ b/Tests/gui/NSToolbar/basicInit.m
@@ -12,7 +12,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSToolbar *ref;
   NSToolbar *tb;
 
@@ -62,6 +61,5 @@ main(int argc, char **argv)
 
   END_SET("NSToolbar basic init")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSToolbar/defaultIdentifierItems.m
+++ b/Tests/gui/NSToolbar/defaultIdentifierItems.m
@@ -44,7 +44,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSToolbar *t1;
   NSToolbar *t2;
 
@@ -88,6 +87,5 @@ main(int argc, char **argv)
 
   END_SET("NSToolbar default identifier items")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSToolbar/itemNotification.m
+++ b/Tests/gui/NSToolbar/itemNotification.m
@@ -62,7 +62,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   TBDelegate *del;
   Recorder *r;
   NSToolbar *tb;
@@ -125,6 +124,5 @@ main(int argc, char **argv)
 
   END_SET("NSToolbar item notification")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSToolbarItem/basic.m
+++ b/Tests/gui/NSToolbarItem/basic.m
@@ -15,7 +15,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSToolbarItem *item;
 
   START_SET("NSToolbarItem basic")
@@ -70,6 +69,5 @@ int main()
 
   END_SET("NSToolbarItem basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSToolbarItem/copySubclass.m
+++ b/Tests/gui/NSToolbarItem/copySubclass.m
@@ -17,8 +17,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("copying a toolbar item subclass")
 
   NS_DURING
@@ -82,6 +80,5 @@ main(int argc, char **argv)
 
   END_SET("copying a toolbar item subclass")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSToolbarItem/enabled.m
+++ b/Tests/gui/NSToolbarItem/enabled.m
@@ -8,7 +8,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSToolbarItem *item;
 
   START_SET("NSToolbarItem enabled")
@@ -25,6 +24,5 @@ int main()
 
   END_SET("NSToolbarItem enabled")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSToolbarItem/paletteLabel.m
+++ b/Tests/gui/NSToolbarItem/paletteLabel.m
@@ -9,7 +9,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSToolbarItem *item;
 
   START_SET("NSToolbarItem paletteLabel")
@@ -27,6 +26,5 @@ int main()
 
   END_SET("NSToolbarItem paletteLabel")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSToolbarItem/tag.m
+++ b/Tests/gui/NSToolbarItem/tag.m
@@ -8,7 +8,6 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSToolbarItem *item;
 
   START_SET("NSToolbarItem tag")
@@ -25,6 +24,5 @@ int main()
 
   END_SET("NSToolbarItem tag")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSToolbarItemGroup/basic.m
+++ b/Tests/gui/NSToolbarItemGroup/basic.m
@@ -15,8 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSToolbarItemGroup basic")
 
   NS_DURING
@@ -52,6 +50,5 @@ main(int argc, char **argv)
 
   END_SET("NSToolbarItemGroup basic")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSToolbarItemGroup/selection.m
+++ b/Tests/gui/NSToolbarItemGroup/selection.m
@@ -40,8 +40,6 @@ groupWithMode(NSToolbarItemGroupSelectionMode mode)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("selection")
 
   NS_DURING
@@ -196,6 +194,5 @@ main(int argc, char **argv)
 
   END_SET("selection")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSToolbarItemGroup/subitemsEmpty.m
+++ b/Tests/gui/NSToolbarItemGroup/subitemsEmpty.m
@@ -15,8 +15,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("empty subitems")
 
   NS_DURING
@@ -47,6 +45,5 @@ main(int argc, char **argv)
 
   END_SET("empty subitems")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTrackingArea/basic.m
+++ b/Tests/gui/NSTrackingArea/basic.m
@@ -14,8 +14,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("option constants match AppKit")
     PASS(NSTrackingMouseEnteredAndExited == 0x01
       && NSTrackingMouseMoved == 0x02
@@ -76,6 +74,5 @@ main(int argc, char **argv)
       "the copy keeps the rect, options, owner and userInfo");
   END_SET("copy preserves the rect, options, owner and userInfo")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSTreeController/binding.m
+++ b/Tests/gui/NSTreeController/binding.m
@@ -64,7 +64,6 @@ node(NSString *aName)
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSTreeController	*tc;
   NSObjectController	*oc;
   NSMutableDictionary	*model;
@@ -140,7 +139,6 @@ withKeyPath: @"content.roots"
 
   END_SET("NSTreeController content array binding")
 
-  DESTROY(arp);
 
   return 0;
 }

--- a/Tests/gui/NSTreeNode/basic.m
+++ b/Tests/gui/NSTreeNode/basic.m
@@ -10,8 +10,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("a new node")
     NSTreeNode	*node = [NSTreeNode treeNodeWithRepresentedObject: @"root"];
 
@@ -79,6 +77,5 @@ main(int argc, char **argv)
       "a two-step index path reaches the grandchild");
   END_SET("descendantNodeAtIndexPath:")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSView/autoresize.m
+++ b/Tests/gui/NSView/autoresize.m
@@ -26,7 +26,6 @@ addSubview(NSView *sup, NSRect frame, NSUInteger mask)
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSView autoresize")
 
   NS_DURING
@@ -161,6 +160,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSView autoresize")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSView/autoresizeRounding.m
+++ b/Tests/gui/NSView/autoresizeRounding.m
@@ -91,7 +91,6 @@ scaledAutoresizeCase(void)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSView *sub;
 
   START_SET("NSView autoresizeRounding")
@@ -227,6 +226,5 @@ main(int argc, char **argv)
 
   END_SET("NSView autoresizeRounding")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSView/backingAligned.m
+++ b/Tests/gui/NSView/backingAligned.m
@@ -28,7 +28,6 @@ rectEqual(NSRect r, CGFloat x, CGFloat y, CGFloat w, CGFloat h)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   NSView *v;
   NSRect r;
   NSRect n;
@@ -114,6 +113,5 @@ main(int argc, char **argv)
 
   END_SET("NSView backingAlignedRect")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSView/centerScanRectSize.m
+++ b/Tests/gui/NSView/centerScanRectSize.m
@@ -30,8 +30,6 @@ checkRect(NSView *view, NSRect in, NSRect want)
 
 int main(int argc, char **argv)
 {
-	CREATE_AUTORELEASE_POOL(arp);
-
 	NSView *view;
 
 	START_SET("NSView GNUstep centerScanRectSize")
@@ -63,6 +61,5 @@ int main(int argc, char **argv)
 
 	END_SET("NSView GNUstep centerScanRectSize")
 
-	DESTROY(arp);
 	return 0;
 }

--- a/Tests/gui/NSView/convert.m
+++ b/Tests/gui/NSView/convert.m
@@ -17,7 +17,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSView convert")
 
   NS_DURING
@@ -185,6 +184,5 @@ int main(int argc, const char **argv)
   NS_ENDHANDLER
   END_SET("NSView convert (windowed)")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSView/convertRectNoWindow.m
+++ b/Tests/gui/NSView/convertRectNoWindow.m
@@ -12,8 +12,6 @@
 
 int main(int argc, char **argv)
 {
-	CREATE_AUTORELEASE_POOL(arp);
-
 	NSView *outer;
 	NSView *inner;
 	NSRect r;
@@ -64,6 +62,5 @@ int main(int argc, char **argv)
 
 	END_SET("NSView GNUstep convertRectNoWindow")
 
-	DESTROY(arp);
 	return 0;
 }

--- a/Tests/gui/NSView/flipMargin.m
+++ b/Tests/gui/NSView/flipMargin.m
@@ -31,7 +31,6 @@ resized(Class superClass, NSUInteger mask)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSView autoresize flip invariance")
 
   NS_DURING
@@ -58,6 +57,5 @@ main(int argc, const char **argv)
     "maxYMargin autoresize is unchanged by a flipped superview");
 
   END_SET("NSView autoresize flip invariance")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSView/frameBounds.m
+++ b/Tests/gui/NSView/frameBounds.m
@@ -83,7 +83,6 @@ FBCheckMatrix(NSView *view, CGFloat *ts)
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSView frame and bounds")
 
   NS_DURING
@@ -347,6 +346,5 @@ int main(int argc, const char **argv)
   NS_ENDHANDLER
   END_SET("NSView frame and bounds (windowed)")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSView/frameRotationSign.m
+++ b/Tests/gui/NSView/frameRotationSign.m
@@ -12,8 +12,6 @@
 
 int main(int argc, char **argv)
 {
-	CREATE_AUTORELEASE_POOL(arp);
-
 	NSView *view;
 	int passed;
 
@@ -52,6 +50,5 @@ int main(int argc, char **argv)
 
 	END_SET("NSView GNUstep frameRotationSign")
 
-	DESTROY(arp);
 	return 0;
 }

--- a/Tests/gui/NSView/hiddenNotifications.m
+++ b/Tests/gui/NSView/hiddenNotifications.m
@@ -20,7 +20,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   HideRecorder *parent, *visibleChild, *hiddenChild;
 
   START_SET("NSView hidden notifications")
@@ -90,6 +89,5 @@ main(int argc, char **argv)
 
   END_SET("NSView hidden notifications")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSView/hitTest.m
+++ b/Tests/gui/NSView/hitTest.m
@@ -8,7 +8,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSView hitTest")
 
   NS_DURING
@@ -46,6 +45,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSView hitTest")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSView/rendering.m
+++ b/Tests/gui/NSView/rendering.m
@@ -19,7 +19,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSView rendering")
 
   NS_DURING
@@ -66,6 +65,5 @@ int main(int argc, const char **argv)
     "centre pixel of a red-fill view is red");
 
   END_SET("NSView rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSView/rotation.m
+++ b/Tests/gui/NSView/rotation.m
@@ -28,7 +28,6 @@ RotRectsClose(NSRect a, NSRect b, CGFloat eps)
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSView rotation")
 
   NS_DURING
@@ -142,6 +141,5 @@ int main(int argc, const char **argv)
   NS_ENDHANDLER
   END_SET("NSView rotation (windowed)")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSView/visibleClip.m
+++ b/Tests/gui/NSView/visibleClip.m
@@ -10,7 +10,6 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSView visibleClip (windowless)")
 
   NS_DURING
@@ -135,6 +134,5 @@ int main(int argc, const char **argv)
 
   END_SET("NSView visibleClip (windowed)")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSViewController/appearance.m
+++ b/Tests/gui/NSViewController/appearance.m
@@ -38,7 +38,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSViewController appearance")
 
   NS_DURING
@@ -80,6 +79,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSViewController appearance")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSViewController/layout.m
+++ b/Tests/gui/NSViewController/layout.m
@@ -34,7 +34,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   LayoutVC *vc;
   NSView *view;
 
@@ -88,6 +87,5 @@ main(int argc, const char **argv)
 
   END_SET("NSViewController layout")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSViewController/viewDidLoad.m
+++ b/Tests/gui/NSViewController/viewDidLoad.m
@@ -36,8 +36,6 @@
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("NSViewController viewDidLoad")
 
   NS_DURING
@@ -80,6 +78,5 @@ main(int argc, char **argv)
 
   END_SET("NSViewController viewDidLoad")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSWindow/aspectRatio.m
+++ b/Tests/gui/NSWindow/aspectRatio.m
@@ -7,7 +7,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSWindow aspectRatio")
 
   NS_DURING
@@ -45,6 +44,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSWindow aspectRatio")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSWindow/behaviour.m
+++ b/Tests/gui/NSWindow/behaviour.m
@@ -9,7 +9,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSWindow behaviour")
 
   NS_DURING
@@ -49,6 +48,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSWindow behaviour")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSWindow/cascade.m
+++ b/Tests/gui/NSWindow/cascade.m
@@ -7,7 +7,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSWindow cascade")
 
   NS_DURING
@@ -42,6 +41,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSWindow cascade")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSWindow/frameContent.m
+++ b/Tests/gui/NSWindow/frameContent.m
@@ -7,7 +7,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSWindow frame and content")
 
   NS_DURING
@@ -53,6 +52,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSWindow frame and content")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSWindow/screen.m
+++ b/Tests/gui/NSWindow/screen.m
@@ -7,7 +7,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSWindow screen conversion")
 
   NS_DURING
@@ -40,6 +39,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSWindow screen conversion")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSWindow/sizing.m
+++ b/Tests/gui/NSWindow/sizing.m
@@ -7,7 +7,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSWindow sizing")
 
   NS_DURING
@@ -57,6 +56,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSWindow sizing")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSWindow/windowRender.m
+++ b/Tests/gui/NSWindow/windowRender.m
@@ -21,7 +21,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSWindow content rendering")
 
   NS_DURING
@@ -63,6 +62,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSWindow content rendering")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSWindowController/config.m
+++ b/Tests/gui/NSWindowController/config.m
@@ -11,7 +11,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSWindowController config")
 
   NS_DURING
@@ -61,6 +60,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSWindowController config")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/NSWindowController/lifecycle.m
+++ b/Tests/gui/NSWindowController/lifecycle.m
@@ -32,7 +32,6 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
   START_SET("NSWindowController lifecycle")
 
   NS_DURING
@@ -79,6 +78,5 @@ main(int argc, const char **argv)
   NS_ENDHANDLER
 
   END_SET("NSWindowController lifecycle")
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/gui/TextSystem/repeatedAttachmentCellHeight.m
+++ b/Tests/gui/TextSystem/repeatedAttachmentCellHeight.m
@@ -38,7 +38,6 @@ static int count;
 int main(int argc, char **argv)
 {
 	unichar chars[4]={'a','b','c',NSAttachmentCharacter};
-	CREATE_AUTORELEASE_POOL(arp);
 	NSTextStorage *text;
 	NSLayoutManager *lm;
 	NSTextContainer *tc;
@@ -78,7 +77,6 @@ int main(int argc, char **argv)
 
 	END_SET("TextSystem GNUstep repeatedAttachmentCellHeight");
 
-	DESTROY(arp);
 	return 0;
 }
 


### PR DESCRIPTION
These tests wrap their body in an autorelease pool of their own although the body already sits inside a START_SET. START_SET creates a pool and END_SET releases it, so the outer one does nothing.

Removed from 376 files. The change is deletions only, 856 of them, and adds no line anywhere.

Two files are deliberately left out. TextSystem/deallocation.m calls RECREATE_AUTORELEASE_POOL inside its set and so needs the declaration. NSApplication/basic.m needs an unreachable early return taken out before its pool can go, which is a change of a different kind and is sent separately.

Run gnustep-tests from Tests/gui. 4353 assertions pass and one is a dashed hope, before and after, with all 448 test programs building.

It was also run with base and gui built GNUSTEP_WITH_ASAN=1 and leak checking on, where the totals are 4351 and two, again the same before and after. The set of files LSAN reports is unchanged, no file's leak total moves by a single byte, and nothing reports being autoreleased with no pool in place, so none of the pools removed here was doing any work.
