### PR TITLE
Fix: do not raise out of +[NSWorkspace initialize]

### DIFF
--- a/Source/NSWorkspace.m
+++ b/Source/NSWorkspace.m
@@ -629,15 +629,32 @@ static NSDictionary		*urlPreferences = nil;
       NS_DURING
 	{
 	  NSFileManager	*mgr = [NSFileManager defaultManager];
+	  NSArray	*library;
 	  NSString	*service;
 	  NSData	*data;
 	  NSDictionary	*dict;
 
+	  /* Without a library directory of the user's own there is nowhere for
+	   * any of this to have been cached, which happens where the home
+	   * directory cannot be resolved.  Leave the paths unset and load
+	   * nothing: a nil path reads as unreadable, so the loads below are
+	   * skipped, and the class stays usable.
+	   */
+	  library = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory,
+	    NSUserDomainMask, YES);
+	  if ([library count] == 0)
+	    {
+	      NSLog(@"No library directory for the user: the workspace"
+		@" preferences and the cached application list are"
+		@" unavailable.");
+	      service = nil;
+	    }
+	  else
+	    {
+	      service = [[library objectAtIndex: 0]
+		stringByAppendingPathComponent: @"Services"];
+	    }
 
-	  service = [[NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, 
-	    NSUserDomainMask, YES) objectAtIndex: 0]
-	    stringByAppendingPathComponent: @"Services"];
-	  
 	  /*
 	   *	Load file extension preferences.
 	   */
@@ -691,7 +708,11 @@ static NSDictionary		*urlPreferences = nil;
 	}
       NS_HANDLER
 	{
-	  [localException raise];
+	  /* None of this is needed for the class to work, and raising from
+	   * +initialize leaves it half set up and hands the exception to
+	   * whichever caller happened to touch it first.  Report and carry on.
+	   */
+	  NSLog(@"Unable to read the workspace preferences: %@", localException);
 	}
       NS_ENDHANDLER
     }


### PR DESCRIPTION
+[NSWorkspace initialize] reads the file extension preferences, the URL scheme preferences and the cached application list, inside an NS_DURING whose handler is [localException raise]. Any failure there is therefore re-raised out of +initialize, which leaves the class half set up and hands the exception to whichever caller first touched it. None of those files is needed for the class to work, so the failure is now reported and initialisation carries on.

The directory it reads them from comes from the user's library search path, taken with objectAtIndex: 0 without checking there is one. Where the home directory does not resolve that array is empty, so this raised NSRangeException before any of the reads were attempted. It now logs and leaves the three paths unset, which is safe: a nil path reads as unreadable, so the loads are skipped.

There is no automated test, since provoking either needs a machine whose home directory does not resolve.

Verified two ways. On such a machine the NSRangeException is gone and the class initialises. On a normal one the full test suite is unchanged at 4353 passed, no failures and no failed builds.
