### PR TITLE
Fix: number NSTextAlignment as AppKit does

### DIFF
--- a/Headers/AppKit/NSText.h
+++ b/Headers/AppKit/NSText.h
@@ -72,10 +72,10 @@
 typedef NSInteger NSTextAlignment;
 enum {
   NSLeftTextAlignment = 0,
-  NSRightTextAlignment,
-  NSCenterTextAlignment,
-  NSJustifiedTextAlignment,
-  NSNaturalTextAlignment
+  NSCenterTextAlignment = 1,
+  NSRightTextAlignment = 2,
+  NSJustifiedTextAlignment = 3,
+  NSNaturalTextAlignment = 4
 };
 
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_11, GS_API_LATEST)

--- a/Source/NSParagraphStyle.m
+++ b/Source/NSParagraphStyle.m
@@ -216,9 +216,9 @@ static NSParagraphStyle	*defaultStyle = nil;
 {
   if (self == [NSParagraphStyle class])
     {
-      /* Set the class version to 2, as the writing direction is now 
-	 stored in the encoding */
-      [self setVersion: 3];
+      /* Version 3 stores the writing direction in the encoding.  Version 4
+	 numbers NSTextAlignment as AppKit does. */
+      [self setVersion: 4];
     }
 }
 
@@ -554,6 +554,19 @@ static NSParagraphStyle	*defaultStyle = nil;
         {
           [aCoder decodeValueOfObjCType: @encode(NSInteger)
 				     at: &_baseDirection];
+        }
+
+      /* Before version 4 right was 1 and centre was 2. */
+      if ([aCoder versionForClassName: @"NSParagraphStyle"] < 4)
+        {
+          if (_alignment == 1)
+            {
+              _alignment = NSRightTextAlignment;
+            }
+          else if (_alignment == 2)
+            {
+              _alignment = NSCenterTextAlignment;
+            }
         }
     }
 

--- a/Tests/gui/NSText/alignmentValues.m
+++ b/Tests/gui/NSText/alignmentValues.m
@@ -1,0 +1,57 @@
+/* NSTextAlignment carries the same numbers as AppKit, which stores them in
+   keyed archives and reads them back as raw integers.  The values below were
+   read from a macOS runner: left 0, centre 1, right 2, justified 3 and
+   natural 4. */
+#import "Testing.h"
+#import <Foundation/NSArchiver.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSData.h>
+#import <AppKit/NSParagraphStyle.h>
+#import <AppKit/NSText.h>
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("NSTextAlignment values")
+
+  NSMutableParagraphStyle *style;
+  NSParagraphStyle *decoded;
+  NSData *data;
+
+  PASS(NSLeftTextAlignment == 0, "NSLeftTextAlignment is 0");
+  PASS(NSCenterTextAlignment == 1, "NSCenterTextAlignment is 1");
+  PASS(NSRightTextAlignment == 2, "NSRightTextAlignment is 2");
+  PASS(NSJustifiedTextAlignment == 3, "NSJustifiedTextAlignment is 3");
+  PASS(NSNaturalTextAlignment == 4, "NSNaturalTextAlignment is 4");
+
+  PASS(NSTextAlignmentLeft == NSLeftTextAlignment
+    && NSTextAlignmentCenter == NSCenterTextAlignment
+    && NSTextAlignmentRight == NSRightTextAlignment
+    && NSTextAlignmentJustified == NSJustifiedTextAlignment
+    && NSTextAlignmentNatural == NSNaturalTextAlignment,
+    "the current names have the values of the deprecated ones");
+
+  PASS([NSParagraphStyle version] == 4,
+    "the NSParagraphStyle class version records the change");
+
+  style = AUTORELEASE([[NSMutableParagraphStyle alloc] init]);
+  PASS([style alignment] == NSNaturalTextAlignment,
+    "a new paragraph style is naturally aligned");
+
+  [style setAlignment: NSRightTextAlignment];
+  PASS([style alignment] == 2, "a right aligned paragraph style reads 2");
+
+  data = [NSArchiver archivedDataWithRootObject: style];
+  decoded = [NSUnarchiver unarchiveObjectWithData: data];
+  PASS([decoded alignment] == NSRightTextAlignment,
+    "the alignment survives an archive that is not keyed");
+
+  [style setAlignment: NSCenterTextAlignment];
+  data = [NSArchiver archivedDataWithRootObject: style];
+  decoded = [NSUnarchiver unarchiveObjectWithData: data];
+  PASS([decoded alignment] == NSCenterTextAlignment,
+    "a centred paragraph style survives the same archive");
+
+  END_SET("NSTextAlignment values")
+  return 0;
+}


### PR DESCRIPTION
NSTextAlignment numbered right 1 and centre 2, where AppKit numbers centre 1 and right 2 (issue #752). Left, justified and natural already agreed. Code that uses the names round-tripped, but the raw value differs, so a keyed archive written by one library and read by the other swaps right and centre.

The constants are now left 0, centre 1, right 2, justified 3 and natural 4, read from a macOS runner. This breaks the values already stored in archives, which is what was agreed in the issue.

NSParagraphStyle keeps its own alignment in an archive that is not keyed, so its class version goes to 4 and a version below that has right and centre swapped back on decode. NSCell stores the alignment in the NSCellFlags2 bits of a keyed archive, where there is no version to test, so a document saved with a right aligned cell reads as centred until it is saved again. GSXib5KeyedUnarchiver reads the alignment from the strings in the xib and needs no change.

Tests/gui/NSText/alignmentValues.m pins the five values, the current names against the deprecated ones, the class version, and a paragraph style through an archive that is not keyed. It fails 4 and passes 29 before, and passes 11 more after; Tests/gui is otherwise unchanged.

Closes #752
