### PR TITLE
tests: use the exception macros instead of hand written handlers (Part 3)

### DIFF
--- a/Tests/gui/NSLevelIndicatorCell/basic.m
+++ b/Tests/gui/NSLevelIndicatorCell/basic.m
@@ -17,7 +17,6 @@ int main()
   NSLevelIndicatorStyle styles[4];
   double maxes[4];
   int i;
-  BOOL raised;
 
   START_SET("NSLevelIndicatorCell basic")
 
@@ -100,21 +99,11 @@ int main()
        "tickMarkValueAtIndex: 0 is the minimum value");
 
   /* out-of-range and negative tick indices raise NSRangeException */
-  raised = NO;
-  NS_DURING
-    [cell tickMarkValueAtIndex: 11];
-  NS_HANDLER
-    raised = [[localException name] isEqualToString: NSRangeException];
-  NS_ENDHANDLER
-  PASS(raised, "tickMarkValueAtIndex: past the last tick raises NSRangeException");
+  PASS_EXCEPTION(({ [cell tickMarkValueAtIndex: 11]; }), NSRangeException,
+    "tickMarkValueAtIndex: past the last tick raises NSRangeException");
 
-  raised = NO;
-  NS_DURING
-    [cell tickMarkValueAtIndex: -1];
-  NS_HANDLER
-    raised = [[localException name] isEqualToString: NSRangeException];
-  NS_ENDHANDLER
-  PASS(raised, "tickMarkValueAtIndex: a negative index raises NSRangeException");
+  PASS_EXCEPTION(({ [cell tickMarkValueAtIndex: -1]; }), NSRangeException,
+    "tickMarkValueAtIndex: a negative index raises NSRangeException");
 
   END_SET("NSLevelIndicatorCell basic")
 

--- a/Tests/gui/NSPageController/selection.m
+++ b/Tests/gui/NSPageController/selection.m
@@ -104,7 +104,6 @@ main(int argc, char **argv)
     NSPageController	*controller;
     Delegate		*delegate;
     NSArray		*objects;
-    BOOL		raised;
 
     /* selecting through the delegate */
     controller = AUTORELEASE([[NSPageController alloc] init]);
@@ -134,14 +133,8 @@ main(int argc, char **argv)
     [controller setArrangedObjects:
       [NSArray arrayWithObjects: @"a", @"b", nil]];
 
-    raised = NO;
-    NS_DURING
-      [controller setSelectedIndex: 1];
-    NS_HANDLER
-      raised = YES;
-    NS_ENDHANDLER
-
-    PASS(raised == NO, "selecting a page with no delegate does not raise");
+    PASS_RUNS(({ [controller setSelectedIndex: 1]; }),
+      "selecting a page with no delegate does not raise");
     PASS([controller selectedIndex] == 1, "the selected index is still set");
     PASS([controller selectedViewController] == nil,
       "there is no selected view controller without a delegate");
@@ -150,55 +143,30 @@ main(int argc, char **argv)
      * nothing and so cannot be out of range, which is why an empty controller
      * tolerates zero. */
     controller = AUTORELEASE([[NSPageController alloc] init]);
-    raised = NO;
-    NS_DURING
-      [controller setSelectedIndex: 0];
-    NS_HANDLER
-      raised = YES;
-    NS_ENDHANDLER
-    PASS(raised == NO, "selecting zero on an empty controller does not raise");
+    PASS_RUNS(({ [controller setSelectedIndex: 0]; }),
+      "selecting zero on an empty controller does not raise");
     PASS([controller selectedIndex] == 0, "the selected index stays at zero");
 
-    raised = NO;
-    NS_DURING
-      [controller setSelectedIndex: 5];
-    NS_HANDLER
-      raised = [[localException name]
-        isEqualToString: NSInternalInconsistencyException];
-    NS_ENDHANDLER
-    PASS(raised == YES, "an index an empty controller has no object for raises");
+    PASS_EXCEPTION(({ [controller setSelectedIndex: 5]; }),
+      NSInternalInconsistencyException,
+      "an index an empty controller has no object for raises");
 
     controller = AUTORELEASE([[NSPageController alloc] init]);
     [controller setArrangedObjects:
       [NSArray arrayWithObjects: @"a", @"b", @"c", nil]];
 
-    raised = NO;
-    NS_DURING
-      [controller setSelectedIndex: 3];
-    NS_HANDLER
-      raised = [[localException name]
-        isEqualToString: NSInternalInconsistencyException];
-    NS_ENDHANDLER
-    PASS(raised == YES, "an index past the last object raises");
+    PASS_EXCEPTION(({ [controller setSelectedIndex: 3]; }),
+      NSInternalInconsistencyException,
+      "an index past the last object raises");
 
-    raised = NO;
-    NS_DURING
-      [controller setSelectedIndex: -1];
-    NS_HANDLER
-      raised = [[localException name]
-        isEqualToString: NSInternalInconsistencyException];
-    NS_ENDHANDLER
-    PASS(raised == YES, "a negative index raises");
+    PASS_EXCEPTION(({ [controller setSelectedIndex: -1]; }),
+      NSInternalInconsistencyException,
+      "a negative index raises");
 
     /* navigating an empty controller */
     controller = AUTORELEASE([[NSPageController alloc] init]);
-    raised = NO;
-    NS_DURING
-      [controller navigateBack: nil];
-    NS_HANDLER
-      raised = YES;
-    NS_ENDHANDLER
-    PASS(raised == NO, "navigating back on an empty controller does not raise");
+    PASS_RUNS(({ [controller navigateBack: nil]; }),
+      "navigating back on an empty controller does not raise");
     PASS([controller selectedIndex] == 0,
       "the selected index stays at zero when navigating back");
   }

--- a/Tests/gui/NSPredicateEditorRowTemplate/basic.m
+++ b/Tests/gui/NSPredicateEditorRowTemplate/basic.m
@@ -136,20 +136,9 @@ rightExpressionAttributeType: NSStringAttributeType
          [NSPredicate predicateWithFormat: @"name == 'a' AND title == 'b'"]] == 0.0,
        "a compound predicate does not match a comparison template");
 
-  {
-    BOOL raised = NO;
-
-    NS_DURING
-      {
-        [template matchForPredicate: nil];
-      }
-    NS_HANDLER
-      {
-        raised = YES;
-      }
-    NS_ENDHANDLER
-    PASS(raised == YES, "matching a nil predicate raises");
-  }
+  /* nil for the name: this check was written to accept any exception. */
+  PASS_EXCEPTION(({ [template matchForPredicate: nil]; }), nil,
+    "matching a nil predicate raises");
 
   /* Setting the row from a predicate, then reading it back. */
   [template setPredicate:

--- a/Tests/gui/NSPrinter/deviceDescription.m
+++ b/Tests/gui/NSPrinter/deviceDescription.m
@@ -107,7 +107,6 @@ main(int argc, char **argv)
     NSImage *image;
     NSBitmapImageRep *rep;
     NSImageRep *best = nil;
-    BOOL raised = NO;
 
     image = AUTORELEASE([[NSImage alloc] initWithSize: NSMakeSize(16, 16)]);
     rep = AUTORELEASE([[NSBitmapImageRep alloc]
@@ -123,19 +122,9 @@ main(int argc, char **argv)
                                     bitsPerPixel: 0]);
     [image addRepresentation: rep];
 
-    NS_DURING
-      {
-        best = [image bestRepresentationForDevice: description];
-      }
-    NS_HANDLER
-      {
-        raised = YES;
-      }
-    NS_ENDHANDLER
-
-    PASS(raised == NO,
-         "asking an image for its best representation for a printer does not "
-         "raise");
+    PASS_RUNS(({ best = [image bestRepresentationForDevice: description]; }),
+      "asking an image for its best representation for a printer does not "
+      "raise");
     PASS_EQUAL(best, rep,
                "the representation of the image is returned");
   }

--- a/Tests/gui/NSRulerMarker/basic.m
+++ b/Tests/gui/NSRulerMarker/basic.m
@@ -22,7 +22,6 @@ int main()
   NSRulerView *rv;
   NSImage *img;
   NSRulerMarker *m;
-  BOOL raised;
 
   START_SET("NSRulerMarker basic")
 
@@ -72,27 +71,21 @@ int main()
        "representedObject round-trips");
 
   /* a nil ruler view or image raises NSInvalidArgumentException */
-  raised = NO;
-  NS_DURING
-    AUTORELEASE([[NSRulerMarker alloc] initWithRulerView: nil
-                                          markerLocation: 0.0
-                                                   image: img
-                                             imageOrigin: NSZeroPoint]);
-  NS_HANDLER
-    raised = [[localException name] isEqualToString: NSInvalidArgumentException];
-  NS_ENDHANDLER
-  PASS(raised, "a nil ruler view raises NSInvalidArgumentException");
+  PASS_EXCEPTION(({
+      AUTORELEASE([[NSRulerMarker alloc] initWithRulerView: nil
+                                            markerLocation: 0.0
+                                                     image: img
+                                               imageOrigin: NSZeroPoint]);
+    }), NSInvalidArgumentException,
+    "a nil ruler view raises NSInvalidArgumentException");
 
-  raised = NO;
-  NS_DURING
-    AUTORELEASE([[NSRulerMarker alloc] initWithRulerView: rv
-                                          markerLocation: 0.0
-                                                   image: nil
-                                             imageOrigin: NSZeroPoint]);
-  NS_HANDLER
-    raised = [[localException name] isEqualToString: NSInvalidArgumentException];
-  NS_ENDHANDLER
-  PASS(raised, "a nil image raises NSInvalidArgumentException");
+  PASS_EXCEPTION(({
+      AUTORELEASE([[NSRulerMarker alloc] initWithRulerView: rv
+                                            markerLocation: 0.0
+                                                     image: nil
+                                               imageOrigin: NSZeroPoint]);
+    }), NSInvalidArgumentException,
+    "a nil image raises NSInvalidArgumentException");
 
   END_SET("NSRulerMarker basic")
 

--- a/Tests/gui/NSSecureTextField/echo.m
+++ b/Tests/gui/NSSecureTextField/echo.m
@@ -38,16 +38,9 @@ int main()
   /* The cell class is hard-wired and cannot be replaced. */
   PASS([NSSecureTextField cellClass] == [NSSecureTextFieldCell class],
        "the cell class is NSSecureTextFieldCell");
-  {
-    BOOL raised = NO;
-
-    NS_DURING
-      [NSSecureTextField setCellClass: [NSTextFieldCell class]];
-    NS_HANDLER
-      raised = [[localException name] isEqualToString: NSInvalidArgumentException];
-    NS_ENDHANDLER
-    PASS(raised, "setCellClass: raises rather than accept another class");
-  }
+  PASS_EXCEPTION(({ [NSSecureTextField setCellClass: [NSTextFieldCell class]]; }),
+    NSInvalidArgumentException,
+    "setCellClass: raises rather than accept another class");
 
   /* A field uses a secure cell, echoes bullets by default, and forwards
      the flag to its cell. */

--- a/Tests/gui/NSToolbarItemGroup/selection.m
+++ b/Tests/gui/NSToolbarItemGroup/selection.m
@@ -51,7 +51,6 @@ main(int argc, char **argv)
 
   {
     NSToolbarItemGroup	*group;
-    BOOL		raised;
 
     /* the enumerations */
     PASS(NSToolbarItemGroupSelectionModeSelectOne == 0
@@ -167,29 +166,14 @@ main(int argc, char **argv)
 
     /* out of range */
     group = groupWithMode(NSToolbarItemGroupSelectionModeSelectOne);
-    raised = NO;
-    NS_DURING
-      [group isSelectedAtIndex: 99];
-    NS_HANDLER
-      raised = [[localException name] isEqualToString: NSRangeException];
-    NS_ENDHANDLER
-    PASS(raised == YES, "asking about an index out of range raises");
+    PASS_EXCEPTION(({ [group isSelectedAtIndex: 99]; }), NSRangeException,
+      "asking about an index out of range raises");
 
-    raised = NO;
-    NS_DURING
-      [group setSelected: YES atIndex: 99];
-    NS_HANDLER
-      raised = [[localException name] isEqualToString: NSRangeException];
-    NS_ENDHANDLER
-    PASS(raised == YES, "selecting an index out of range raises");
+    PASS_EXCEPTION(({ [group setSelected: YES atIndex: 99]; }), NSRangeException,
+      "selecting an index out of range raises");
 
-    raised = NO;
-    NS_DURING
-      [group setSelectedIndex: 99];
-    NS_HANDLER
-      raised = [[localException name] isEqualToString: NSRangeException];
-    NS_ENDHANDLER
-    PASS(raised == YES, "setting the selected index out of range raises");
+    PASS_EXCEPTION(({ [group setSelectedIndex: 99]; }), NSRangeException,
+      "setting the selected index out of range raises");
   }
 
   END_SET("selection")

--- a/Tests/gui/NSView/backingAligned.m
+++ b/Tests/gui/NSView/backingAligned.m
@@ -98,18 +98,9 @@ main(int argc, char **argv)
                  4, 5, 6, 7),
        "an already integral rectangle is unchanged");
 
-  {
-    BOOL raised = NO;
-
-    NS_DURING
-      [v backingAlignedRect: r options: NSAlignMinXInward];
-    NS_HANDLER
-      if ([[localException name] isEqualToString: NSInvalidArgumentException])
-        raised = YES;
-    NS_ENDHANDLER
-    PASS(raised,
-         "an axis without exactly two of min, max and size raises");
-  }
+  PASS_EXCEPTION(({ [v backingAlignedRect: r options: NSAlignMinXInward]; }),
+    NSInvalidArgumentException,
+    "an axis without exactly two of min, max and size raises");
 
   END_SET("NSView backingAlignedRect")
 


### PR DESCRIPTION
tests: use the exception macros instead of hand written handlers (Part 3)

Eight test files still check for an exception with an NS_DURING, a BOOL and a
PASS on the flag. PASS_EXCEPTION and PASS_RUNS say the same thing in one line,
and PASS_EXCEPTION additionally checks which exception was raised, which two of
these files did not.

Converted, with the exception each file already named: NSLevelIndicatorCell/
basic.m and NSToolbarItemGroup/selection.m (NSRangeException),
NSRulerMarker/basic.m, NSSecureTextField/echo.m and NSView/backingAligned.m
(NSInvalidArgumentException), NSPageController/selection.m
(NSInternalInconsistencyException, and PASS_RUNS for the three checks that
something does not raise), NSPrinter/deviceDescription.m (PASS_RUNS), and
NSPredicateEditorRowTemplate/basic.m, which accepted any exception and so keeps
nil for the name rather than gaining a check it never had.

The caveat is what this deliberately leaves alone. Three files under
Tests/gui wrap their sets in ENTER_POOL, which looks like the same tidy-up but
is not: NSFontDescriptor/basic.m, NSGradient/basic.m and
NSGradient/customLocations.m each build resources shared between several sets
between the pool and the first START_SET, and those autorelease with no pool in
place if it is removed. The backend availability guards, which end in SKIP, are
also untouched.

Path to the tests: the eight files above, 17 assertions between them.

No assertion moves. The eight directories report 335 passed and 0 failed before
and after, with identical per-file counts and no failed builds, and the whole
Tests/gui suite is 4613 passed and 0 failed either way on the cairo backend.
