### PR TITLE
tests: skip the custom image rep test when the backend cannot read a drawing back

### DIFF
--- a/Tests/gui/NSImage/customImageRep.m
+++ b/Tests/gui/NSImage/customImageRep.m
@@ -90,8 +90,18 @@ main(int argc, char **argv)
       [img addRepresentation: rep];
 
       NSColor *first = renderCentre(img);
-      PASS(first != nil && [first redComponent] > 0.9
-           && [first blueComponent] < 0.1,
+
+      /* A backend that cannot read a drawing back answers nil here, as the
+       * headless one does: -initWithFocusedViewRect: fails and there is
+       * nothing to check.  That is the same ground the offscreen drawing
+       * tests cover with GSCanDrawOffscreen(), which does not apply to a
+       * window. */
+      if (first == nil)
+        {
+          SKIP("the installed backend cannot read a drawing back")
+        }
+
+      PASS([first redComponent] > 0.9 && [first blueComponent] < 0.1,
            "the custom rep draws red the first time");
 
       p->color = [NSColor blueColor];


### PR DESCRIPTION
tests: skip the custom image rep test when the backend cannot read a drawing back

customImageRep.m draws into a window and reads the pixels back with
-initWithFocusedViewRect:. On the headless backend that call fails and answers
nil, so both assertions failed for want of a backend rather than for anything
about NSCustomImageRep. Its neighbours in Tests/gui guard the same ground with
GSCanDrawOffscreen(), which does not apply here because this test uses a window
rather than an offscreen image.

The test now skips when the read-back answers nil.

The caveat is that a backend which reads back the wrong pixels still fails, as
it should: only a nil result skips.

Path to the test: Tests/gui/NSImage/customImageRep.m, both assertions.

On headless the set goes from 2 failed to skipped. On cairo, art, xlib and opal
Tests/gui/NSImage is 79 passed and 0 failed either way.

Worth noting for anyone tracking the winlib numbers: the two failures this test
used to show there were the zero alpha division fixed in #880, not a fault in
the backend, and they are gone now that it has merged.
