### PR TITLE
CI: use actions that run on Node 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
         working-directory: ${{ env.SRC_PATH }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           path: ${{ env.SRC_PATH }}
 
@@ -138,7 +138,7 @@ jobs:
           make check
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: Logs - ${{ matrix.name }}
@@ -167,7 +167,7 @@ jobs:
         working-directory: ${{ env.SRC_PATH }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           path: ${{ env.SRC_PATH }}
 
@@ -219,7 +219,7 @@ jobs:
           xvfb-run -a make check
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: Logs - Ubuntu x64 Clang gnustep-2.0 (headless)


### PR DESCRIPTION
Every job ends with a warning that actions/checkout targets Node.js 20 and is being forced onto Node.js 24. The runner no longer gives checkout the runtime it declares, and the compatibility shim is being withdrawn.

checkout v3 declares node16 and v4 declares node20. v5 is the release that moved checkout to node24. upload-artifact v4 and v5 both declare node20, and v6 is the release that moved it, so the two actions land on different major versions. These are the smallest bumps that remove the warning. checkout v6 stores credentials in a separate file and v7 blocks checking out a fork under pull_request_target and workflow_run, neither of which belongs here.

Both releases need runner 2.327.1 or newer. The runners this workflow gets are 2.336.0.

Verified on the fork: all 4 jobs build and test green, and no job logs the deprecation warning.
