### PR TITLE
Fix: answer nil when a pattern colour cannot be converted

### DIFF
--- a/Source/NSColor.m
+++ b/Source/NSColor.m
@@ -3429,6 +3429,26 @@ static	NSRecursiveLock		*namedColorLock = nil;
   return NSPatternColorSpace;
 }
 
+- (NSColor*) colorUsingColorSpaceName: (NSString *)colorSpace
+			       device: (NSDictionary *)deviceDescription
+{
+  if (colorSpace == nil)
+    {
+      if (deviceDescription != nil)
+	colorSpace = [deviceDescription objectForKey: NSDeviceColorSpaceName];
+      if (colorSpace == nil)
+        colorSpace = NSDeviceRGBColorSpace;
+    }
+  if ([colorSpace isEqualToString: NSPatternColorSpace])
+    {
+      return self;
+    }
+  /* An image is not a set of components, so there is nothing to convert to
+   * any other space.  Answer nil, which is what a caller tests for, rather
+   * than raising the way the inherited method would. */
+  return nil;
+}
+
 - (NSImage*) patternImage
 {
   return _pattern;

--- a/Tests/gui/NSColor/patternColour.m
+++ b/Tests/gui/NSColor/patternColour.m
@@ -1,0 +1,59 @@
+/* A pattern colour has no components to convert, so asking it for a component
+ * based colour space answers nil rather than raising: a caller is expected to
+ * test the result, which is what AppKit does.  Asking for a component itself
+ * does raise, because there is no value to give.  These are plain value
+ * operations with no window server, so the test runs headlessly.
+ */
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSException.h>
+#include <AppKit/NSColor.h>
+#include <AppKit/NSImage.h>
+#include <AppKit/NSGraphics.h>
+
+int
+main(int argc, char **argv)
+{
+  START_SET("NSColor patternColour")
+
+  NSImage *image = AUTORELEASE([[NSImage alloc]
+    initWithSize: NSMakeSize(4, 4)]);
+  NSColor *pattern = [NSColor colorWithPatternImage: image];
+
+  PASS(pattern != nil, "a pattern colour is made from an image");
+  PASS_EQUAL([pattern colorSpaceName], NSPatternColorSpace,
+    "a pattern colour is in the pattern colour space");
+  PASS([pattern patternImage] == image,
+    "a pattern colour keeps the image it was made from");
+
+  /* The conversions.  Nil, not an exception. */
+  PASS([pattern colorUsingColorSpaceName: NSCalibratedRGBColorSpace] == nil,
+    "a pattern colour does not convert to the calibrated RGB space");
+  PASS([pattern colorUsingColorSpaceName: NSDeviceRGBColorSpace] == nil,
+    "a pattern colour does not convert to the device RGB space");
+  PASS([pattern colorUsingColorSpaceName: NSDeviceWhiteColorSpace] == nil,
+    "a pattern colour does not convert to the device white space");
+  PASS([pattern colorUsingColorSpaceName: NSDeviceCMYKColorSpace] == nil,
+    "a pattern colour does not convert to the device CMYK space");
+
+  /* Its own space is not a conversion at all. */
+  PASS([pattern colorUsingColorSpaceName: NSPatternColorSpace] == pattern,
+    "a pattern colour asked for its own colour space answers itself");
+
+  /* A component has no value to give, so that one does raise. */
+  {
+    BOOL raised = NO;
+
+    NS_DURING
+      (void)[pattern redComponent];
+    NS_HANDLER
+      raised = YES;
+    NS_ENDHANDLER
+    PASS(raised, "asking a pattern colour for a component raises");
+  }
+
+  END_SET("NSColor patternColour")
+
+  return 0;
+}


### PR DESCRIPTION
Fix: answer nil when a pattern colour cannot be converted

A pattern colour holds an image rather than a set of components, so it cannot
be converted to a component based colour space. GSPatternColor does not
override -colorUsingColorSpaceName:device:, so the inherited method raises
"should be overridden by subclass" for it, where callers expect nil and test
for it. -[GSGState _setColorFromGradient:at:] in libs-back wraps the call in an
NS_DURING for exactly this reason.

The class now answers itself for the pattern colour space and nil for any
other. Asking it for a component still raises, because there is no value to
give.

The caveat is the exception the component accessors raise: AppKit raises
NSInvalidArgumentException there and GNUstep raises
NSInternalInconsistencyException, which this change does not alter.

Checked against macOS 15 with a probe on a runner: a pattern colour answers nil
for the calibrated RGB, device RGB and component based spaces, and raises for
-redComponent.

Tests/gui/NSColor/patternColour.m is new and covers both halves. Four of its
ten assertions fail before the change and none after. Tests/gui is 4580 passed
and 0 failed either way on the cairo backend.
