### PR TITLE
tests: report an exception a set does not recognise

### DIFF
--- a/Tests/gui/NSOpenGLView/config.m
+++ b/Tests/gui/NSOpenGLView/config.m
@@ -16,9 +16,20 @@ main(int argc, const char **argv)
   NS_DURING
     [NSApplication sharedApplication];
   NS_HANDLER
-    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+    /* SKIP raises SkipSet, so a handler around a block that skips must let it
+       through or the skip is lost and the set reports nothing at all.  */
+    if ([[localException name] isEqualToString: @"SkipSet"])
+      [localException raise];
+    else if ([[localException name] isEqualToString: NSInternalInconsistencyException]
       || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
-      SKIP("It looks like GNUstep backend is not yet installed")
+      {
+        SKIP("It looks like GNUstep backend is not yet installed")
+      }
+    else
+      {
+        PASS(NO, "the application starts without an unexpected exception, "
+          "but %s was raised", [[localException name] UTF8String]);
+      }
   NS_ENDHANDLER
 
   NS_DURING
@@ -45,9 +56,18 @@ main(int argc, const char **argv)
         }
     }
   NS_HANDLER
-    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+    if ([[localException name] isEqualToString: @"SkipSet"])
+      [localException raise];
+    else if ([[localException name] isEqualToString: NSInternalInconsistencyException]
       || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
-      SKIP("No display available")
+      {
+        SKIP("No display available")
+      }
+    else
+      {
+        PASS(NO, "configuring the view raises no unexpected exception, "
+          "but %s was raised", [[localException name] UTF8String]);
+      }
   NS_ENDHANDLER
 
   END_SET("NSOpenGLView config")

--- a/Tests/gui/NSPanel/render.m
+++ b/Tests/gui/NSPanel/render.m
@@ -15,8 +15,20 @@ main(int argc, const char **argv)
   NS_DURING
     [NSApplication sharedApplication];
   NS_HANDLER
-    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
-      SKIP("It looks like GNUstep backend is not yet installed")
+    /* SKIP raises SkipSet, so a handler around a block that skips must let it
+       through or the skip is lost and the set reports nothing at all.  */
+    if ([[localException name] isEqualToString: @"SkipSet"])
+      [localException raise];
+    else if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      {
+        SKIP("It looks like GNUstep backend is not yet installed")
+      }
+    else
+      {
+        PASS(NO, "the application starts without an unexpected exception, "
+          "but %s was raised", [[localException name] UTF8String]);
+      }
   NS_ENDHANDLER
 
   NS_DURING
@@ -57,9 +69,18 @@ main(int argc, const char **argv)
         "matches the local golden (captured on first run)");
     }
   NS_HANDLER
-    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+    if ([[localException name] isEqualToString: @"SkipSet"])
+      [localException raise];
+    else if ([[localException name] isEqualToString: NSInternalInconsistencyException]
       || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
-      SKIP("No display available")
+      {
+        SKIP("No display available")
+      }
+    else
+      {
+        PASS(NO, "rendering raises no unexpected exception, but %s was raised",
+          [[localException name] UTF8String]);
+      }
   NS_ENDHANDLER
 
   END_SET("NSPanel render")

--- a/Tests/gui/NSPrintInfo/sharedPrintInfo.m
+++ b/Tests/gui/NSPrintInfo/sharedPrintInfo.m
@@ -11,8 +11,10 @@ int main(int argc, char **argv)
 {
 	START_SET("NSPrintInfo sharedPrintInfo")
 
-	/* Should run without causing any exceptions. */
-	[NSPrintInfo sharedPrintInfo];
+	/* The set had no testcase at all, so it reported nothing whether this
+	   worked or not. */
+	PASS_RUNS([NSPrintInfo sharedPrintInfo];,
+		"sharedPrintInfo runs without raising");
 
 	END_SET("NSPrintInfo sharedPrintInfo")
 	return 0;

--- a/Tests/gui/NSRulerView/render.m
+++ b/Tests/gui/NSRulerView/render.m
@@ -17,8 +17,20 @@ main(int argc, const char **argv)
   NS_DURING
     [NSApplication sharedApplication];
   NS_HANDLER
-    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
-      SKIP("It looks like GNUstep backend is not yet installed")
+    /* SKIP raises SkipSet, so a handler around a block that skips must let it
+       through or the skip is lost and the set reports nothing at all.  */
+    if ([[localException name] isEqualToString: @"SkipSet"])
+      [localException raise];
+    else if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      {
+        SKIP("It looks like GNUstep backend is not yet installed")
+      }
+    else
+      {
+        PASS(NO, "the application starts without an unexpected exception, "
+          "but %s was raised", [[localException name] UTF8String]);
+      }
   NS_ENDHANDLER
 
   NS_DURING
@@ -55,9 +67,18 @@ main(int argc, const char **argv)
         "matches the local golden (captured on first run)");
     }
   NS_HANDLER
-    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+    if ([[localException name] isEqualToString: @"SkipSet"])
+      [localException raise];
+    else if ([[localException name] isEqualToString: NSInternalInconsistencyException]
       || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
-      SKIP("No display available")
+      {
+        SKIP("No display available")
+      }
+    else
+      {
+        PASS(NO, "rendering raises no unexpected exception, but %s was raised",
+          [[localException name] UTF8String]);
+      }
   NS_ENDHANDLER
 
   END_SET("NSRulerView render")

--- a/Tests/gui/NSSwitch/rendering.m
+++ b/Tests/gui/NSSwitch/rendering.m
@@ -20,8 +20,20 @@ main(int argc, const char **argv)
   NS_DURING
     [NSApplication sharedApplication];
   NS_HANDLER
-    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
-      SKIP("It looks like GNUstep backend is not yet installed")
+    /* SKIP raises SkipSet, so a handler around a block that skips must let it
+       through or the skip is lost and the set reports nothing at all.  */
+    if ([[localException name] isEqualToString: @"SkipSet"])
+      [localException raise];
+    else if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+      || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
+      {
+        SKIP("It looks like GNUstep backend is not yet installed")
+      }
+    else
+      {
+        PASS(NO, "the application starts without an unexpected exception, "
+          "but %s was raised", [[localException name] UTF8String]);
+      }
   NS_ENDHANDLER
 
   NS_DURING
@@ -46,9 +58,18 @@ main(int argc, const char **argv)
         "a switch renders into a bitmap of its bounds");
     }
   NS_HANDLER
-    if ([[localException name] isEqualToString: NSInternalInconsistencyException]
+    if ([[localException name] isEqualToString: @"SkipSet"])
+      [localException raise];
+    else if ([[localException name] isEqualToString: NSInternalInconsistencyException]
       || [[localException name] isEqualToString: @"NSWindowServerCommunicationException"])
-      SKIP("No display available")
+      {
+        SKIP("No display available")
+      }
+    else
+      {
+        PASS(NO, "rendering raises no unexpected exception, but %s was raised",
+          [[localException name] UTF8String]);
+      }
   NS_ENDHANDLER
 
   END_SET("NSSwitch rendering")

--- a/Tests/gui/TextSystem/repeatedAttachmentCellHeight.m
+++ b/Tests/gui/TextSystem/repeatedAttachmentCellHeight.m
@@ -73,7 +73,12 @@ int main(int argc, char **argv)
 		value: ta
 		range: NSMakeRange(3,1)];
 	[text endEditing];
-	[lm usedRectForTextContainer: tc];
+
+	/* The set had no testcase at all, so it reported nothing whether it
+	   worked or not.  MyCell exits if the frame is requested more than once,
+	   which is the stuck case; reaching here and returning is the result.  */
+	PASS_RUNS([lm usedRectForTextContainer: tc];,
+		"the layout terminates with a cell filling the line fragment height");
 
 	END_SET("TextSystem GNUstep repeatedAttachmentCellHeight");
 


### PR DESCRIPTION
4 sets in Tests/gui caught every exception but acted on 2 names, so any other
exception was discarded and the set ended having run no testcase and reported
nothing at all. 2 more sets contained no testcase to begin with, so they
reported nothing on any platform.

The handlers now report the name of an exception they do not recognise. SKIP
raises SkipSet, so they pass that through instead of swallowing it too:
NSOpenGLView/config skips when there is no pixel format, and its own handler
was eating that skip. The first handler in NSPanel, NSRulerView and NSSwitch
accepted only NSInternalInconsistencyException while the second also accepted
NSWindowServerCommunicationException, which is what starting without a display
raises, so it now accepts both. NSPrintInfo/sharedPrintInfo and
TextSystem/repeatedAttachmentCellHeight use PASS_RUNS.

A backend that raises from a primitive it does not implement will now fail
these render tests rather than report nothing, which is the intent.

Tests/gui/NSOpenGLView/config.m, NSPanel/render.m, NSPrintInfo/sharedPrintInfo.m,
NSRulerView/render.m, NSSwitch/rendering.m and
TextSystem/repeatedAttachmentCellHeight.m.

On Linux the 4 sets report as before, with a display and without one. The other
2 report 1 passed where they reported nothing.
