### PR TITLE
Fix: free the PNG row pointers when libpng reports an error

### DIFF
--- a/Source/NSBitmapImageRep+PNG.m
+++ b/Source/NSBitmapImageRep+PNG.m
@@ -99,8 +99,12 @@ static void reader_func(png_structp png_struct, png_bytep data,
   png_infop png_info, png_end_info;
 
   int width,height;
-  unsigned char *buf = NULL;
-  png_bytep *row_ptrs = NULL;
+  /* Written after setjmp() and read in the longjmp() handler below, so they
+     have to survive the jump; a plain local may be held in a register that
+     longjmp restores to its value at the setjmp call. */
+  unsigned char * volatile buf = NULL;
+  png_bytep * volatile row_ptrs = NULL;
+  unsigned char *plane;
   int bytes_per_row;
   size_t imageSize = 0;
   int type,channels,depth;
@@ -274,7 +278,8 @@ static void reader_func(png_structp png_struct, png_bytep data,
       bitmapFormat |= NSBitmapFormatThirtyTwoBitBigEndian;
     }
 
-  self = [self initWithBitmapDataPlanes: &buf
+  plane = (unsigned char *)buf;
+  self = [self initWithBitmapDataPlanes: &plane
                              pixelsWide: width
                              pixelsHigh: height
                           bitsPerSample: depth


### PR DESCRIPTION
-_initBitmapFromPNG: holds the decoded buffer and the row pointer array in plain locals. Both are assigned after setjmp() and read again in the longjmp() handler, where the value of a local that has been written since the setjmp call is indeterminate. In practice one of them is held in a register that longjmp restores to its earlier value, so the handler sees NULL and skips the free. A PNG that libpng rejects part way through decoding therefore leaks the row pointer array, which holds one pointer per row of the height declared in the header.

Declaring the two pointers volatile makes them survive the jump. The bitmap data planes argument now takes a plain copy of the buffer pointer, since it wants an unqualified one.

Tests/gui/NSBitmapImageRep/pngAllocationOverflow.m already covers this: it feeds a 2148 by 1000000 image that libpng rejects with "Not enough image data".

Run gnustep-tests from Tests/gui. 4353 assertions pass and one is a dashed hope, before and after.

Built with base and gui GNUSTEP_WITH_ASAN=1, that test goes from leaking 8000000 bytes in one allocation to leaking nothing, and no other test program's leak total changes.
