### PR TITLE
tests: add the general drawing tests, run against any backend

### DIFF
--- a/Tests/gui/GSDrawTest.h
+++ b/Tests/gui/GSDrawTest.h
@@ -1,0 +1,143 @@
+/* GSDrawTest.h
+
+   Shared support for the drawing tests: draw into an offscreen image through
+   the AppKit path, read the pixels back, and check them.  This exercises
+   whichever backend is installed rather than any one of them, so the same
+   test covers cairo, art, xlib and winlib.
+
+   These helpers need a backend, so a test that uses them must keep the usual
+   START_SET / SKIP guard.  Colours are checked with a small tolerance,
+   because a backend may carry them through fixed-point arithmetic.
+
+   GSRenderTest.h covers the other half of this ground, rendering a view or a
+   window through the server; use that when a view hierarchy is what is being
+   drawn, and this when the drawing calls themselves are.
+
+   This is header-only (static inline) so each test tool gets its own copy.
+*/
+
+#ifndef GSDrawTest_h
+#define GSDrawTest_h
+
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+/* Start drawing into an offscreen image of the given size.  Pair with
+   GSDrawEnd, which reads the pixels back. */
+static inline NSImage *
+GSDrawBegin(int w, int h)
+{
+  NSImage *img = [[NSImage alloc] initWithSize: NSMakeSize(w, h)];
+
+  [img lockFocus];
+  return img;
+}
+
+/* Finish the drawing started by GSDrawBegin and return the pixels.  Row 0 of
+   the representation is the top of the image. */
+static inline NSBitmapImageRep *
+GSDrawEnd(NSImage *img, int w, int h)
+{
+  NSBitmapImageRep *rep;
+
+  [[NSGraphicsContext currentContext] flushGraphics];
+  rep = [[NSBitmapImageRep alloc]
+	  initWithFocusedViewRect: NSMakeRect(0, 0, w, h)];
+  [img unlockFocus];
+  [img release];
+  return [rep autorelease];
+}
+
+/* Whether the pixel at (x, y) is the given device-RGB colour, within a
+   tolerance of tol per channel. */
+static inline BOOL
+GSPixelNear(NSBitmapImageRep *rep, int x, int y, int r, int g, int b, int tol)
+{
+  NSUInteger	px[5];
+
+  [rep getPixel: px atX: x y: y];
+  return (abs((int)px[0] - r) <= tol
+	  && abs((int)px[1] - g) <= tol
+	  && abs((int)px[2] - b) <= tol);
+}
+
+/* Whether the pixel at (x, y) is the given device-RGB colour. */
+static inline BOOL
+GSPixelIs(NSBitmapImageRep *rep, int x, int y, int r, int g, int b)
+{
+  return GSPixelNear(rep, x, y, r, g, b, 2);
+}
+
+/* The value of one channel of the pixel at (x, y), 0 for red, 1 for green,
+   2 for blue. */
+static inline int
+GSPixelChannel(NSBitmapImageRep *rep, int x, int y, int channel)
+{
+  NSUInteger	px[5];
+
+  [rep getPixel: px atX: x y: y];
+  return (int)px[channel];
+}
+
+/* Start drawing into an offscreen image of the given size, with the whole of
+   it filled opaque white first, so that a test can check that an area was
+   left unpainted. */
+static inline NSImage *
+GSDrawBeginWhite(int w, int h)
+{
+  NSImage *img = GSDrawBegin(w, h);
+
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  return img;
+}
+
+/* Whether the installed backend draws offscreen and reads the pixels back.
+   A backend need not: the headless one draws nothing at all, and a server
+   may be running without one that can.  A test calls this after the backend
+   has started and skips when it answers NO, so that a backend which cannot
+   draw reports a skip rather than a wall of failed assertions. */
+static inline BOOL
+GSCanDrawOffscreen(void)
+{
+  NSImage		*img;
+  NSBitmapImageRep	*rep;
+  BOOL			ok = NO;
+
+  NS_DURING
+    {
+      img = GSDrawBegin(4, 4);
+      [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+      NSRectFill(NSMakeRect(0, 0, 4, 4));
+      rep = GSDrawEnd(img, 4, 4);
+      ok = (rep != nil && GSPixelIs(rep, 2, 2, 255, 0, 0)) ? YES : NO;
+    }
+  NS_HANDLER
+    {
+      ok = NO;
+    }
+  NS_ENDHANDLER
+  return ok;
+}
+
+/* How many pixels in the rectangle are the given device-RGB colour. */
+static inline int
+GSPixelCount(NSBitmapImageRep *rep, NSRect area, int r, int g, int b)
+{
+  int	x, y, n = 0;
+
+  for (y = (int)NSMinY(area); y < (int)NSMaxY(area); y++)
+    {
+      for (x = (int)NSMinX(area); x < (int)NSMaxX(area); x++)
+	{
+	  if (GSPixelIs(rep, x, y, r, g, b))
+	    {
+	      n++;
+	    }
+	}
+    }
+  return n;
+}
+
+#endif /* GSDrawTest_h */

--- a/Tests/gui/NSBezierPath/drawingCurves.m
+++ b/Tests/gui/NSBezierPath/drawingCurves.m
@@ -1,0 +1,81 @@
+/* Curved paths, checked by reading the pixels back: a filled oval paints its
+ * centre and not the corner of its bounding box, and a stroked cubic curve
+ * paints along its raised middle rather than along the straight chord.
+ *
+ * None of it is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#import "../GSDrawTest.h"
+
+#import <AppKit/AppKit.h>
+#import <AppKit/NSBezierPath.h>
+#include <stdlib.h>
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("curves")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  if (NO == GSCanDrawOffscreen())
+    {
+      SKIP("the installed backend does not draw offscreen")
+    }
+
+  int w = 20, h = 20;
+  NSImage *img;
+  NSBitmapImageRep *rep;
+
+  /* A filled oval paints its centre and leaves the corners of the bounding box
+   * clear, because the ellipse does not reach the corners. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0] set];
+  {
+    NSBezierPath *p = [NSBezierPath bezierPath];
+    [p appendBezierPathWithOvalInRect: NSMakeRect(2, 2, 16, 16)];
+    [p fill];
+  }
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 10, h - 1 - 10, 0, 0, 255),
+       "a filled oval paints its centre");
+  PASS(rep != nil && GSPixelIs(rep, 3, h - 1 - 3, 255, 255, 255),
+       "a filled oval leaves the corner of its bounding box clear");
+
+  /* Stroking a cubic curve follows the curve, not the straight chord.  The
+   * curve runs from (2,4) to (18,4) with both control points high, so it peaks
+   * near y = 12 at the middle and stays clear of the chord at y = 4. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  {
+    NSBezierPath *p = [NSBezierPath bezierPath];
+    [p setLineWidth: 2.0];
+    [p moveToPoint: NSMakePoint(2, 4)];
+    [p curveToPoint: NSMakePoint(18, 4)
+       controlPoint1: NSMakePoint(2, 16)
+       controlPoint2: NSMakePoint(18, 16)];
+    [p stroke];
+  }
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 10, h - 1 - 12, 0, 0, 0),
+       "a stroked cubic curve paints along its raised middle");
+  PASS(rep != nil && GSPixelIs(rep, 10, h - 1 - 4, 255, 255, 255),
+       "a stroked cubic curve leaves the straight chord clear");
+
+  END_SET("curves")
+  return 0;
+}

--- a/Tests/gui/NSBezierPath/drawingRoundStroke.m
+++ b/Tests/gui/NSBezierPath/drawingRoundStroke.m
@@ -1,0 +1,117 @@
+/* Round line caps and joins, checked by reading the pixels back: a round cap
+ * paints on the axis past the endpoint but rounds off the corner that a
+ * square cap would fill, and a miter join fills the outer corner more than a
+ * round join does.
+ *
+ * None of it is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#import "../GSDrawTest.h"
+
+#import <AppKit/AppKit.h>
+#import <AppKit/NSBezierPath.h>
+#include <stdlib.h>
+
+/* Count dark pixels in the square [x0,x1) x [y0,y1) of the rep. */
+static long
+darkCount(NSBitmapImageRep *rep, int x0, int y0, int x1, int y1)
+{
+  long n = 0;
+  int x, y;
+
+  for (y = y0; y < y1; y++)
+    for (x = x0; x < x1; x++)
+      {
+        NSUInteger px[5];
+
+        [rep getPixel: px atX: x y: y];
+        if (px[0] < 100)
+          n++;
+      }
+  return n;
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("round stroke")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  if (NO == GSCanDrawOffscreen())
+    {
+      SKIP("the installed backend does not draw offscreen")
+    }
+
+  int w = 40, h = 40;
+  NSImage *img;
+  NSBitmapImageRep *rep;
+
+  /* A round cap paints a half-disc past the endpoint, so a point on the axis
+   * just beyond the endpoint is painted, but rounds off the square corner, so a
+   * point out at the corner of where a square cap would reach is left clear.
+   * The line runs to x = 24 with width 12 (radius 6). */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  {
+    NSBezierPath *p = [NSBezierPath bezierPath];
+    [p setLineWidth: 12.0];
+    [p setLineCapStyle: NSRoundLineCapStyle];
+    [p moveToPoint: NSMakePoint(8, 20)];
+    [p lineToPoint: NSMakePoint(24, 20)];
+    [p stroke];
+  }
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 28, h - 1 - 20, 0, 0, 0),
+       "a round cap paints on the axis past the endpoint");
+  PASS(rep != nil && GSPixelIs(rep, 29, h - 1 - 25, 255, 255, 255),
+       "a round cap rounds off the corner a square cap would fill");
+
+  /* A round join cuts the sharp outer corner, so it fills fewer pixels in the
+   * outer-corner region than a miter join.  The path bends at (12,12) from a
+   * vertical to a horizontal segment; the outer corner is the lower-left. */
+  {
+    long dark[2] = { 0, 0 };
+    int style;
+
+    for (style = 0; style < 2; style++)
+      {
+        img = GSDrawBegin(w, h);
+        [[NSColor whiteColor] set];
+        NSRectFill(NSMakeRect(0, 0, w, h));
+        [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+        {
+          NSBezierPath *p = [NSBezierPath bezierPath];
+          [p setLineWidth: 12.0];
+          [p setLineJoinStyle: (style == 0 ? NSMiterLineJoinStyle
+                                           : NSRoundLineJoinStyle)];
+          [p moveToPoint: NSMakePoint(12, 32)];
+          [p lineToPoint: NSMakePoint(12, 12)];
+          [p lineToPoint: NSMakePoint(32, 12)];
+          [p stroke];
+        }
+        rep = GSDrawEnd(img, w, h);
+        /* The miter fills the outer wedge out to the sharp corner at device
+         * (6,6); the differing region is device x,y in 6..12, which in rep
+         * space is cols 6..12, rows h-1-12 .. h-1-6. */
+        dark[style] = darkCount(rep, 5, h - 1 - 12, 13, h - 1 - 5);
+      }
+    PASS(dark[0] > dark[1],
+         "a miter join fills the outer corner more than a round join");
+  }
+
+  END_SET("round stroke")
+  return 0;
+}

--- a/Tests/gui/NSBezierPath/drawingWindingRule.m
+++ b/Tests/gui/NSBezierPath/drawingWindingRule.m
@@ -1,0 +1,102 @@
+/* The winding rules, checked by reading the pixels back.  A non-zero fill
+ * paints a doubly-enclosed region, an even-odd fill leaves it as a hole, and
+ * the same two rules apply to a clip built from the path.
+ *
+ * None of it is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#import "../GSDrawTest.h"
+
+#import <AppKit/AppKit.h>
+#import <AppKit/NSBezierPath.h>
+#include <stdlib.h>
+
+/* An outer rectangle with a smaller inner rectangle, both appended as rects so
+ * they wind the same way.  The inner hole spans device x,y in 7..13. */
+static NSBezierPath *
+donutPath(void)
+{
+  NSBezierPath *p = [NSBezierPath bezierPath];
+  [p appendBezierPathWithRect: NSMakeRect(2, 2, 16, 16)];
+  [p appendBezierPathWithRect: NSMakeRect(7, 7, 6, 6)];
+  return p;
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("winding rule")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  if (NO == GSCanDrawOffscreen())
+    {
+      SKIP("the installed backend does not draw offscreen")
+    }
+
+  int w = 20, h = 20;
+  NSImage *img;
+  NSBitmapImageRep *rep;
+  NSBezierPath *p;
+
+  /* Non-zero fill: the inner region is enclosed twice, so it is filled and the
+   * hole is painted over. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0] set];
+  p = donutPath();
+  [p setWindingRule: NSNonZeroWindingRule];
+  [p fill];
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 10, h - 1 - 10, 0, 0, 255),
+       "a non-zero fill paints the doubly-enclosed inner region");
+  PASS(rep != nil && GSPixelIs(rep, 4, h - 1 - 10, 0, 0, 255),
+       "a non-zero fill paints the outer ring");
+
+  /* Even-odd fill: the inner region is crossed twice, so it is left as a hole
+   * while the outer ring is still painted. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0] set];
+  p = donutPath();
+  [p setWindingRule: NSEvenOddWindingRule];
+  [p fill];
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 10, h - 1 - 10, 255, 255, 255),
+       "an even-odd fill leaves the inner region as a hole");
+  PASS(rep != nil && GSPixelIs(rep, 4, h - 1 - 10, 0, 0, 255),
+       "an even-odd fill still paints the outer ring");
+
+  /* Even-odd clip: clipping with the even-odd rule confines a following fill to
+   * the outer ring and leaves the inner hole and the outside untouched. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  p = donutPath();
+  [p setWindingRule: NSEvenOddWindingRule];
+  [p addClip];
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 4, h - 1 - 10, 255, 0, 0),
+       "an even-odd clip admits drawing in the outer ring");
+  PASS(rep != nil && GSPixelIs(rep, 10, h - 1 - 10, 255, 255, 255),
+       "an even-odd clip excludes the inner hole");
+  PASS(rep != nil && GSPixelIs(rep, 0, h - 1 - 0, 255, 255, 255),
+       "an even-odd clip excludes the area outside the path");
+
+  END_SET("winding rule")
+  return 0;
+}

--- a/Tests/gui/NSGraphicsContext/clipping.m
+++ b/Tests/gui/NSGraphicsContext/clipping.m
@@ -1,0 +1,94 @@
+/* Clipping through the AppKit path, checked by reading the pixels back.
+ * Covers intersecting and disjoint clip rectangles, and a clip built from a
+ * path surviving a save and restore of the graphics state, for a triangle,
+ * an oval and an even-odd ring.
+ *
+ * None of it is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#import "../GSDrawTest.h"
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+/* Clip to the given path, save, fill everything red, restore.  The fill runs on
+ * the copied state that inherited the clip. */
+static NSBitmapImageRep *
+clipSaveFill(int w, int h, NSBezierPath *clip)
+{
+  NSImage *img = GSDrawBeginWhite(w, h);
+
+  [clip addClip];
+  [NSGraphicsContext saveGraphicsState];
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [NSGraphicsContext restoreGraphicsState];
+  return GSDrawEnd(img, w, h);
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("clipping")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  if (NO == GSCanDrawOffscreen())
+    {
+      SKIP("the installed backend does not draw offscreen")
+    }
+
+  int w = 24, h = 24;
+  NSBitmapImageRep *rep;
+  NSBezierPath *p;
+
+  /* A triangle with the right angle at (3,3) and hypotenuse (21,3)-(3,21).
+   * Read back (top-left origin) its interior is the lower-left half: (7,16) is
+   * inside, (18,6) is above the hypotenuse, outside the triangle but inside its
+   * bounding box.  If the clip were reduced to its bounding box, (18,6) would
+   * fill. */
+  p = [NSBezierPath bezierPath];
+  [p moveToPoint: NSMakePoint(3, 3)];
+  [p lineToPoint: NSMakePoint(21, 3)];
+  [p lineToPoint: NSMakePoint(3, 21)];
+  [p closePath];
+  rep = clipSaveFill(w, h, p);
+  PASS(rep != nil && GSPixelIs(rep, 7, 16, 255, 0, 0),
+       "a triangle clip still paints its interior after save/restore");
+  PASS(rep != nil && GSPixelIs(rep, 18, 6, 255, 255, 255),
+       "a triangle clip is not widened to its bounding box by save/restore");
+
+  /* An oval clip: the centre is inside, a bounding-box corner is outside. */
+  p = [NSBezierPath bezierPathWithOvalInRect: NSMakeRect(3, 3, 18, 18)];
+  rep = clipSaveFill(w, h, p);
+  PASS(rep != nil && GSPixelIs(rep, 12, 12, 255, 0, 0),
+       "an oval clip still paints its interior after save/restore");
+  PASS(rep != nil && GSPixelIs(rep, 4, 4, 255, 255, 255),
+       "an oval clip corner is not filled after save/restore");
+
+  /* An even-odd ring (outer rect minus inner rect): a point on the ring is
+   * inside, the central hole is outside.  Checks that the even-odd rule is
+   * carried across the save as well as the geometry. */
+  p = [NSBezierPath bezierPath];
+  [p appendBezierPathWithRect: NSMakeRect(3, 3, 18, 18)];
+  [p appendBezierPathWithRect: NSMakeRect(9, 9, 6, 6)];
+  [p setWindingRule: NSEvenOddWindingRule];
+  rep = clipSaveFill(w, h, p);
+  PASS(rep != nil && GSPixelIs(rep, 5, 12, 255, 0, 0),
+       "an even-odd ring clip still paints the ring after save/restore");
+  PASS(rep != nil && GSPixelIs(rep, 12, 12, 255, 255, 255),
+       "an even-odd ring clip keeps its hole after save/restore");
+
+  END_SET("clipping")
+  return 0;
+}

--- a/Tests/gui/NSGraphicsContext/clippingStack.m
+++ b/Tests/gui/NSGraphicsContext/clippingStack.m
@@ -1,0 +1,74 @@
+/* Successive clips intersect: setting a second clip does not replace the
+ * first, so drawing is confined to the intersection of the two, and two
+ * disjoint clips leave nothing to draw.  The other clipping tests only set a
+ * single clip, so this covers the accumulation of the clip stack.
+ *
+ * None of it is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#import "../GSDrawTest.h"
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("clip stack")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  if (NO == GSCanDrawOffscreen())
+    {
+      SKIP("the installed backend does not draw offscreen")
+    }
+
+  int w = 20, h = 20;
+  NSImage *img;
+  NSBitmapImageRep *rep;
+
+  /* Two clips intersect: a clip to the left half and then to the top half
+   * confine a fill to the top-left quadrant only. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  NSRectClip(NSMakeRect(0, 0, w / 2, h));
+  NSRectClip(NSMakeRect(0, h / 2, w, h / 2));
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, w / 4, h - 1 - (3 * h / 4), 255, 0, 0),
+       "two clips admit drawing in their intersecting quadrant");
+  PASS(rep != nil && GSPixelIs(rep, 3 * w / 4, h - 1 - (3 * h / 4), 255, 255, 255),
+       "the quadrant outside the first clip stays clear");
+  PASS(rep != nil && GSPixelIs(rep, w / 4, h - 1 - (h / 4), 255, 255, 255),
+       "the quadrant outside the second clip stays clear");
+
+  /* Two disjoint clips leave an empty region: a clip to the left half and then
+   * to the right half admit no drawing at all. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  NSRectClip(NSMakeRect(0, 0, w / 2, h));
+  NSRectClip(NSMakeRect(w / 2, 0, w / 2, h));
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, w / 4, h / 2, 255, 255, 255)
+       && GSPixelIs(rep, 3 * w / 4, h / 2, 255, 255, 255),
+       "two disjoint clips leave nothing to draw");
+
+  END_SET("clip stack")
+
+  return 0;
+}

--- a/Tests/gui/NSGraphicsContext/compositeOperators.m
+++ b/Tests/gui/NSGraphicsContext/compositeOperators.m
@@ -1,0 +1,73 @@
+/* The compositing operators, checked by reading the pixels back: copy
+ * replaces the destination, source-over shows an opaque source and blends a
+ * transparent one, destination-over keeps an opaque destination,
+ * plus-lighter adds the two, and clear erases.
+ *
+ * None of it is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none.  Colours are checked with a
+ * small tolerance, because a backend may carry them through fixed-point
+ * arithmetic.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#import "../GSDrawTest.h"
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+/* Fill a red destination, then fill it again with FG using OP, and read the
+ * centre pixel back. */
+static NSBitmapImageRep *
+composite(NSColor *fg, NSCompositingOperation op)
+{
+  int w = 20, h = 20;
+  NSImage *img = GSDrawBegin(w, h);
+
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [fg set];
+  NSRectFillUsingOperation(NSMakeRect(0, 0, w, h), op);
+  return GSDrawEnd(img, w, h);
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("composite ops")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  if (NO == GSCanDrawOffscreen())
+    {
+      SKIP("the installed backend does not draw offscreen")
+    }
+
+  NSColor *blue = [NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0];
+  NSColor *green = [NSColor colorWithDeviceRed: 0.0 green: 1.0 blue: 0.0 alpha: 1.0];
+
+  PASS(GSPixelIs(composite(blue, NSCompositeCopy), 10, 10, 0, 0, 255),
+    "copy replaces the destination with the source");
+
+  PASS(GSPixelIs(composite(blue, NSCompositeSourceOver), 10, 10, 0, 0, 255),
+    "source-over with an opaque source shows the source");
+
+  PASS(GSPixelIs(composite(blue, NSCompositeDestinationOver), 10, 10, 255, 0, 0),
+    "destination-over keeps the opaque destination");
+
+  PASS(GSPixelIs(composite(green, NSCompositePlusLighter), 10, 10, 255, 255, 0),
+    "plus-lighter adds the source to the destination");
+
+  PASS(GSPixelIs(composite(blue, NSCompositeClear), 10, 10, 0, 0, 0),
+    "clear erases the destination");
+
+  END_SET("composite ops")
+  return 0;
+}

--- a/Tests/gui/NSGraphicsContext/drawing.m
+++ b/Tests/gui/NSGraphicsContext/drawing.m
@@ -1,0 +1,397 @@
+/* Drawing through the AppKit path, checked by reading the pixels back: lock
+ * focus on an image, draw, then read it with -initWithFocusedViewRect: and
+ * look at what was painted.  This covers fills, bezier fills, alpha
+ * compositing, strokes with their caps, joins and dashes, clipping, drawing
+ * an image, drawing text, and the translate, scale and rotate transforms.
+ *
+ * None of it is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none.  Colours are checked with a
+ * small tolerance, because a backend may carry them through fixed-point
+ * arithmetic.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#import "../GSDrawTest.h"
+
+#import <AppKit/AppKit.h>
+#import <AppKit/NSBezierPath.h>
+#include <stdlib.h>
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("general drawing")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  if (NO == GSCanDrawOffscreen())
+    {
+      SKIP("the installed backend does not draw offscreen")
+    }
+
+  int w = 20, h = 20;
+  NSImage *img;
+  NSBitmapImageRep *rep;
+
+  /* A solid fill covers the whole image with one colour. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, w / 2, h / 2, 255, 0, 0),
+       "a solid red fill reads back red");
+
+  /* A second fill over the left half leaves the right half untouched.  The x
+   * axis is not affected by the flipped y origin, so left stays left. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 0.0 green: 1.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w / 2, h));
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, w / 4, h / 2, 0, 255, 0),
+       "the left half is filled green");
+  PASS(rep != nil && GSPixelIs(rep, 3 * w / 4, h / 2, 255, 0, 0),
+       "the right half stays red");
+
+  /* Filling a bezier-path rectangle paints inside and leaves outside alone. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0] set];
+  {
+    NSBezierPath *p = [NSBezierPath bezierPath];
+    [p appendBezierPathWithRect: NSMakeRect(2, 2, 6, 6)];
+    [p fill];
+  }
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 5, h - 1 - 5, 0, 0, 255),
+       "a filled bezier rectangle paints blue inside");
+  PASS(rep != nil && GSPixelIs(rep, w - 3, h / 2, 255, 0, 0),
+       "outside the bezier rectangle stays red");
+
+  /* Compositing a half-transparent white over red lightens it (source-over):
+   * out = 255*0.5 + 255*0.5 for red, 0*0.5 + 255*0.5 for green/blue ~= 127. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 0.5] set];
+  NSRectFillUsingOperation(NSMakeRect(0, 0, w, h), NSCompositeSourceOver);
+  rep = GSDrawEnd(img, w, h);
+  {
+    unsigned char *d = [rep bitmapData];
+    unsigned char *px = d + (h / 2) * [rep bytesPerRow]
+                          + (w / 2) * [rep samplesPerPixel];
+    PASS(px[0] >= 250 && px[1] >= 110 && px[1] <= 145
+         && px[2] >= 110 && px[2] <= 145,
+         "half-transparent white over red lightens green and blue to ~127");
+  }
+
+  /* A stroked line paints along its width and leaves clear pixels alone. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  {
+    NSBezierPath *p = [NSBezierPath bezierPath];
+    [p setLineWidth: 4.0];
+    [p moveToPoint: NSMakePoint(0, h / 2)];
+    [p lineToPoint: NSMakePoint(w, h / 2)];
+    [p stroke];
+  }
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, w / 2, h / 2, 0, 0, 0),
+       "a stroked line paints black along its centre");
+  PASS(rep != nil && GSPixelIs(rep, w / 2, h / 2 - 7, 255, 255, 255),
+       "pixels clear of the stroked line stay white");
+
+  /* A clip rectangle confines drawing to the left half of the image. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  NSRectClip(NSMakeRect(0, 0, w / 2, h));
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, w / 4, h / 2, 255, 0, 0),
+       "drawing inside the clip rectangle is painted");
+  PASS(rep != nil && GSPixelIs(rep, 3 * w / 4, h / 2, 255, 255, 255),
+       "drawing outside the clip rectangle is suppressed");
+
+  /* Drawing an image paints its pixels into the destination. */
+  {
+    NSBitmapImageRep *srcRep;
+    NSImage *src;
+    unsigned char *sd;
+    int i;
+
+    srcRep = [[NSBitmapImageRep alloc]
+        initWithBitmapDataPlanes: NULL
+                      pixelsWide: 8
+                      pixelsHigh: 8
+                   bitsPerSample: 8
+                 samplesPerPixel: 4
+                        hasAlpha: YES
+                        isPlanar: NO
+                  colorSpaceName: NSDeviceRGBColorSpace
+                     bytesPerRow: 0
+                    bitsPerPixel: 0];
+    sd = [srcRep bitmapData];
+    for (i = 0; i < 8 * 8; i++)
+      {
+        sd[i * 4 + 0] = 0;
+        sd[i * 4 + 1] = 255;
+        sd[i * 4 + 2] = 0;
+        sd[i * 4 + 3] = 255;
+      }
+    src = [[NSImage alloc] initWithSize: NSMakeSize(8, 8)];
+    [src addRepresentation: srcRep];
+    [srcRep release];
+
+    img = GSDrawBegin(w, h);
+    [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 1.0] set];
+    NSRectFill(NSMakeRect(0, 0, w, h));
+    [src drawInRect: NSMakeRect(0, 0, w / 2, h)
+           fromRect: NSZeroRect
+          operation: NSCompositeSourceOver
+           fraction: 1.0];
+    rep = GSDrawEnd(img, w, h);
+    [src release];
+
+    PASS(rep != nil && GSPixelIs(rep, w / 4, h / 2, 0, 255, 0),
+         "a drawn image paints its pixels (green) where it is drawn");
+    PASS(rep != nil && GSPixelIs(rep, 3 * w / 4, h / 2, 255, 255, 255),
+         "the area where no image was drawn stays white");
+  }
+
+  /* Drawing text paints glyph pixels.  The shapes are font-dependent, so just
+   * check that some black glyphs were painted and the whole image was not
+   * covered. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  {
+    NSDictionary *attrs = [NSDictionary dictionaryWithObjectsAndKeys:
+        [NSColor blackColor], NSForegroundColorAttributeName,
+        [NSFont systemFontOfSize: 14], NSFontAttributeName, nil];
+    [@"H" drawAtPoint: NSMakePoint(4, 2) withAttributes: attrs];
+  }
+  rep = GSDrawEnd(img, w, h);
+  {
+    unsigned char *d = [rep bitmapData];
+    long bpr = [rep bytesPerRow], spp = [rep samplesPerPixel];
+    long x, y, dark = 0;
+
+    for (y = 0; y < h; y++)
+      for (x = 0; x < w; x++)
+        {
+          unsigned char *px = d + y * bpr + x * spp;
+          if (px[0] < 100 && px[1] < 100 && px[2] < 100)
+            dark++;
+        }
+    PASS(rep != nil && dark > 0 && dark < (long)w * h,
+         "drawing text paints some black glyph pixels but not the whole image");
+  }
+
+  /* Line caps: a butt cap ends at the endpoint, a square cap extends past it by
+   * half the line width.  The line runs to x = 12 with width 6, so x = 14 is
+   * inside a square cap but clear of a butt cap. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  {
+    NSBezierPath *p = [NSBezierPath bezierPath];
+    [p setLineWidth: 6.0];
+    [p setLineCapStyle: NSButtLineCapStyle];
+    [p moveToPoint: NSMakePoint(4, h / 2)];
+    [p lineToPoint: NSMakePoint(12, h / 2)];
+    [p stroke];
+  }
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 14, h / 2, 255, 255, 255),
+       "a butt line cap does not paint past the endpoint");
+
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  {
+    NSBezierPath *p = [NSBezierPath bezierPath];
+    [p setLineWidth: 6.0];
+    [p setLineCapStyle: NSSquareLineCapStyle];
+    [p moveToPoint: NSMakePoint(4, h / 2)];
+    [p lineToPoint: NSMakePoint(12, h / 2)];
+    [p stroke];
+  }
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 14, h / 2, 0, 0, 0),
+       "a square line cap paints past the endpoint");
+
+  /* A dash pattern paints some segments of the line and leaves gaps. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  {
+    NSBezierPath *p = [NSBezierPath bezierPath];
+    CGFloat pattern[2] = { 4.0, 4.0 };
+    [p setLineWidth: 4.0];
+    [p setLineDash: pattern count: 2 phase: 0.0];
+    [p moveToPoint: NSMakePoint(0, h / 2)];
+    [p lineToPoint: NSMakePoint(w, h / 2)];
+    [p stroke];
+  }
+  rep = GSDrawEnd(img, w, h);
+  {
+    unsigned char *d = [rep bitmapData];
+    long bpr = [rep bytesPerRow], spp = [rep samplesPerPixel];
+    long x, on = 0, off = 0;
+    for (x = 0; x < w; x++)
+      {
+        unsigned char *px = d + (h / 2) * bpr + x * spp;
+        if (px[0] < 100) on++;
+        else if (px[0] > 200) off++;
+      }
+    PASS(rep != nil && on > 0 && off > 0,
+         "a dashed line paints some segments and leaves gaps");
+  }
+
+  /* Line joins: a miter join fills the sharp outer corner, a bevel cuts it off,
+   * so a miter paints more of the outer-corner region than a bevel. */
+  {
+    long dark[2] = { 0, 0 };
+    int style;
+
+    for (style = 0; style < 2; style++)
+      {
+        unsigned char *d;
+        long bpr, spp, cx, cy;
+
+        img = GSDrawBegin(w, h);
+        [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 1.0] set];
+        NSRectFill(NSMakeRect(0, 0, w, h));
+        [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+        {
+          NSBezierPath *p = [NSBezierPath bezierPath];
+          [p setLineWidth: 6.0];
+          [p setLineJoinStyle: (style == 0 ? NSMiterLineJoinStyle
+                                           : NSBevelLineJoinStyle)];
+          [p moveToPoint: NSMakePoint(5, 4)];
+          [p lineToPoint: NSMakePoint(5, 14)];
+          [p lineToPoint: NSMakePoint(15, 14)];
+          [p stroke];
+        }
+        rep = GSDrawEnd(img, w, h);
+        d = [rep bitmapData];
+        bpr = [rep bytesPerRow];
+        spp = [rep samplesPerPixel];
+        for (cy = 1; cy <= 5; cy++)
+          for (cx = 0; cx <= 4; cx++)
+            {
+              unsigned char *px = d + cy * bpr + cx * spp;
+              if (px[0] < 100)
+                dark[style]++;
+            }
+      }
+    PASS(dark[0] > dark[1],
+         "a miter join fills the outer corner more than a bevel join");
+  }
+
+  /* A translate transform offsets subsequent drawing.  The transform is applied
+   * inside a saved graphics state and restored before the pixels are read back,
+   * so the read-back uses the identity transform. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [NSGraphicsContext saveGraphicsState];
+  {
+    NSAffineTransform *t = [NSAffineTransform transform];
+    [t translateXBy: w / 2 yBy: 0.0];
+    [t concat];
+    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+    NSRectFill(NSMakeRect(0, 0, 4, h));
+  }
+  [NSGraphicsContext restoreGraphicsState];
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, w / 2 + 2, h / 2, 255, 0, 0),
+       "a translate transform moves the fill to the offset position");
+  PASS(rep != nil && GSPixelIs(rep, 2, h / 2, 255, 255, 255),
+       "the untranslated origin is left unpainted");
+
+  /* A non-rectangular (triangular) clip path confines drawing to the path.  The
+   * triangle has corners (0,0), (w,0), (0,h), so the lower-left corner is inside
+   * and the upper-right corner is outside. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  {
+    NSBezierPath *tri = [NSBezierPath bezierPath];
+    [tri moveToPoint: NSMakePoint(0, 0)];
+    [tri lineToPoint: NSMakePoint(w, 0)];
+    [tri lineToPoint: NSMakePoint(0, h)];
+    [tri closePath];
+    [tri addClip];
+    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+    NSRectFill(NSMakeRect(0, 0, w, h));
+  }
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 2, h - 3, 255, 0, 0),
+       "drawing inside a triangular clip path is painted");
+  PASS(rep != nil && GSPixelIs(rep, w - 3, 2, 255, 255, 255),
+       "drawing outside the triangular clip path is suppressed");
+
+  /* A scale transform enlarges subsequent drawing.  A 4-wide strip scaled 2x in
+   * x reaches to x = 8, so x = 6 is inside it and x = 10 is beyond. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [NSGraphicsContext saveGraphicsState];
+  {
+    NSAffineTransform *t = [NSAffineTransform transform];
+    [t scaleXBy: 2.0 yBy: 1.0];
+    [t concat];
+    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+    NSRectFill(NSMakeRect(0, 0, 4, h));
+  }
+  [NSGraphicsContext restoreGraphicsState];
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 6, h / 2, 255, 0, 0),
+       "a scale transform enlarges the fill in x");
+  PASS(rep != nil && GSPixelIs(rep, 10, h / 2, 255, 255, 255),
+       "the area beyond the scaled fill stays white");
+
+  /* A 90-degree rotation about the centre moves a right-middle mark to the top.
+   * A point (x,y) about centre (w/2,h/2) rotates to (w/2 + (h/2 - y),
+   * h/2 + (x - w/2)); the mark at (~18,~10) lands at (~10,~18) = top-middle. */
+  img = GSDrawBegin(w, h);
+  [[NSColor colorWithDeviceRed: 1.0 green: 1.0 blue: 1.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [NSGraphicsContext saveGraphicsState];
+  {
+    NSAffineTransform *t = [NSAffineTransform transform];
+    [t translateXBy: w / 2.0 yBy: h / 2.0];
+    [t rotateByDegrees: 90.0];
+    [t translateXBy: -w / 2.0 yBy: -h / 2.0];
+    [t concat];
+    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+    NSRectFill(NSMakeRect(w - 4, h / 2 - 2, 4, 4));
+  }
+  [NSGraphicsContext restoreGraphicsState];
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, w / 2, 2, 255, 0, 0),
+       "a 90-degree rotation moves the right-middle mark to the top");
+  PASS(rep != nil && GSPixelIs(rep, w - 2, h / 2, 255, 255, 255),
+       "the mark's original position is left unpainted after rotation");
+
+  END_SET("general drawing")
+  return 0;
+}

--- a/Tests/gui/NSGraphicsContext/graphicsStateStack.m
+++ b/Tests/gui/NSGraphicsContext/graphicsStateStack.m
@@ -1,0 +1,107 @@
+/* The graphics state stack, checked by reading the pixels back: a save and
+ * restore recovers the fill colour that was in force, lifts a clip that was
+ * set inside it, and nests, so an inner restore recovers the middle entry
+ * and an outer restore the first.
+ *
+ * None of it is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#import "../GSDrawTest.h"
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("graphics state")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  if (NO == GSCanDrawOffscreen())
+    {
+      SKIP("the installed backend does not draw offscreen")
+    }
+
+  int w = 20, h = 20;
+  NSImage *img;
+  NSBitmapImageRep *rep;
+
+  /* Restoring the graphics state recovers the earlier fill colour: red is set,
+   * the state saved, blue set, then restored, so a fill uses red again. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  [NSGraphicsContext saveGraphicsState];
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0] set];
+  [NSGraphicsContext restoreGraphicsState];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, w / 2, h / 2, 255, 0, 0),
+       "restoring the graphics state recovers the earlier fill colour");
+
+  /* Restoring the graphics state recovers the earlier clip: with no clip set, a
+   * clip to the left half is applied inside a saved state, then restored, so a
+   * following fill reaches the right half again. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [NSGraphicsContext saveGraphicsState];
+  NSRectClip(NSMakeRect(0, 0, w / 2, h));
+  [NSGraphicsContext restoreGraphicsState];
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 3 * w / 4, h / 2, 255, 0, 0),
+       "restoring the graphics state lifts a clip set inside it");
+
+  /* A clip applied inside a saved state still confines drawing before the
+   * restore. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [NSGraphicsContext saveGraphicsState];
+  NSRectClip(NSMakeRect(0, 0, w / 2, h));
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [NSGraphicsContext restoreGraphicsState];
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, w / 4, h / 2, 255, 0, 0)
+       && GSPixelIs(rep, 3 * w / 4, h / 2, 255, 255, 255),
+       "a clip inside a saved state confines drawing before the restore");
+
+  /* The stack nests: red, save, green, save, blue, inner restore back to green,
+   * outer restore back to red.  The left strip is filled after the inner
+   * restore (green) and the right strip after the outer restore (red). */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  [NSGraphicsContext saveGraphicsState];
+  [[NSColor colorWithDeviceRed: 0.0 green: 1.0 blue: 0.0 alpha: 1.0] set];
+  [NSGraphicsContext saveGraphicsState];
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0] set];
+  [NSGraphicsContext restoreGraphicsState];
+  NSRectFill(NSMakeRect(0, 0, w / 2, h));
+  [NSGraphicsContext restoreGraphicsState];
+  NSRectFill(NSMakeRect(w / 2, 0, w / 2, h));
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, w / 4, h / 2, 0, 255, 0),
+       "an inner restore recovers the middle colour on the stack");
+  PASS(rep != nil && GSPixelIs(rep, 3 * w / 4, h / 2, 255, 0, 0),
+       "an outer restore recovers the first colour on the stack");
+
+  END_SET("graphics state")
+  return 0;
+}

--- a/Tests/gui/NSImage/drawingAlpha.m
+++ b/Tests/gui/NSImage/drawingAlpha.m
@@ -1,0 +1,102 @@
+/* Drawing an image with an alpha channel, checked by reading the pixels
+ * back: a half-transparent image composites with what is under it, and an
+ * opaque one shows its own colour.
+ *
+ * None of it is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none.  Colours are checked with a
+ * small tolerance, because a backend may carry them through fixed-point
+ * arithmetic.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#import "../GSDrawTest.h"
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+/* An n x n bitmap filled with one RGBA colour. */
+static NSImage *
+solidImage(int n, int r, int g, int b, int a)
+{
+  NSBitmapImageRep *rep = [[NSBitmapImageRep alloc]
+    initWithBitmapDataPlanes: NULL pixelsWide: n pixelsHigh: n
+                bitsPerSample: 8 samplesPerPixel: 4 hasAlpha: YES isPlanar: NO
+               colorSpaceName: NSDeviceRGBColorSpace
+                 bitmapFormat: NSAlphaNonpremultipliedBitmapFormat
+                  bytesPerRow: n * 4 bitsPerPixel: 32];
+  unsigned char *d = [rep bitmapData];
+  NSImage *img;
+  int i;
+
+  for (i = 0; i < n * n; i++)
+    {
+      d[i * 4 + 0] = r;
+      d[i * 4 + 1] = g;
+      d[i * 4 + 2] = b;
+      d[i * 4 + 3] = a;
+    }
+  img = [[NSImage alloc] initWithSize: NSMakeSize(n, n)];
+  [img addRepresentation: rep];
+  [rep release];
+  return AUTORELEASE(img);
+}
+
+/* Draw IMG over a solid background of the given gray and read the centre. */
+static NSBitmapImageRep *
+over(NSImage *img, int bg)
+{
+  int w = 20, h = 20;
+  NSImage *dst = [[NSImage alloc] initWithSize: NSMakeSize(w, h)];
+  NSBitmapImageRep *rep;
+
+  [dst lockFocus];
+  [[NSColor colorWithDeviceRed: bg / 255.0 green: bg / 255.0 blue: bg / 255.0
+                         alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [img drawInRect: NSMakeRect(0, 0, w, h)
+         fromRect: NSZeroRect
+        operation: NSCompositeSourceOver
+         fraction: 1.0];
+  [[NSGraphicsContext currentContext] flushGraphics];
+  rep = [[NSBitmapImageRep alloc]
+          initWithFocusedViewRect: NSMakeRect(0, 0, w, h)];
+  [dst unlockFocus];
+  [dst release];
+  return AUTORELEASE(rep);
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("image alpha")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  if (NO == GSCanDrawOffscreen())
+    {
+      SKIP("the installed backend does not draw offscreen")
+    }
+
+  /* a half-transparent gray over black is half of 128 */
+  PASS(GSPixelIs(over(solidImage(4, 128, 128, 128, 128), 0), 10, 10, 64, 64, 64),
+    "a half-transparent gray image over black composites to a quarter tone");
+
+  /* a half-transparent gray over white keeps half the background */
+  PASS(GSPixelIs(over(solidImage(4, 128, 128, 128, 128), 255), 10, 10, 191, 191, 191),
+    "a half-transparent gray image over white composites to a light tone");
+
+  /* an opaque image still shows its own colour (regression guard) */
+  PASS(GSPixelIs(over(solidImage(4, 128, 128, 128, 255), 0), 10, 10, 128, 128, 128),
+    "an opaque gray image over black shows its colour");
+
+  END_SET("image alpha")
+  return 0;
+}

--- a/Tests/gui/NSImage/drawingPixels.m
+++ b/Tests/gui/NSImage/drawingPixels.m
@@ -1,0 +1,108 @@
+/* The pixels of a drawn image, checked by reading them back: the image keeps
+ * its orientation, with the top of the bitmap at the top, and a 24-bit image
+ * with no alpha channel decodes to its own colour.
+ *
+ * None of it is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#import "../GSDrawTest.h"
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+/* Draw SRC scaled over the whole 20x20 canvas with nearest-neighbour sampling,
+ * so each source pixel stays a solid block. */
+static NSBitmapImageRep *
+draw(NSImage *src)
+{
+  int w = 20, h = 20;
+  NSImage *dst = [[NSImage alloc] initWithSize: NSMakeSize(w, h)];
+  NSBitmapImageRep *rep;
+
+  [dst lockFocus];
+  [[NSGraphicsContext currentContext]
+    setImageInterpolation: NSImageInterpolationNone];
+  [[NSColor colorWithDeviceRed: 0 green: 0 blue: 0 alpha: 1] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [src drawInRect: NSMakeRect(0, 0, w, h)
+         fromRect: NSZeroRect
+        operation: NSCompositeSourceOver
+         fraction: 1.0];
+  [[NSGraphicsContext currentContext] flushGraphics];
+  rep = [[NSBitmapImageRep alloc]
+          initWithFocusedViewRect: NSMakeRect(0, 0, w, h)];
+  [dst unlockFocus];
+  [dst release];
+  return [rep autorelease];
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("image pixels")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  if (NO == GSCanDrawOffscreen())
+    {
+      SKIP("the installed backend does not draw offscreen")
+    }
+
+  NSBitmapImageRep *rep, *out;
+  NSImage *src;
+  unsigned char *d;
+  int i;
+
+  /* A 2x2 image, bitmap row 0 (top) = red, green; row 1 (bottom) = blue, white.
+   * Drawn over the canvas it must keep that layout. */
+  rep = [[NSBitmapImageRep alloc]
+    initWithBitmapDataPlanes: NULL pixelsWide: 2 pixelsHigh: 2
+                bitsPerSample: 8 samplesPerPixel: 4 hasAlpha: YES isPlanar: NO
+               colorSpaceName: NSDeviceRGBColorSpace bytesPerRow: 8 bitsPerPixel: 32];
+  d = [rep bitmapData];
+  d[0]  = 255; d[1]  = 0;   d[2]  = 0;   d[3]  = 255;   /* top-left  red   */
+  d[4]  = 0;   d[5]  = 255; d[6]  = 0;   d[7]  = 255;   /* top-right green */
+  d[8]  = 0;   d[9]  = 0;   d[10] = 255; d[11] = 255;   /* bot-left  blue  */
+  d[12] = 255; d[13] = 255; d[14] = 255; d[15] = 255;   /* bot-right white */
+  src = [[NSImage alloc] initWithSize: NSMakeSize(2, 2)];
+  [src addRepresentation: rep];
+  [rep release];
+  out = draw(src);
+  [src release];
+
+  PASS(GSPixelIs(out, 5, 5, 255, 0, 0)
+    && GSPixelIs(out, 15, 5, 0, 255, 0)
+    && GSPixelIs(out, 5, 15, 0, 0, 255)
+    && GSPixelIs(out, 15, 15, 255, 255, 255),
+    "the image keeps its orientation, top of the bitmap at the top");
+
+  /* A 24-bit RGB image without alpha decodes to its colour. */
+  rep = [[NSBitmapImageRep alloc]
+    initWithBitmapDataPlanes: NULL pixelsWide: 2 pixelsHigh: 2
+                bitsPerSample: 8 samplesPerPixel: 3 hasAlpha: NO isPlanar: NO
+               colorSpaceName: NSDeviceRGBColorSpace bytesPerRow: 6 bitsPerPixel: 24];
+  d = [rep bitmapData];
+  for (i = 0; i < 4; i++)
+    { d[i * 3 + 0] = 0; d[i * 3 + 1] = 255; d[i * 3 + 2] = 255; }
+  src = [[NSImage alloc] initWithSize: NSMakeSize(2, 2)];
+  [src addRepresentation: rep];
+  [rep release];
+  out = draw(src);
+  [src release];
+
+  PASS(GSPixelIs(out, 10, 10, 0, 255, 255),
+    "a 24-bit rgb image without alpha decodes to its colour");
+
+  END_SET("image pixels")
+  return 0;
+}

--- a/Tests/gui/NSShadow/drawingShadow.m
+++ b/Tests/gui/NSShadow/drawingShadow.m
@@ -1,0 +1,127 @@
+/* A shadow set on the graphics context, checked by reading the pixels back.
+ * A shape is drawn with a coloured shadow at a known offset; the offset
+ * region carries the shadow colour, the shape sits on top of its own shadow
+ * in its own colour, the shadow does not reach beyond its offset region, and
+ * restoring the graphics state clears it.  Fill, even-odd fill and stroke
+ * are each exercised.
+ *
+ * None of it is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none.  Colours are checked with a
+ * small tolerance, because a backend may carry them through fixed-point
+ * arithmetic.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#import "../GSDrawTest.h"
+
+#import <AppKit/AppKit.h>
+#import <AppKit/NSBezierPath.h>
+#import <AppKit/NSShadow.h>
+#include <stdlib.h>
+
+static NSShadow *
+redShadow(void)
+{
+  NSShadow *s = [[[NSShadow alloc] init] autorelease];
+
+  [s setShadowColor: [NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0
+                                           alpha: 1.0]];
+  [s setShadowOffset: NSMakeSize(8, -8)];
+  [s setShadowBlurRadius: 0.0];
+  return s;
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("shadow")
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  if (NO == GSCanDrawOffscreen())
+    {
+      SKIP("the installed backend does not draw offscreen")
+    }
+
+  int w = 40, h = 40;
+  NSImage *img;
+  NSBitmapImageRep *rep;
+  NSBezierPath *p;
+
+  /* A blue rectangle with a red shadow offset to the lower right.  The shape
+   * spans device x,y in 10..22 and the shadow 18..30 vertically 12..24. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [NSGraphicsContext saveGraphicsState];
+  [redShadow() set];
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0] set];
+  [[NSBezierPath bezierPathWithRect: NSMakeRect(10, 20, 12, 12)] fill];
+  [NSGraphicsContext restoreGraphicsState];
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 28, h - 1 - 16, 255, 0, 0),
+       "a filled shape casts a shadow at the offset location");
+  PASS(rep != nil && GSPixelIs(rep, 12, h - 1 - 30, 0, 0, 255),
+       "a filled shape is drawn in its own colour");
+  PASS(rep != nil && GSPixelIs(rep, 20, h - 1 - 22, 0, 0, 255),
+       "a filled shape sits on top of its own shadow");
+  PASS(rep != nil && GSPixelIs(rep, 3, h - 1 - 3, 255, 255, 255),
+       "the shadow does not extend beyond its offset region");
+
+  /* Even-odd fill casts a shadow through the same path. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [NSGraphicsContext saveGraphicsState];
+  [redShadow() set];
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0] set];
+  p = [NSBezierPath bezierPathWithRect: NSMakeRect(10, 20, 12, 12)];
+  [p setWindingRule: NSEvenOddWindingRule];
+  [p fill];
+  [NSGraphicsContext restoreGraphicsState];
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 28, h - 1 - 16, 255, 0, 0),
+       "an even-odd fill casts a shadow at the offset location");
+
+  /* A stroked shape casts a shadow of its outline. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [NSGraphicsContext saveGraphicsState];
+  [redShadow() set];
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0] set];
+  p = [NSBezierPath bezierPathWithRect: NSMakeRect(10, 20, 12, 12)];
+  [p setLineWidth: 6];
+  [p stroke];
+  [NSGraphicsContext restoreGraphicsState];
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 30, h - 1 - 18, 255, 0, 0),
+       "a stroked shape casts a shadow of its outline");
+  PASS(rep != nil && GSPixelIs(rep, 22, h - 1 - 26, 0, 0, 255),
+       "a stroked shape is drawn in its own colour");
+
+  /* The shadow follows the graphics state stack: after the state that set it is
+   * restored, a further fill casts no shadow. */
+  img = GSDrawBegin(w, h);
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [NSGraphicsContext saveGraphicsState];
+  [redShadow() set];
+  [NSGraphicsContext restoreGraphicsState];
+  [[NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0] set];
+  [[NSBezierPath bezierPathWithRect: NSMakeRect(10, 20, 12, 12)] fill];
+  rep = GSDrawEnd(img, w, h);
+  PASS(rep != nil && GSPixelIs(rep, 28, h - 1 - 16, 255, 255, 255),
+       "a restored graphics state clears the shadow");
+
+  END_SET("shadow")
+  return 0;
+}


### PR DESCRIPTION
Tests of general AppKit drawing live under one backend's directory in libs-back, guarded to that backend, so each runs against one graphics backend only. gnustep/libs-back#167 proposed moving those here so they run against whichever backend is installed. This is the drawing half of that.

Ten files, covering fills, alpha compositing, strokes with their caps, joins and dashes, curves, the winding rule, clipping, the graphics state stack, the compositing operators, image drawing and shadows. A new Tests/gui/GSDrawTest.h holds the offscreen draw and pixel read-back helpers, beside the existing GSRenderTest.h.

Each skips when no backend is installed, and when the installed one cannot draw offscreen, which is how the headless backend reports rather than failing every assertion.

Gradients are left out until gnustep/libs-back#190 merges, since before it they hang rather than fail on every backend but cairo and opal.

Run against eight configurations: green on x11 with cairo and with art, and on wayland with cairo; skipped on headless; 9 failed on xlib, 10 on opal, 6 on win32 with cairo, 17 on winlib. Those are backend gaps, two already gnustep/libs-back#188 and #189.

The libs-back copies are not removed here, and fonts are not moved yet.
