### PR TITLE
Fix: do not run the cross-built GSspell during install

### DIFF
--- a/Tools/GNUmakefile.postamble
+++ b/Tools/GNUmakefile.postamble
@@ -20,8 +20,12 @@
 # before-install::
 
 # Things to do after installing
+# GSspell is built for the target, so it cannot be run here when cross
+# compiling.  GNUmakefile guards make_services the same way.
 after-install::
+ifneq ($(CROSS_COMPILING),yes)
 	GSspell.service/GSspell -RegisterOnly YES
+endif
 
 # Things to do before uninstalling
 # before-uninstall::


### PR DESCRIPTION
Tools/GNUmakefile.postamble runs GSspell.service/GSspell -RegisterOnly YES in
after-install. When cross compiling, that binary is built for the target and
cannot run on the build host, so make install stops with Error 127 at
GNUmakefile.postamble:24 and the subprojects after Tools are never installed,
among them Panels, ColorPickers, Resources and Themes.

The line is now guarded with CROSS_COMPILING, as Tools/GNUmakefile already
guards make_services for the same reason.

Measured cross compiling for x86_64-linux-android against API 31: make install
exited 2 with 5 subprojects installed before the change, and exits 0 with all 16
after it. A native build is unchanged, with the registration line still emitted
whenever CROSS_COMPILING is not yes.
