### PR TITLE
tests: use the exception macro in the pattern colour test

### DIFF
--- a/Tests/gui/NSColor/patternColour.m
+++ b/Tests/gui/NSColor/patternColour.m
@@ -42,16 +42,9 @@ main(int argc, char **argv)
     "a pattern colour asked for its own colour space answers itself");
 
   /* A component has no value to give, so that one does raise. */
-  {
-    BOOL raised = NO;
-
-    NS_DURING
-      (void)[pattern redComponent];
-    NS_HANDLER
-      raised = YES;
-    NS_ENDHANDLER
-    PASS(raised, "asking a pattern colour for a component raises");
-  }
+  PASS_EXCEPTION(({ (void)[pattern redComponent]; }),
+    NSInternalInconsistencyException,
+    "asking a pattern colour for a component raises");
 
   END_SET("NSColor patternColour")
 


### PR DESCRIPTION
tests: use the exception macro in the pattern colour test

The check that a pattern colour raises when asked for a component was written
as an NS_DURING with a BOOL and a PASS on the flag. PASS_EXCEPTION says the
same thing in one line and additionally checks which exception was raised,
where the flag accepted any of them.

The assertion count is unchanged, so Tests/gui/NSColor is 49 passed and 0
failed either way.
