### PR TITLE
Fix: place the main menu at the origin of the screen visible frame

### DIFF
--- a/Source/NSMenu.m
+++ b/Source/NSMenu.m
@@ -271,10 +271,9 @@ static BOOL menuBarVisible = YES;
     {
       NSRect screenFrame = [[NSScreen mainScreen] frame];
 
-      NSRect proposedFrame = NSMakeRect(0, 
-		      			screenFrame.size.height -
-		      			[_aWindow frame].size.height +
-					screenFrame.origin.y,
+      NSRect proposedFrame = NSMakeRect(NSMinX(screenFrame),
+					NSMaxY(screenFrame) -
+					[_aWindow frame].size.height,
 					screenFrame.size.width,
 					[_aWindow frame].size.height);
       proposedFrame = [[GSTheme theme] modifyRect: proposedFrame
@@ -312,9 +311,10 @@ static BOOL menuBarVisible = YES;
       
       if ((_aWindow != nil) && ([_aWindow screen] != nil))
         {
-          NSPoint origin = NSMakePoint(0, [[_aWindow screen] visibleFrame].size.height 
-                               - [_aWindow frame].size.height);
-	  
+          NSRect  visible = [[_aWindow screen] visibleFrame];
+          NSPoint origin = NSMakePoint(NSMinX(visible),
+                               NSMaxY(visible) - [_aWindow frame].size.height);
+
           [_aWindow setFrameOrigin: origin];
           [_bWindow setFrameOrigin: origin];
         }


### PR DESCRIPTION
-[NSMenu _setGeometry] places the main menu at x 0, and the vertical branch at
visibleFrame.size.height less the menu height. Both drop the frame's origin,
which is not zero when a window manager reserves part of the screen.

Measured on a 1920x1080 screen. With a dock 64 columns wide down the left edge
the screen frame is 64,0 1856x1080 and the menu was mapped at X column 0, under
the dock; it is now at column 64. With a panel 40 rows deep at the bottom the
frame is 0,40 1920x1040 and the menu top edge was 1040 against a frame top of
1080; it is now flush.

Tests/gui gives 4489 passed 52 failed either way, so nothing moved. Those 52
fail on master here as well.

Reaching this needs a window manager publishing _NET_WORKAREA, so no test in
the suite covers it. The y case also needs gnustep/libs-back#226, which makes
the backend report a work area origin. The x case is reached without it.

Reported as gnustep/libs-back#63.
