### PR TITLE
Fix: use the exception macros instead of hand written handlers in tests. (Part 3)

### DIFF
--- a/Tests/gui/GSTable/gsTableCoderCounts.m
+++ b/Tests/gui/GSTable/gsTableCoderCounts.m
@@ -32,7 +32,7 @@
 
 int main(void)
 {
-  ENTER_POOL
+  START_SET("GSTable gsTableCoderCounts")
   GSTable *t;
   GSTable *t2;
   NSData *d;
@@ -55,6 +55,6 @@ int main(void)
 
   RELEASE(t);
   RELEASE(u);
-  LEAVE_POOL
+  END_SET("GSTable gsTableCoderCounts")
   return 0;
 }

--- a/Tests/gui/NSAnimation/config.m
+++ b/Tests/gui/NSAnimation/config.m
@@ -13,7 +13,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSAnimation config")
   NSAnimation *a;
 
   PASS(NSAnimationEaseInOut == 0, "NSAnimationEaseInOut is 0");
@@ -38,6 +38,6 @@ int main()
   PASS([[a progressMarks] count] == 0, "a new animation has no progress marks");
   PASS([a delegate] == nil, "default delegate is nil");
 
-  DESTROY(arp);
+  END_SET("NSAnimation config")
   return 0;
 }

--- a/Tests/gui/NSAnimation/curve.m
+++ b/Tests/gui/NSAnimation/curve.m
@@ -30,7 +30,7 @@ valueFor(NSAnimationCurve curve, float progress)
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSAnimation curve")
 
   PASS(NEAR(valueFor(NSAnimationLinear, 0.25), 0.25),
        "linear value at 0.25 is 0.25");
@@ -50,6 +50,6 @@ int main()
   PASS(NEAR(valueFor(NSAnimationEaseIn, 1.0), 1.0), "ease-in value at 1 is 1");
   PASS(NEAR(valueFor(NSAnimationEaseOut, 1.0), 1.0), "ease-out value at 1 is 1");
 
-  DESTROY(arp);
+  END_SET("NSAnimation curve")
   return 0;
 }

--- a/Tests/gui/NSAnimation/progressmarks.m
+++ b/Tests/gui/NSAnimation/progressmarks.m
@@ -13,7 +13,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSAnimation progressmarks")
   NSAnimation *a;
   NSArray *marks;
 
@@ -55,6 +55,6 @@ int main()
     && [[marks objectAtIndex: 1] floatValue] == 0.75,
        "setProgressMarks: replaces the previous marks, sorted");
 
-  DESTROY(arp);
+  END_SET("NSAnimation progressmarks")
   return 0;
 }

--- a/Tests/gui/NSAnimation/roundtrips.m
+++ b/Tests/gui/NSAnimation/roundtrips.m
@@ -12,7 +12,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSAnimation roundtrips")
   NSAnimation *a;
   NSObject *delegate;
 
@@ -49,6 +49,6 @@ int main()
   [a setDelegate: delegate];
   PASS([a delegate] == delegate, "delegate round-trips");
 
-  DESTROY(arp);
+  END_SET("NSAnimation roundtrips")
   return 0;
 }

--- a/Tests/gui/NSArrayController/config.m
+++ b/Tests/gui/NSArrayController/config.m
@@ -14,7 +14,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSArrayController config")
   NSArrayController *ac;
 
   ac = AUTORELEASE([[NSArrayController alloc] init]);
@@ -50,6 +50,6 @@ int main()
   PASS([ac automaticallyRearrangesObjects] == YES,
        "automaticallyRearrangesObjects round-trips");
 
-  DESTROY(arp);
+  END_SET("NSArrayController config")
   return 0;
 }

--- a/Tests/gui/NSArrayController/content.m
+++ b/Tests/gui/NSArrayController/content.m
@@ -13,7 +13,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSArrayController content")
   NSArrayController *ac;
   NSSortDescriptor *sd;
   NSArray *arranged;
@@ -41,6 +41,6 @@ int main()
   PASS([[[ac selectedObjects] objectAtIndex: 0] isEqual: @"bravo"],
        "the selected object is the one at the selection index");
 
-  DESTROY(arp);
+  END_SET("NSArrayController content")
   return 0;
 }

--- a/Tests/gui/NSArrayController/defaults.m
+++ b/Tests/gui/NSArrayController/defaults.m
@@ -12,7 +12,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSArrayController defaults")
   NSArrayController *ac;
 
   ac = AUTORELEASE([[NSArrayController alloc] init]);
@@ -29,6 +29,6 @@ int main()
   PASS([[ac selectedObjects] count] == 0,
        "an empty controller has an empty selected-objects array");
 
-  DESTROY(arp);
+  END_SET("NSArrayController defaults")
   return 0;
 }

--- a/Tests/gui/NSArrayController/nilSelection.m
+++ b/Tests/gui/NSArrayController/nilSelection.m
@@ -12,7 +12,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSArrayController nilSelection")
   NSArrayController *ac;
 
   ac = AUTORELEASE([[NSArrayController alloc] init]);
@@ -32,6 +32,6 @@ int main()
   PASS([[ac selectionIndexes] count] == 0,
        "setSelectionIndexes: nil leaves an empty selection index set");
 
-  DESTROY(arp);
+  END_SET("NSArrayController nilSelection")
   return 0;
 }

--- a/Tests/gui/NSBezierPath/basic.m
+++ b/Tests/gui/NSBezierPath/basic.m
@@ -13,7 +13,7 @@ static BOOL eq(double d1, double d2)
 
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  START_SET("NSBezierPath basic")
   id testObject;
   id testObject1;
   id testObject2;
@@ -42,7 +42,7 @@ int main()
                  @"NSBezierPath",
 		 testObjects, NO, NO);
 
-  [arp release];
+  END_SET("NSBezierPath basic")
   return 0;
 }
 

--- a/Tests/gui/NSBezierPath/bounds.m
+++ b/Tests/gui/NSBezierPath/bounds.m
@@ -11,7 +11,7 @@ copyright 2004 Alexander Malmberg <alexander@malmberg.org>
 
 int main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSBezierPath bounds")
   NSBezierPath *p=[[NSBezierPath alloc] init];
   NSRect r;
 
@@ -162,7 +162,7 @@ int main(int argc, char **argv)
 
 //	printf("bounds=%@\n",NSStringFromRect([p bounds]));
   DESTROY(p);
-  DESTROY(arp);
+  END_SET("NSBezierPath bounds")
 
   return 0;
 }

--- a/Tests/gui/NSBezierPath/windingCountAtPoint.m
+++ b/Tests/gui/NSBezierPath/windingCountAtPoint.m
@@ -115,7 +115,7 @@ MyView *view;
 
 int main(int argc, char **argv)
 {
-	CREATE_AUTORELEASE_POOL(arp);
+	START_SET("NSBezierPath windingCountAtPoint")
 	NSBezierPath *p=[[NSBezierPath alloc] init];
 	int i;
 	const char *str;
@@ -701,7 +701,7 @@ int main(int argc, char **argv)
 	}
 
 	DESTROY(p);
-	DESTROY(arp);
+	END_SET("NSBezierPath windingCountAtPoint")
 
 	return 0;
 }

--- a/Tests/gui/NSBitmapImageRep/gifColorMapBounds.m
+++ b/Tests/gui/NSBitmapImageRep/gifColorMapBounds.m
@@ -50,7 +50,7 @@ static const unsigned char validGIF[] = {
 
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  START_SET("NSBitmapImageRep gifColorMapBounds")
 #if defined(GS_TEST_SYSTEM_GIF)
   NSData            *data;
   NSBitmapImageRep  *rep;
@@ -77,6 +77,6 @@ int main()
     "a valid GIF still decodes correctly");
   [rep release];
 #endif
-  [arp release];
+  END_SET("NSBitmapImageRep gifColorMapBounds")
   return 0;
 }

--- a/Tests/gui/NSBitmapImageRep/icnsImportOverflow.m
+++ b/Tests/gui/NSBitmapImageRep/icnsImportOverflow.m
@@ -101,7 +101,7 @@ static const unsigned char goodICNS32[] = {
  */
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  START_SET("NSBitmapImageRep icnsImportOverflow")
   NSData            *data;
   NSBitmapImageRep  *rep;
 
@@ -118,6 +118,6 @@ int main()
     "a valid 32x32 ICNS icon still decodes");
   [rep release];
 
-  [arp release];
+  END_SET("NSBitmapImageRep icnsImportOverflow")
   return 0;
 }

--- a/Tests/gui/NSBitmapImageRep/icnsMaskBounds.m
+++ b/Tests/gui/NSBitmapImageRep/icnsMaskBounds.m
@@ -230,7 +230,7 @@ static const unsigned char truncatedMaskICNS[] = {
 #endif
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  START_SET("NSBitmapImageRep icnsMaskBounds")
 #if !defined(GS_TEST_SYSTEM_ICNS)
   NSData            *data;
   NSBitmapImageRep  *rep;
@@ -248,6 +248,6 @@ int main()
 
   [rep release];
 #endif
-  [arp release];
+  END_SET("NSBitmapImageRep icnsMaskBounds")
   return 0;
 }

--- a/Tests/gui/NSBitmapImageRep/icnsZeroElement.m
+++ b/Tests/gui/NSBitmapImageRep/icnsZeroElement.m
@@ -23,7 +23,7 @@ static const unsigned char zeroSizeElementICNS[] = {
  */
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  START_SET("NSBitmapImageRep icnsZeroElement")
   NSData            *data;
   NSBitmapImageRep  *rep;
   NSArray           *reps;
@@ -40,6 +40,6 @@ int main()
   PASS(reps != nil,
     "an ICNS file with a zero-size element does not hang +imageRepsWithData:");
 
-  [arp release];
+  END_SET("NSBitmapImageRep icnsZeroElement")
   return 0;
 }

--- a/Tests/gui/NSBitmapImageRep/jpegAllocationOverflow.m
+++ b/Tests/gui/NSBitmapImageRep/jpegAllocationOverflow.m
@@ -76,7 +76,7 @@ static const unsigned char validJPEG[] = {
 
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  START_SET("NSBitmapImageRep jpegAllocationOverflow")
   NSData            *data;
   NSBitmapImageRep  *rep;
 
@@ -86,6 +86,6 @@ int main()
     "a valid JPEG still decodes after the allocation size is computed safely");
   [rep release];
 
-  [arp release];
+  END_SET("NSBitmapImageRep jpegAllocationOverflow")
   return 0;
 }

--- a/Tests/gui/NSBitmapImageRep/pngAllocationOverflow.m
+++ b/Tests/gui/NSBitmapImageRep/pngAllocationOverflow.m
@@ -42,7 +42,7 @@ static const unsigned char validPNG[] = {
 
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  START_SET("NSBitmapImageRep pngAllocationOverflow")
   NSData            *data;
   NSBitmapImageRep  *rep;
   const unsigned char *px;
@@ -62,6 +62,6 @@ int main()
     "the valid PNG colour data is decoded correctly");
   [rep release];
 
-  [arp release];
+  END_SET("NSBitmapImageRep pngAllocationOverflow")
   return 0;
 }

--- a/Tests/gui/NSBitmapImageRep/testcopy.m
+++ b/Tests/gui/NSBitmapImageRep/testcopy.m
@@ -7,7 +7,7 @@
 
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  START_SET("NSBitmapImageRep testcopy")
   NSBitmapImageRep *origBitmap, *copy1Bitmap, *copy2Bitmap;
 
   origBitmap = [[NSBitmapImageRep alloc] initWithBitmapDataPlanes: NULL
@@ -35,6 +35,6 @@ int main()
   DESTROY(copy1Bitmap);
   DESTROY(copy2Bitmap);
   DESTROY(origBitmap);
-  [arp release];
+  END_SET("NSBitmapImageRep testcopy")
   return 0;
 }

--- a/Tests/gui/NSBitmapImageRep/tiffPaletteOverflow.m
+++ b/Tests/gui/NSBitmapImageRep/tiffPaletteOverflow.m
@@ -231,7 +231,7 @@ static const unsigned char goodPalette8bppTIFF[] = {
  */
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  START_SET("NSBitmapImageRep tiffPaletteOverflow")
   NSData            *data;
   NSBitmapImageRep  *rep;
 
@@ -249,6 +249,6 @@ int main()
     "a valid 8-bit palette TIFF still decodes");
   [rep release];
 
-  [arp release];
+  END_SET("NSBitmapImageRep tiffPaletteOverflow")
   return 0;
 }

--- a/Tests/gui/NSColor/spaceConversions.m
+++ b/Tests/gui/NSColor/spaceConversions.m
@@ -19,7 +19,7 @@ eq(CGFloat a, CGFloat b)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSColor spaceConversions")
 
   /* An achromatic RGB colour keeps its value when converted to grayscale. */
   {
@@ -76,6 +76,6 @@ main(int argc, char **argv)
       "the grayscale and CMYK spaces report two and five components");
   }
 
-  DESTROY(arp);
+  END_SET("NSColor spaceConversions")
   return 0;
 }

--- a/Tests/gui/NSColorPicker/config.m
+++ b/Tests/gui/NSColorPicker/config.m
@@ -10,7 +10,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSColorPicker config")
   NSColorPicker *picker;
 
   picker = AUTORELEASE([[NSColorPicker alloc]
@@ -19,6 +19,6 @@ int main()
   PASS(picker != nil, "a picker with a nil panel is created");
   PASS([picker colorPanel] == nil, "a nil color panel stays nil");
 
-  DESTROY(arp);
+  END_SET("NSColorPicker config")
   return 0;
 }

--- a/Tests/gui/NSColorPicker/retain.m
+++ b/Tests/gui/NSColorPicker/retain.m
@@ -23,7 +23,7 @@ static BOOL panelDeallocated;
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSColorPicker retain")
   NSColorPicker *picker;
   id panel;
 
@@ -37,6 +37,6 @@ int main()
 
   RELEASE(picker);
 
-  DESTROY(arp);
+  END_SET("NSColorPicker retain")
   return 0;
 }

--- a/Tests/gui/NSCursor/config.m
+++ b/Tests/gui/NSCursor/config.m
@@ -12,7 +12,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSCursor config")
   NSCursor *c;
 
   c = AUTORELEASE([[NSCursor alloc] initWithImage: nil
@@ -30,6 +30,6 @@ int main()
   [c setOnMouseExited: YES];
   PASS([c isSetOnMouseExited] == YES, "setOnMouseExited: round-trips");
 
-  DESTROY(arp);
+  END_SET("NSCursor config")
   return 0;
 }

--- a/Tests/gui/NSDictionaryController/config.m
+++ b/Tests/gui/NSDictionaryController/config.m
@@ -14,7 +14,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSDictionaryController config")
   NSDictionaryController *dc;
   NSDictionaryControllerKeyValuePair *kvp;
 
@@ -46,6 +46,6 @@ int main()
   [dc setExcludedKeys: [NSArray arrayWithObject: @"x"]];
   PASS([[dc excludedKeys] count] == 1, "excludedKeys round-trips");
 
-  DESTROY(arp);
+  END_SET("NSDictionaryController config")
   return 0;
 }

--- a/Tests/gui/NSDictionaryController/headeronly.m
+++ b/Tests/gui/NSDictionaryController/headeronly.m
@@ -9,11 +9,11 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSDictionaryController headeronly")
 
   PASS([NSDictionaryController class] != Nil,
        "the NSDictionaryController class is available");
 
-  DESTROY(arp);
+  END_SET("NSDictionaryController headeronly")
   return 0;
 }

--- a/Tests/gui/NSDictionaryController/plaininit.m
+++ b/Tests/gui/NSDictionaryController/plaininit.m
@@ -11,13 +11,13 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSDictionaryController plaininit")
   NSDictionaryController *dc;
 
   dc = AUTORELEASE([[NSDictionaryController alloc] init]);
   PASS(dc != nil, "a dictionary controller can be created with -init");
   PASS([[dc initialKey] isEqual: @"key"], "its initial key is the default");
 
-  DESTROY(arp);
+  END_SET("NSDictionaryController plaininit")
   return 0;
 }

--- a/Tests/gui/NSDraggingImageComponent/basic.m
+++ b/Tests/gui/NSDraggingImageComponent/basic.m
@@ -14,7 +14,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSDraggingImageComponent basic")
   NSDraggingImageComponent *c;
   NSImage *image;
 
@@ -45,6 +45,6 @@ int main()
   [c setContents: image];
   PASS([c contents] == image, "the contents round-trip");
 
-  DESTROY(arp);
+  END_SET("NSDraggingImageComponent basic")
   return 0;
 }

--- a/Tests/gui/NSLayoutAnchor/basic.m
+++ b/Tests/gui/NSLayoutAnchor/basic.m
@@ -9,7 +9,7 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSLayoutAnchor basic")
 
   PASS([NSLayoutDimension isSubclassOfClass: [NSLayoutAnchor class]],
        "NSLayoutDimension is a subclass of NSLayoutAnchor");
@@ -23,6 +23,6 @@ int main(int argc, const char **argv)
   PASS([NSLayoutAnchor conformsToProtocol: @protocol(NSCoding)],
        "NSLayoutAnchor conforms to NSCoding");
 
-  DESTROY(arp);
+  END_SET("NSLayoutAnchor basic")
   return 0;
 }

--- a/Tests/gui/NSLayoutGuide/anchors.m
+++ b/Tests/gui/NSLayoutGuide/anchors.m
@@ -8,7 +8,7 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSLayoutGuide anchors")
 
   NSLayoutGuide *g = AUTORELEASE([[NSLayoutGuide alloc] init]);
   NSLayoutGuide *g2 = AUTORELEASE([[NSLayoutGuide alloc] init]);
@@ -40,6 +40,6 @@ int main(int argc, const char **argv)
   PASS([lead secondAttribute] == NSLayoutAttributeLeading,
        "leading constraint secondAttribute is Leading");
 
-  DESTROY(arp);
+  END_SET("NSLayoutGuide anchors")
   return 0;
 }

--- a/Tests/gui/NSLayoutGuide/basic.m
+++ b/Tests/gui/NSLayoutGuide/basic.m
@@ -9,7 +9,7 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSLayoutGuide basic")
 
   NSLayoutGuide *g = [[NSLayoutGuide alloc] init];
   PASS(g != nil, "NSLayoutGuide -init returns an instance");
@@ -26,6 +26,6 @@ int main(int argc, const char **argv)
        "conforms to NSUserInterfaceItemIdentification");
 
   RELEASE(g);
-  DESTROY(arp);
+  END_SET("NSLayoutGuide basic")
   return 0;
 }

--- a/Tests/gui/NSLayoutGuide/identifier.m
+++ b/Tests/gui/NSLayoutGuide/identifier.m
@@ -7,7 +7,7 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSLayoutGuide identifier")
 
   NSLayoutGuide *g = AUTORELEASE([[NSLayoutGuide alloc] init]);
 
@@ -19,6 +19,6 @@ int main(int argc, const char **argv)
   PASS([[g identifier] isEqualToString: @"id1"],
        "identifier is copied, not shared with the argument");
 
-  DESTROY(arp);
+  END_SET("NSLayoutGuide identifier")
   return 0;
 }

--- a/Tests/gui/NSLayoutManager/config.m
+++ b/Tests/gui/NSLayoutManager/config.m
@@ -18,7 +18,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSLayoutManager config")
   NSLayoutManager *lm;
   NSTextContainer *tc;
   NSTextStorage *ts;
@@ -71,6 +71,6 @@ int main()
   PASS([lm textStorage] == ts,
        "adding the layout manager to a text storage links it");
 
-  DESTROY(arp);
+  END_SET("NSLayoutManager config")
   return 0;
 }

--- a/Tests/gui/NSMovieView/config.m
+++ b/Tests/gui/NSMovieView/config.m
@@ -9,7 +9,7 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSMovieView config")
 
   NSMovieView *v = AUTORELEASE([[NSMovieView alloc]
     initWithFrame: NSMakeRect(0, 0, 200, 150)]);
@@ -49,6 +49,6 @@ main(int argc, const char **argv)
   PASS([v volume] == 0.0 && [v isMuted] == YES,
     "a zero volume mutes playback");
 
-  DESTROY(arp);
+  END_SET("NSMovieView config")
   return 0;
 }

--- a/Tests/gui/NSPDFInfo/basic.m
+++ b/Tests/gui/NSPDFInfo/basic.m
@@ -10,7 +10,7 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSPDFInfo basic")
 
   /* Enum values match AppKit. */
   PASS(NSPaperOrientationPortrait == 0, "NSPaperOrientationPortrait is 0");
@@ -41,6 +41,6 @@ int main(int argc, const char **argv)
   PASS([info conformsToProtocol: @protocol(NSCopying)], "conforms to NSCopying");
 
   RELEASE(info);
-  DESTROY(arp);
+  END_SET("NSPDFInfo basic")
   return 0;
 }

--- a/Tests/gui/NSPDFInfo/copy.m
+++ b/Tests/gui/NSPDFInfo/copy.m
@@ -8,7 +8,7 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSPDFInfo copy")
 
   NSPDFInfo *info = [[NSPDFInfo alloc] init];
   [info setFileExtensionHidden: YES];
@@ -27,6 +27,6 @@ int main(int argc, const char **argv)
 
   RELEASE(info);
   RELEASE(copy);
-  DESTROY(arp);
+  END_SET("NSPDFInfo copy")
   return 0;
 }

--- a/Tests/gui/NSPDFInfo/initdefaults.m
+++ b/Tests/gui/NSPDFInfo/initdefaults.m
@@ -11,7 +11,7 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSPDFInfo initdefaults")
 
   NSPDFInfo *info = [[NSPDFInfo alloc] init];
 
@@ -33,6 +33,6 @@ int main(int argc, const char **argv)
        "default paperSize is non-zero");
 
   RELEASE(info);
-  DESTROY(arp);
+  END_SET("NSPDFInfo initdefaults")
   return 0;
 }

--- a/Tests/gui/NSParagraphStyle/NSParagraphStyle_defaultWritingDirection.m
+++ b/Tests/gui/NSParagraphStyle/NSParagraphStyle_defaultWritingDirection.m
@@ -11,14 +11,14 @@ int main(int argc, char **argv)
 {
 	int ok;
 
-	CREATE_AUTORELEASE_POOL(arp);
+	START_SET("NSParagraphStyle NSParagraphStyle_defaultWritingDirection")
 
 	ok = [NSParagraphStyle defaultWritingDirectionForLanguage: @"en"]==NSWritingDirectionLeftToRight
 	  && [NSParagraphStyle defaultWritingDirectionForLanguage: @"ar"]==NSWritingDirectionRightToLeft;
 
 	PASS(ok,"[NSParagraphStyle defaultWritingDirectionForLanguage:] works");
 
-	DESTROY(arp);
+	END_SET("NSParagraphStyle NSParagraphStyle_defaultWritingDirection")
 	return 0;
 }
 

--- a/Tests/gui/NSParagraphStyle/paragraphStyleCoderTabStops.m
+++ b/Tests/gui/NSParagraphStyle/paragraphStyleCoderTabStops.m
@@ -45,7 +45,7 @@
 
 int main(void)
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+  START_SET("NSParagraphStyle paragraphStyleCoderTabStops")
   HugeTabCountCoder *fc = AUTORELEASE([HugeTabCountCoder new]);
   NSMutableParagraphStyle *p;
   NSParagraphStyle *p2;
@@ -68,6 +68,6 @@ int main(void)
   PASS(p2 != nil && [[p2 tabStops] count] == 2,
     "a paragraph style with tab stops round-trips through a non-keyed archive");
 
-  [arp release];
+  END_SET("NSParagraphStyle paragraphStyleCoderTabStops")
   return 0;
 }

--- a/Tests/gui/NSPasteboardItem/basic.m
+++ b/Tests/gui/NSPasteboardItem/basic.m
@@ -12,7 +12,7 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSPasteboardItem basic")
 
   NSString *t1 = @"public.data";
   NSString *t2 = @"public.utf8-plain-text";
@@ -47,6 +47,6 @@ int main(int argc, const char **argv)
 
   RELEASE(a);
   RELEASE(b);
-  DESTROY(arp);
+  END_SET("NSPasteboardItem basic")
   return 0;
 }

--- a/Tests/gui/NSPasteboardItem/registertype.m
+++ b/Tests/gui/NSPasteboardItem/registertype.m
@@ -9,7 +9,7 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSPasteboardItem registertype")
 
   NSString *t1 = @"public.utf8-plain-text";
   NSString *t2 = @"public.data";
@@ -30,6 +30,6 @@ int main(int argc, const char **argv)
        "setting the same type twice does not duplicate it");
 
   RELEASE(item);
-  DESTROY(arp);
+  END_SET("NSPasteboardItem registertype")
   return 0;
 }

--- a/Tests/gui/NSPathControlItem/basic.m
+++ b/Tests/gui/NSPathControlItem/basic.m
@@ -11,7 +11,7 @@
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSPathControlItem basic")
 
   NSPathControlItem *it = [[NSPathControlItem alloc] init];
   PASS(it != nil, "NSPathControlItem -init returns an instance");
@@ -49,6 +49,6 @@ int main(int argc, const char **argv)
   RELEASE(a);
 
   RELEASE(it);
-  DESTROY(arp);
+  END_SET("NSPathControlItem basic")
   return 0;
 }

--- a/Tests/gui/NSPopover/animates.m
+++ b/Tests/gui/NSPopover/animates.m
@@ -7,12 +7,12 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSPopover animates")
 
   NSPopover *p = AUTORELEASE([[NSPopover alloc] init]);
 
   PASS([p animates] == YES, "a new popover animates by default");
 
-  DESTROY(arp);
+  END_SET("NSPopover animates")
   return 0;
 }

--- a/Tests/gui/NSPopover/config.m
+++ b/Tests/gui/NSPopover/config.m
@@ -9,7 +9,7 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSPopover config")
 
   NSPopover *p = AUTORELEASE([[NSPopover alloc] init]);
 
@@ -51,6 +51,6 @@ main(int argc, const char **argv)
   PASS(NSEqualRects([p positioningRect], NSMakeRect(1, 2, 3, 4)),
     "the positioning rect round-trips");
 
-  DESTROY(arp);
+  END_SET("NSPopover config")
   return 0;
 }

--- a/Tests/gui/NSPopover/contentViewController.m
+++ b/Tests/gui/NSPopover/contentViewController.m
@@ -11,7 +11,7 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSPopover contentViewController")
 
   NSPopover *p = AUTORELEASE([[NSPopover alloc] init]);
   NSViewController *vc = AUTORELEASE([[NSViewController alloc] init]);
@@ -23,6 +23,6 @@ main(int argc, const char **argv)
   PASS([p contentViewController] == vc,
     "a content view controller with a view is assigned directly");
 
-  DESTROY(arp);
+  END_SET("NSPopover contentViewController")
   return 0;
 }

--- a/Tests/gui/NSPrintInfo/sharedPrintInfo.m
+++ b/Tests/gui/NSPrintInfo/sharedPrintInfo.m
@@ -2,17 +2,19 @@
 copyright 2004 Alexander Malmberg <alexander@malmberg.org>
 */
 
+#include "Testing.h"
+
 #include <Foundation/NSAutoreleasePool.h>
 #include <AppKit/NSPrintInfo.h>
 
 int main(int argc, char **argv)
 {
-	CREATE_AUTORELEASE_POOL(arp);
+	START_SET("NSPrintInfo sharedPrintInfo")
 
 	/* Should run without causing any exceptions. */
 	[NSPrintInfo sharedPrintInfo];
 
-	DESTROY(arp);
+	END_SET("NSPrintInfo sharedPrintInfo")
 	return 0;
 }
 

--- a/Tests/gui/NSRulerView/config.m
+++ b/Tests/gui/NSRulerView/config.m
@@ -9,7 +9,7 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSRulerView config")
 
   NSRulerView *r = AUTORELEASE([[NSRulerView alloc]
     initWithScrollView: nil orientation: NSHorizontalRuler]);
@@ -50,6 +50,6 @@ main(int argc, const char **argv)
     PASS([v isFlipped] == NO, "a vertical ruler is not flipped");
   }
 
-  DESTROY(arp);
+  END_SET("NSRulerView config")
   return 0;
 }

--- a/Tests/gui/NSRulerView/markers.m
+++ b/Tests/gui/NSRulerView/markers.m
@@ -24,7 +24,7 @@ markerAt(NSRulerView *r, CGFloat loc)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSRulerView markers")
 
   NSRulerView *r = AUTORELEASE([[NSRulerView alloc]
     initWithScrollView: nil orientation: NSHorizontalRuler]);
@@ -58,6 +58,6 @@ main(int argc, const char **argv)
   PASS([r markers] == nil || [[r markers] count] == 0,
     "setting nil markers clears the list");
 
-  DESTROY(arp);
+  END_SET("NSRulerView markers")
   return 0;
 }

--- a/Tests/gui/NSSplitViewController/config.m
+++ b/Tests/gui/NSSplitViewController/config.m
@@ -12,7 +12,7 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSplitViewController config")
 
   NSSplitViewController *svc = AUTORELEASE([[NSSplitViewController alloc] init]);
 
@@ -29,6 +29,6 @@ main(int argc, const char **argv)
   PASS([svc minimumThicknessForInlineSidebars] == 44.5,
     "the minimum inline sidebar thickness round-trips to another value");
 
-  DESTROY(arp);
+  END_SET("NSSplitViewController config")
   return 0;
 }

--- a/Tests/gui/NSSplitViewItem/coding.m
+++ b/Tests/gui/NSSplitViewItem/coding.m
@@ -11,7 +11,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSplitViewItem coding")
   NSSplitViewItem *item;
   NSSplitViewItem *decoded;
   NSData *data;
@@ -45,6 +45,6 @@ int main()
   PASS([decoded titlebarSeparatorStyle] == NSTitlebarSeparatorStyleLine,
        "titlebarSeparatorStyle survives the round-trip");
 
-  DESTROY(arp);
+  END_SET("NSSplitViewItem coding")
   return 0;
 }

--- a/Tests/gui/NSSplitViewItem/config.m
+++ b/Tests/gui/NSSplitViewItem/config.m
@@ -12,7 +12,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSplitViewItem config")
   NSViewController *vc;
   NSSplitViewItem *item;
 
@@ -28,6 +28,6 @@ int main()
   PASS([item titlebarSeparatorStyle] == NSTitlebarSeparatorStyleAutomatic,
        "default titlebarSeparatorStyle is Automatic");
 
-  DESTROY(arp);
+  END_SET("NSSplitViewItem config")
   return 0;
 }

--- a/Tests/gui/NSSplitViewItem/defaults.m
+++ b/Tests/gui/NSSplitViewItem/defaults.m
@@ -12,7 +12,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSplitViewItem defaults")
   NSSplitViewItem *item;
 
   PASS(NSSplitViewItemUnspecifiedDimension == -1.0,
@@ -33,6 +33,6 @@ int main()
   PASS([item allowsFullHeightLayout] == YES,
        "default allowsFullHeightLayout is YES");
 
-  DESTROY(arp);
+  END_SET("NSSplitViewItem defaults")
   return 0;
 }

--- a/Tests/gui/NSSplitViewItem/enumvalues.m
+++ b/Tests/gui/NSSplitViewItem/enumvalues.m
@@ -9,7 +9,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSplitViewItem enumvalues")
 
   PASS(NSTitlebarSeparatorStyleAutomatic == 0,
        "NSTitlebarSeparatorStyleAutomatic is 0");
@@ -20,6 +20,6 @@ int main()
   PASS(NSTitlebarSeparatorStyleShadow == 3,
        "NSTitlebarSeparatorStyleShadow is 3");
 
-  DESTROY(arp);
+  END_SET("NSSplitViewItem enumvalues")
   return 0;
 }

--- a/Tests/gui/NSSplitViewItem/memory.m
+++ b/Tests/gui/NSSplitViewItem/memory.m
@@ -23,7 +23,7 @@ static BOOL vcDeallocated;
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSplitViewItem memory")
   NSSplitViewItem *item;
   ProbeViewController *vc;
 
@@ -46,6 +46,6 @@ int main()
   PASS(vcDeallocated == YES,
        "a deallocated item releases its view controller");
 
-  DESTROY(arp);
+  END_SET("NSSplitViewItem memory")
   return 0;
 }

--- a/Tests/gui/NSSplitViewItem/roundtrips.m
+++ b/Tests/gui/NSSplitViewItem/roundtrips.m
@@ -12,7 +12,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSSplitViewItem roundtrips")
   NSViewController *vc;
   NSSplitViewItem *item;
 
@@ -51,6 +51,6 @@ int main()
   [item setViewController: vc];
   PASS([item viewController] == vc, "viewController round-trips");
 
-  DESTROY(arp);
+  END_SET("NSSplitViewItem roundtrips")
   return 0;
 }

--- a/Tests/gui/NSTabViewController/config.m
+++ b/Tests/gui/NSTabViewController/config.m
@@ -10,7 +10,7 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSTabViewController config")
 
   NSTabViewController *tc = AUTORELEASE([[NSTabViewController alloc] init]);
 
@@ -38,6 +38,6 @@ main(int argc, const char **argv)
   PASS([tc canPropagateSelectedChildViewControllerTitle] == NO,
     "the title propagation flag round-trips to NO");
 
-  DESTROY(arp);
+  END_SET("NSTabViewController config")
   return 0;
 }

--- a/Tests/gui/NSTabViewController/defaults.m
+++ b/Tests/gui/NSTabViewController/defaults.m
@@ -9,7 +9,7 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSTabViewController defaults")
 
   NSTabViewController *tc = AUTORELEASE([[NSTabViewController alloc] init]);
 
@@ -18,6 +18,6 @@ main(int argc, const char **argv)
   PASS([tc canPropagateSelectedChildViewControllerTitle] == YES,
     "a fresh controller propagates the selected child's title");
 
-  DESTROY(arp);
+  END_SET("NSTabViewController defaults")
   return 0;
 }

--- a/Tests/gui/NSTabViewController/delegate.m
+++ b/Tests/gui/NSTabViewController/delegate.m
@@ -9,7 +9,7 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSTabViewController delegate")
 
   NSTabViewController *tc = AUTORELEASE([[NSTabViewController alloc] init]);
 
@@ -23,6 +23,6 @@ main(int argc, const char **argv)
     && [[tc toolbarSelectableItemIdentifiers: nil] count] == 0,
     "the selectable toolbar identifiers start empty");
 
-  DESTROY(arp);
+  END_SET("NSTabViewController delegate")
   return 0;
 }

--- a/Tests/gui/NSTextStorage/config.m
+++ b/Tests/gui/NSTextStorage/config.m
@@ -14,7 +14,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSTextStorage config")
   NSTextStorage *ts;
   id delegate;
 
@@ -37,6 +37,6 @@ int main()
   [ts setDelegate: delegate];
   PASS([ts delegate] == delegate, "delegate round-trips");
 
-  DESTROY(arp);
+  END_SET("NSTextStorage config")
   return 0;
 }

--- a/Tests/gui/NSTreeController/config.m
+++ b/Tests/gui/NSTreeController/config.m
@@ -13,7 +13,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSTreeController config")
   NSTreeController *tc;
 
   tc = AUTORELEASE([[NSTreeController alloc] init]);
@@ -54,6 +54,6 @@ int main()
    */
   [tc setContent: nil];
 
-  DESTROY(arp);
+  END_SET("NSTreeController config")
   return 0;
 }

--- a/Tests/gui/NSTreeController/defaults.m
+++ b/Tests/gui/NSTreeController/defaults.m
@@ -9,7 +9,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSTreeController defaults")
   NSTreeController *tc;
 
   tc = AUTORELEASE([[NSTreeController alloc] init]);
@@ -24,6 +24,6 @@ int main()
   // Break retain loop to allow this objecty to be deallocated
   [tc setContent: nil];
 
-  DESTROY(arp);
+  END_SET("NSTreeController defaults")
   return 0;
 }

--- a/Tests/gui/NSUserDefaultsController/config.m
+++ b/Tests/gui/NSUserDefaultsController/config.m
@@ -15,7 +15,7 @@
 
 int main()
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSUserDefaultsController config")
   NSUserDefaultsController *shared;
   NSUserDefaultsController *c;
 
@@ -46,6 +46,6 @@ int main()
   [c setInitialValues: [NSDictionary dictionaryWithObject: @"v" forKey: @"k"]];
   PASS([[c initialValues] count] == 1, "initialValues round-trips");
 
-  DESTROY(arp);
+  END_SET("NSUserDefaultsController config")
   return 0;
 }

--- a/Tests/gui/NSView/visibleRectNoWindow.m
+++ b/Tests/gui/NSView/visibleRectNoWindow.m
@@ -18,7 +18,7 @@ isUnbounded(NSRect r)
 
 int main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSView visibleRectNoWindow")
   NSView *v, *sup, *child, *hidden;
 
   v = AUTORELEASE([[NSView alloc] initWithFrame: NSMakeRect(0, 0, 100, 80)]);
@@ -40,6 +40,6 @@ int main(int argc, const char **argv)
   PASS(NSEqualRects([hidden visibleRect], NSZeroRect),
        "a hidden windowless view has a zero visibleRect");
 
-  DESTROY(arp);
+  END_SET("NSView visibleRectNoWindow")
   return 0;
 }

--- a/Tests/gui/NSVisualEffectView/config.m
+++ b/Tests/gui/NSVisualEffectView/config.m
@@ -9,7 +9,7 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSVisualEffectView config")
 
   NSVisualEffectView *v = AUTORELEASE([[NSVisualEffectView alloc]
     initWithFrame: NSMakeRect(0, 0, 100, 100)]);
@@ -24,6 +24,6 @@ main(int argc, const char **argv)
     "the interior background style starts at zero");
   PASS([v maskImage] == nil, "there is no mask image by default");
 
-  DESTROY(arp);
+  END_SET("NSVisualEffectView config")
   return 0;
 }

--- a/Tests/gui/NSVisualEffectView/roundtrips.m
+++ b/Tests/gui/NSVisualEffectView/roundtrips.m
@@ -9,7 +9,7 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
+  START_SET("NSVisualEffectView roundtrips")
 
   NSVisualEffectView *v = AUTORELEASE([[NSVisualEffectView alloc]
     initWithFrame: NSMakeRect(0, 0, 100, 100)]);
@@ -38,6 +38,6 @@ main(int argc, const char **argv)
   [v setMaskImage: nil];
   PASS([v maskImage] == nil, "the mask image can be cleared");
 
-  DESTROY(arp);
+  END_SET("NSVisualEffectView roundtrips")
   return 0;
 }


### PR DESCRIPTION
These tests put their body in an autorelease pool of their own rather than in a set. START_SET creates the pool itself and END_SET releases it, so the pool is covered either way, and a set additionally stops an uncaught exception taking the whole program down with it, and can be skipped when what it tests is not available.

Wrapped 65 files, replacing the pool with START_SET and END_SET named after the class and the file, in the style already used elsewhere in the suite. NSPrintInfo/sharedPrintInfo.m also gains the Testing.h include it now needs, since it had no assertions and so never included it.

NSPasteboard/lazy_copy.m is left alone. It drains and recreates its pool in the middle of the test, so the pool is not simply an outer wrapper there.

Run gnustep-tests from Tests/gui. 4353 assertions pass and one is a dashed hope, before and after, with all 448 test programs building.

It was also run with base and gui built GNUSTEP_WITH_ASAN=1 and leak checking on, where the set of files LSAN reports and every file's leak total are unchanged.
