### PR TITLE
Fix: correct the copyright and author of a new header

### DIFF
--- a/Source/GSAutoLayoutAnchorPrivate.h
+++ b/Source/GSAutoLayoutAnchorPrivate.h
@@ -3,7 +3,10 @@
    Private interface used to create NSLayoutAnchor instances bound to a
    particular item and layout attribute.
 
-   Copyright (C) 2020 Free Software Foundation, Inc.
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: July 2026
 
    This file is part of the GNUstep Library.
 


### PR DESCRIPTION
GSAutoLayoutAnchorPrivate.h was added in #550 and took the copyright line of the autolayout files around it, 2020, with no author line at all. The file is new and so is everything it declares.

It now reads 2026 and names Todd White as the author, in the form the other files in Source use. Nothing else changes.

Fred asked for this cleanup on gnustep/libs-opal#48. Checking every file added by this work across this repository, in merged commits and on open branches, this is the only one here with the wrong data.

Path to check it: git log --diff-filter=A --format='%an %ad' -- Source/GSAutoLayoutAnchorPrivate.h answers Todd White, July 2026.

Comments only, no code, so there is nothing for the tests to show either way.
