### PR TITLE
tests: add the font and glyph metric tests, run against any backend

### DIFF
--- a/Tests/gui/NSFont/fontmetrics.m
+++ b/Tests/gui/NSFont/fontmetrics.m
@@ -1,0 +1,102 @@
+/* Font metrics through NSFont.  The width of a string is its advance (how far
+ * the drawing pen moves), so the width of a run of one character is a whole
+ * multiple of a single character's width; the ink bounding box, which is
+ * narrower, would not add up.  Also check that the metrics follow the point
+ * size and that the ascender and descender have the right signs.
+ *
+ * The metrics of a scaled font are not exactly the metrics of the unscaled one
+ * multiplied, because a font may be designed differently at different sizes,
+ * so the two size assertions allow a tenth either way.  That is still far
+ * inside a backend which ignores the point size altogether.
+ *
+ * None of this is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none, or when that backend reports no
+ * metrics.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+#include <math.h>
+
+static BOOL
+nearly(CGFloat a, CGFloat b)
+{
+  CGFloat d = a - b;
+
+  return (d < 0.5 && d > -0.5) ? YES : NO;
+}
+
+/* `a` is within a tenth of `b`, both being positive metrics. */
+static BOOL
+inProportion(CGFloat a, CGFloat b)
+{
+  if (a <= 0.0 || b <= 0.0)
+    {
+      return NO;
+    }
+  return (fabs((double)(a - b)) <= 0.1 * (double)b) ? YES : NO;
+}
+
+int
+main(int argc, char **argv)
+{
+  START_SET("font metrics")
+
+  NSFont *f, *big;
+  CGFloat wi, wiiii, wW, wWWWW;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  f = [NSFont systemFontOfSize: 14];
+  big = [NSFont systemFontOfSize: 28];
+  if (nil == f || nil == big)
+    {
+      SKIP("the installed backend builds no font")
+    }
+  if ([f maximumAdvancement].width <= 0.0)
+    {
+      SKIP("the installed backend reports no font metrics")
+    }
+  PASS(f != nil && big != nil, "the system font is available at two sizes");
+
+  PASS(nearly([f widthOfString: @""], 0.0), "an empty string has zero width");
+
+  /* the width is the advance, so a run of a character is a whole multiple of
+   * the single-character width */
+  wi = [f widthOfString: @"i"];
+  wiiii = [f widthOfString: @"iiii"];
+  wW = [f widthOfString: @"W"];
+  wWWWW = [f widthOfString: @"WWWW"];
+  PASS(wi > 0.0 && nearly(wiiii, 4 * wi),
+    "four i's are four times the width of one i");
+  PASS(wW > 0.0 && nearly(wWWWW, 4 * wW),
+    "four W's are four times the width of one W");
+
+  /* metrics follow the point size */
+  PASS(inProportion([big widthOfString: @"Wi"], 2 * [f widthOfString: @"Wi"]),
+    "the string width follows the point size");
+  PASS(inProportion([big ascender], 2 * [f ascender]),
+    "the ascender follows the point size");
+
+  /* the ascender is above the baseline, the descender below */
+  PASS([f ascender] > 0.0, "the ascender is positive");
+  PASS([f descender] < 0.0, "the descender is negative");
+
+  /* no glyph advances more than the maximum advancement */
+  PASS([f maximumAdvancement].width >= wW,
+    "the maximum advancement is at least the width of a W");
+
+  END_SET("font metrics")
+
+  return 0;
+}

--- a/Tests/gui/NSFont/glyphmetrics.m
+++ b/Tests/gui/NSFont/glyphmetrics.m
@@ -1,0 +1,144 @@
+/* Per-glyph metrics through NSFont: the advancement of a glyph, its ink
+ * bounding box (which is narrower than the advancement, since the advancement
+ * includes the side bearings), that the advancement follows the point size,
+ * and that a fixed-pitch font advances every glyph the same.
+ *
+ * An NSGlyph is an index into the font, so which value stands for a character
+ * is the font's business: casting the character gives the metrics of an
+ * unrelated glyph.  The glyphs are therefore taken from a layout manager,
+ * which maps the characters through the same font the drawing path uses.
+ *
+ * As in fontmetrics.m, a scaled font is not exactly the unscaled one
+ * multiplied, so the size assertion allows a tenth either way.
+ *
+ * None of this is particular to one backend, so it runs against whichever one
+ * is installed and skips when there is none, or when that backend reports no
+ * metrics.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+#include <math.h>
+
+static BOOL
+nearly(CGFloat a, CGFloat b)
+{
+  CGFloat d = a - b;
+
+  return (d < 0.5 && d > -0.5) ? YES : NO;
+}
+
+/* `a` is within a tenth of `b`, both being positive metrics. */
+static BOOL
+inProportion(CGFloat a, CGFloat b)
+{
+  if (a <= 0.0 || b <= 0.0)
+    {
+      return NO;
+    }
+  return (fabs((double)(a - b)) <= 0.1 * (double)b) ? YES : NO;
+}
+
+/* The glyph the layout machinery uses for character `index` of `string` when
+ * it is set in `font`. */
+static NSGlyph
+glyphInFont(NSFont *font, NSString *string, unsigned index)
+{
+  NSTextStorage *storage;
+  NSLayoutManager *layout;
+  NSTextContainer *container;
+  NSGlyph glyph;
+
+  storage = [[NSTextStorage alloc] initWithString: string];
+  [storage addAttribute: NSFontAttributeName
+                  value: font
+                  range: NSMakeRange(0, [string length])];
+  layout = [[NSLayoutManager alloc] init];
+  container = [[NSTextContainer alloc]
+    initWithContainerSize: NSMakeSize(1000, 1000)];
+  [layout addTextContainer: container];
+  [storage addLayoutManager: layout];
+
+  glyph = ([layout numberOfGlyphs] > index)
+    ? [layout glyphAtIndex: index] : NSNullGlyph;
+
+  RELEASE(container);
+  RELEASE(layout);
+  RELEASE(storage);
+  return glyph;
+}
+
+int
+main(int argc, char **argv)
+{
+  START_SET("glyph metrics")
+
+  NSFont *f, *big, *mono;
+  NSGlyph gW, gi, gA, bigW, monoW, monoi;
+  NSSize aW, ai;
+  NSRect bW, bi;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
+
+  f = [NSFont systemFontOfSize: 14];
+  big = [NSFont systemFontOfSize: 28];
+  mono = [NSFont userFixedPitchFontOfSize: 14];
+  if (nil == f || nil == big || nil == mono)
+    {
+      SKIP("the installed backend builds no font")
+    }
+  if ([f maximumAdvancement].width <= 0.0)
+    {
+      SKIP("the installed backend reports no font metrics")
+    }
+  PASS(f != nil && big != nil && mono != nil, "the fonts are available");
+
+  gW = glyphInFont(f, @"Wi", 0);
+  gi = glyphInFont(f, @"Wi", 1);
+  gA = glyphInFont(f, @"A", 0);
+  bigW = glyphInFont(big, @"Wi", 0);
+  monoW = glyphInFont(mono, @"Wi", 0);
+  monoi = glyphInFont(mono, @"Wi", 1);
+
+  aW = [f advancementForGlyph: gW];
+  ai = [f advancementForGlyph: gi];
+  bW = [f boundingRectForGlyph: gW];
+  bi = [f boundingRectForGlyph: gi];
+
+  PASS(gW != NSNullGlyph && gi != NSNullGlyph,
+    "the layout manager finds a glyph for a character");
+
+  PASS(aW.width > 0.0 && aW.width > ai.width,
+    "a W advances further than an i in a proportional font");
+
+  PASS(inProportion([big advancementForGlyph: bigW].width, 2 * aW.width),
+    "the glyph advancement follows the point size");
+
+  PASS(bW.size.width > 0.0 && bW.size.height > 0.0,
+    "a glyph has a non-empty ink bounding box");
+
+  PASS(bi.size.width > 0.0 && bi.size.width < ai.width,
+    "the ink box of an i is narrower than its advancement");
+
+  PASS([mono advancementForGlyph: monoi].width > 0.0
+    && nearly([mono advancementForGlyph: monoi].width,
+              [mono advancementForGlyph: monoW].width),
+    "a fixed-pitch font advances i and W the same");
+
+  PASS([f glyphIsEncoded: gA],
+    "a common character is an encoded glyph");
+
+  END_SET("glyph metrics")
+
+  return 0;
+}


### PR DESCRIPTION
Tests of general AppKit font behaviour live under one backend's directory in libs-back, guarded to that backend, so each runs against one graphics backend only. gnustep/libs-back#167 proposed moving them here so they run against whichever backend is installed. This is the font half of that; #875 was the drawing half. Two files, the string and font metrics and the per-glyph metrics.

An NSGlyph is an index into the font, and which value stands for a character differs between backends: cairo reads it as a character, art as a FreeType index, opal as a CGGlyph. The originals cast the character, which is right only on cairo, so the glyphs now come from a layout manager. macOS behaves the same way: the cast reports 8.19 for a W where the layout glyph reports 13.40, the string width.

The size assertions allow a tenth either way, since a font may be designed differently at each size: on macOS the system font at 28pt measures 32.40 where twice the 14pt width is 33.41. Each file skips when no backend is installed, or when the installed one reports no metrics, which is how headless reports.

Measured on eight configurations: green on x11 and wayland with cairo, skipped on headless, one failure on art, five on xlib, two on opal, one on win32 with cairo and two on winlib. Those are backend gaps.

