### PR TITLE
Fix: read a coder's capabilities through the ImageMagick accessors

### DIFF
--- a/Source/GSImageMagickImageRep.m
+++ b/Source/GSImageMagickImageRep.m
@@ -61,8 +61,8 @@ static BOOL
 GSImageMagickCanDecode(const MagickInfo *info)
 {
   return (info != (const MagickInfo *)NULL
-    && info->decoder != (DecodeImageHandler *)NULL
-    && info->blob_support != MagickFalse);
+    && GetImageDecoder(info) != (DecodeImageHandler *)NULL
+    && GetMagickBlobSupport(info) != MagickFalse);
 }
 
 /* Look up the ImageMagick coder that claims the leading bytes of DATA, or
@@ -97,8 +97,8 @@ GSImageMagickUsesDelegate(NSData *data)
   const MagickInfo *info = GSImageMagickInfoForData(data);
 
   return (info != (const MagickInfo *)NULL
-    && info->decoder != (DecodeImageHandler *)NULL
-    && info->blob_support == MagickFalse);
+    && GetImageDecoder(info) != (DecodeImageHandler *)NULL
+    && GetMagickBlobSupport(info) == MagickFalse);
 }
 
 /* Seconds ImageMagick is allowed to spend decoding through an external


### PR DESCRIPTION
GSImageMagickCanDecode and GSImageMagickUsesDelegate read the decoder and blob_support members of MagickInfo directly. ImageMagick 7 keeps neither, holding those capability bits in a flags member instead, so the file fails to compile against it with "no member named 'blob_support' in 'struct _MagickInfo'".

Both values have accessor functions, GetImageDecoder and GetMagickBlobSupport, declared with the same signatures in ImageMagick 6 and ImageMagick 7. The four member reads become calls to them. The meaning is unchanged and the file no longer depends on the shape of the structure.

Only ImageMagick 6 is installed in CI, so the version that fails was not built; the ImageMagick 7 declarations were read from its header rather than exercised. ImageMagick support is compiled only when configure is given --enable-imagemagick, so the configuration this broke is not the one CI builds, and neither the original change nor this one is covered there.

To build it: ./configure --enable-imagemagick, then make -C Source.

With ImageMagick 6 the file compiled before this change and compiles after it, and the object file now names GetImageDecoder and GetMagickBlobSupport where it previously named neither. Against ImageMagick 7 it did not compile at all.

Closes #887
