### PR TITLE
Fix: remove an unreachable branch from the NSApplication test

### DIFF
--- a/Tests/gui/NSApplication/basic.m
+++ b/Tests/gui/NSApplication/basic.m
@@ -98,7 +98,6 @@
 
 int main()
 {
-  NSAutoreleasePool *arp = [NSAutoreleasePool new];
   NSApplication *app1, *app2;
   TestApplicationDelegate *delegate;
 
@@ -140,17 +139,7 @@ int main()
     }
     else
     {
-      // Framework initialization error - skip remaining tests
-      if ([[localException name] isEqualToString: NSInternalInconsistencyException])
-      {
-        SKIP("Backend initialization failed - cannot test NSApplication");
-        [arp release];
-        return 0;
-      }
-      else
-      {
-        PASS(NO, "Unexpected exception: %s", [[localException name] UTF8String]);
-      }
+      PASS(NO, "Unexpected exception: %s", [[localException name] UTF8String]);
     }
   }
   NS_ENDHANDLER
@@ -271,6 +260,5 @@ int main()
   END_SET("NSApplication GNUstep basic")
 
   [delegate release];
-  [arp release];
   return 0;
 }

--- a/Tests/gui/NSApplication/basic.m
+++ b/Tests/gui/NSApplication/basic.m
@@ -99,7 +99,9 @@
 int main()
 {
   NSApplication *app1, *app2;
-  TestApplicationDelegate *delegate;
+  /* Released below the set, which is also reached when the set is skipped
+     before this has been assigned. */
+  TestApplicationDelegate *delegate = nil;
 
   START_SET("NSApplication GNUstep basic")
 


### PR DESCRIPTION
The handler for the second -init reports the expected exception in its first branch. Its else then tested the same condition over again, so the block inside could never be entered. That block skipped the rest of the set and returned, which would also have left END_SET unexecuted had it been reachable.

Removed, leaving the else with the report of an unexpected exception that it always fell through to anyway. The outer autorelease pool goes with it, since START_SET creates a pool and END_SET releases it.

Nothing else in the file changes, and no assertion is added or removed.

Run gnustep-tests from Tests/gui. 4353 assertions pass and one is a dashed hope, before and after.
