### PR TITLE
Fix: take the size and pixel size from the selected page in NSPDFImageRep

### DIFF
--- a/Headers/AppKit/NSPDFImageRep.h
+++ b/Headers/AppKit/NSPDFImageRep.h
@@ -100,7 +100,8 @@ APPKIT_EXPORT_CLASS
 
 /**
  * Sets the currently selected page for display and rendering operations.
- * currentPage: Zero-based page index to select (must be within page count bounds)
+ * The size and the pixel size of the representation follow the selected page.
+ * currentPage: Zero-based page index to select, clamped to the page count
  */
 - (void) setCurrentPage: (NSInteger)currentPage;
 

--- a/Source/NSPDFImageRep.m
+++ b/Source/NSPDFImageRep.m
@@ -76,13 +76,12 @@
       if ([_pageReps count] > 0)
         {
           _size = [[_pageReps objectAtIndex: 0] size];
-          _currentPage = 1;
         }
       else
         {
           _size = NSMakeSize(0, 0);
-          _currentPage = 0;
         }
+      _currentPage = 0;
 #else
       ASSIGN(_pageReps, [NSArray array]);
       _size = NSMakeSize(0,0);
@@ -114,7 +113,29 @@
 
 - (void) setCurrentPage: (NSInteger)currentPage
 {
+  NSUInteger count = [_pageReps count];
+  NSImageRep *page;
+
+  if (count == 0)
+    {
+      _currentPage = 0;
+      return;
+    }
+
+  if (currentPage < 0)
+    {
+      currentPage = 0;
+    }
+  else if ((NSUInteger)currentPage >= count)
+    {
+      currentPage = count - 1;
+    }
   _currentPage = currentPage;
+
+  page = [_pageReps objectAtIndex: _currentPage];
+  [self setSize: [page size]];
+  [self setPixelsWide: [page pixelsWide]];
+  [self setPixelsHigh: [page pixelsHigh]];
 }
 
 - (NSInteger) pageCount
@@ -130,8 +151,11 @@
 // Override to draw the specified page...
 - (BOOL) draw
 {
-  NSBitmapImageRep *rep = [_pageReps objectAtIndex: _currentPage - 1];
-  return [rep draw];
+  if ([_pageReps count] == 0)
+    {
+      return NO;
+    }
+  return [[_pageReps objectAtIndex: _currentPage] draw];
 }
 @end
 

--- a/Tests/gui/NSPDFImageRep/pageSelection.m
+++ b/Tests/gui/NSPDFImageRep/pageSelection.m
@@ -1,0 +1,144 @@
+#import "Testing.h"
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSGeometry.h>
+#import <Foundation/NSString.h>
+#import <AppKit/NSImageRep.h>
+#import <AppKit/NSPDFImageRep.h>
+
+/* Build a PDF of pageCount empty pages, page n carrying the media box
+   sizes[n], with an xref table of the right offsets. */
+static NSData *
+pdfWithPageSizes(const NSSize *sizes, unsigned pageCount)
+{
+  NSMutableData *pdf = [NSMutableData data];
+  NSMutableString *kids = [NSMutableString string];
+  unsigned offsets[16];
+  unsigned objects = 0;
+  NSString *text;
+  unsigned xref;
+  unsigned i;
+
+  for (i = 0; i < pageCount; i++)
+    [kids appendFormat: @"%u 0 R ", i + 3];
+
+  [pdf appendBytes: "%PDF-1.4\n" length: 9];
+
+  offsets[objects++] = [pdf length];
+  text = @"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+  [pdf appendData: [text dataUsingEncoding: NSASCIIStringEncoding]];
+
+  offsets[objects++] = [pdf length];
+  text = [NSString stringWithFormat:
+    @"2 0 obj\n<< /Type /Pages /Kids [%@] /Count %u >>\nendobj\n",
+    kids, pageCount];
+  [pdf appendData: [text dataUsingEncoding: NSASCIIStringEncoding]];
+
+  for (i = 0; i < pageCount; i++)
+    {
+      offsets[objects++] = (unsigned)[pdf length];
+      text = [NSString stringWithFormat:
+        @"%u 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 %d %d] "
+        @"/Resources << >> >>\nendobj\n",
+        i + 3, (int)sizes[i].width, (int)sizes[i].height];
+      [pdf appendData: [text dataUsingEncoding: NSASCIIStringEncoding]];
+    }
+
+  xref = [pdf length];
+  text = [NSString stringWithFormat: @"xref\n0 %u\n0000000000 65535 f \n",
+                   pageCount + 3];
+  [pdf appendData: [text dataUsingEncoding: NSASCIIStringEncoding]];
+  for (i = 0; i < objects; i++)
+    {
+      text = [NSString stringWithFormat: @"%010u 00000 n \n", offsets[i]];
+      [pdf appendData: [text dataUsingEncoding: NSASCIIStringEncoding]];
+    }
+  text = [NSString stringWithFormat:
+    @"trailer\n<< /Size %u /Root 1 0 R >>\nstartxref\n%u\n%%%%EOF\n",
+    pageCount + 3, xref];
+  [pdf appendData: [text dataUsingEncoding: NSASCIIStringEncoding]];
+
+  return pdf;
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("NSPDFImageRep page selection")
+
+  const NSSize sizes[3] = {{200, 100}, {400, 300}, {100, 50}};
+  NSData *pdfData = pdfWithPageSizes(sizes, 3);
+  NSPDFImageRep *rep;
+
+  rep = AUTORELEASE([[NSPDFImageRep alloc] initWithData: pdfData]);
+  if ([rep pageCount] == 0)
+    {
+      SKIP("this build renders no PDF page")
+    }
+  else
+    {
+      PASS([rep pageCount] == 3, "pageCount is the number of pages");
+      PASS(NSEqualSizes([rep size], NSMakeSize(200, 100)),
+        "a new representation takes its size from the first page");
+      PASS([rep currentPage] == 0, "a new representation is on page 0");
+      PASS([rep pixelsWide] == NSImageRepMatchesDevice
+        && [rep pixelsHigh] == NSImageRepMatchesDevice,
+        "a new representation has no pixel size");
+
+      [rep setCurrentPage: 1];
+      PASS([rep currentPage] == 1, "setCurrentPage: 1 selects the second page");
+      PASS(NSEqualSizes([rep size], NSMakeSize(400, 300)),
+        "size follows the selected page");
+      PASS([rep pixelsWide] == 400 && [rep pixelsHigh] == 300,
+        "the pixel size follows the selected page");
+      PASS(NSEqualRects([rep bounds], NSMakeRect(0, 0, 400, 300)),
+        "bounds follow the selected page");
+
+      [rep setCurrentPage: 2];
+      PASS(NSEqualSizes([rep size], NSMakeSize(100, 50)),
+        "the third page is 100 by 50");
+      PASS([rep pixelsWide] == 100 && [rep pixelsHigh] == 50,
+        "the pixel size of the third page is 100 by 50");
+
+      [rep setCurrentPage: 3];
+      PASS([rep currentPage] == 2,
+        "setCurrentPage: past the last page selects the last page");
+      PASS([rep pixelsWide] == 100 && [rep pixelsHigh] == 50,
+        "the pixel size stays on the last page");
+
+      [rep setCurrentPage: -1];
+      PASS([rep currentPage] == 0,
+        "setCurrentPage: below zero selects the first page");
+      PASS([rep pixelsWide] == 200 && [rep pixelsHigh] == 100,
+        "the pixel size returns to the first page");
+    }
+
+  END_SET("NSPDFImageRep page selection")
+
+  START_SET("NSPDFImageRep drawing the first page")
+
+  const NSSize one[1] = {{200, 100}};
+  NSPDFImageRep *rep
+    = AUTORELEASE([[NSPDFImageRep alloc] initWithData: pdfWithPageSizes(one, 1)]);
+  NSString *raised = nil;
+
+  if ([rep pageCount] == 0)
+    {
+      SKIP("this build renders no PDF page")
+    }
+  else
+    {
+      [rep setCurrentPage: 0];
+      NS_DURING
+        [rep draw];
+      NS_HANDLER
+        raised = [localException name];
+      NS_ENDHANDLER
+      PASS(![raised isEqualToString: NSRangeException],
+        "-draw on page 0 stays inside the page list");
+    }
+
+  END_SET("NSPDFImageRep drawing the first page")
+  return 0;
+}


### PR DESCRIPTION
-[NSPDFImageRep pixelsWide] and -pixelsHigh answer 0 because nothing sets them. -setCurrentPage: only stored the number, so the size stayed on the first page. _currentPage started at 1 while the header documents the index as zero based, and -draw indexed the page list at currentPage - 1, so -setCurrentPage: 0 followed by -draw raised NSRangeException.

-setCurrentPage: now clamps the index, selects that page representation and takes its size, pixelsWide and pixelsHigh. A new representation starts on page 0, and -draw indexes the page list at currentPage and answers NO with no page.

On macOS 26 a representation from +imageRepWithData: answers 0 for both, which is NSImageRepMatchesDevice, and -setCurrentPage: sets the pixel size to the page media box rounded up. Both hold here. The pixel size is the page raster, at ImageMagick's default 72 dpi. The page index becomes zero based, as the header already stated.

Tests/gui/NSPDFImageRep/pageSelection.m builds a three page PDF of 200x100, 400x300 and 100x50 and checks size, pixelsWide, pixelsHigh, bounds and the clamping. The set skips where no PDF page renders, so a build without ImageMagick does not assert.

In that file: 7 passed, 11 failed before; 18 passed, 0 failed after. Nothing else in Tests/gui moved, 4025 to 4036 passed.

Closes #889
