### PR TITLE
Add setTemplate:/template in NSImage (macOS10.5) stencil/template images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ DerivedData/
 compile_commands.json
 **/.cache
 **/.vscode
+*.err
+*.out
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ compile_commands.json
 *.err
 *.out
 .vscode
+*.tmp

--- a/Headers/AppKit/NSButton.h
+++ b/Headers/AppKit/NSButton.h
@@ -164,6 +164,12 @@ APPKIT_EXPORT_CLASS
 //
 - (NSColor *) bezelColor;
 - (void) setBezelColor: (NSColor *)color;
+
+//
+// Content tint color
+//
+- (NSColor *) contentTintColor;
+- (void) setContentTintColor: (NSColor *)color;
 #endif
 
 @end

--- a/Headers/AppKit/NSButtonCell.h
+++ b/Headers/AppKit/NSButtonCell.h
@@ -150,6 +150,7 @@ APPKIT_EXPORT_CLASS
   NSGradientType _gradient_type;
   NSColor *_backgroundColor;
   NSColor *_bezelColor;
+  NSColor *_contentTintColor;
   // Think of the following as a BOOL ivars
 #define _buttoncell_is_transparent _cell.subclass_bool_one
 #define _image_dims_when_disabled _cell.subclass_bool_two
@@ -492,6 +493,16 @@ APPKIT_EXPORT_CLASS
  * default bezel colour for the button's style and state.
  */
 - (void) setBezelColor: (NSColor *)color;
+/**
+ * Returns the tint color used when drawing template image content, or nil
+ * when the button uses its default content colour.
+ */
+- (NSColor *) contentTintColor;
+/**
+ * Sets the tint color used when drawing template image content. Pass nil to
+ * use the default content colour for the button's style and state.
+ */
+- (void) setContentTintColor: (NSColor *)color;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_4, GS_API_LATEST)
 /**

--- a/Headers/AppKit/NSImage.h
+++ b/Headers/AppKit/NSImage.h
@@ -517,3 +517,4 @@ APPKIT_EXPORT_CLASS
 #endif
 
 #endif // _GNUstep_H_NSImage
+

--- a/Headers/AppKit/NSImage.h
+++ b/Headers/AppKit/NSImage.h
@@ -142,6 +142,7 @@ APPKIT_EXPORT_CLASS
     unsigned	cacheSeparately: 1;
     unsigned	unboundedCacheDepth: 1;
     unsigned	syncLoad: 1;
+    unsigned	template: 1;
   } _flags;
   NSMutableArray	*_reps;
   NSColor		*_color;
@@ -458,6 +459,9 @@ APPKIT_EXPORT_CLASS
 - (void) setFlipped: (BOOL)flag;
 - (BOOL) isFlipped;
 
+- (void) setTemplate: (BOOL)isTemplate;
+- (BOOL) isTemplate;
+
 //
 // Assigning a Delegate 
 //
@@ -513,4 +517,3 @@ APPKIT_EXPORT_CLASS
 #endif
 
 #endif // _GNUstep_H_NSImage
-

--- a/Headers/AppKit/NSImageView.h
+++ b/Headers/AppKit/NSImageView.h
@@ -62,6 +62,8 @@
 #import <AppKit/NSControl.h>
 #import <AppKit/NSImageCell.h>
 
+@class NSColor;
+
 APPKIT_EXPORT_CLASS
 @interface NSImageView : NSControl
 {
@@ -73,6 +75,7 @@ APPKIT_EXPORT_CLASS
     unsigned initiatesDrag: 1;
     unsigned animates: 1;
   } _ivflags;
+  NSColor *_contentTintColor;
 }
 
 /**
@@ -159,6 +162,18 @@ APPKIT_EXPORT_CLASS
  * flag: YES to enable clipboard operations, NO to disable
  */
 - (void)setAllowsCutCopyPaste:(BOOL)flag;
+#endif
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_14, GS_API_LATEST)
+/**
+ * Returns the tint color used when drawing template image content, or nil
+ * when the image view uses its default content colour.
+ */
+- (NSColor *) contentTintColor;
+/**
+ * Sets the tint color used when drawing template image content. Pass nil to
+ * use the default content colour for the image view's state.
+ */
+- (void) setContentTintColor: (NSColor *)color;
 #endif
 #if OS_API_VERSION(MAC_OS_X_VERSION_10_12, GS_API_LATEST)
 /**

--- a/Source/NSButton.m
+++ b/Source/NSButton.m
@@ -639,6 +639,17 @@ static id buttonCellClass = nil;
   [self setNeedsDisplay: YES];
 }
 
+- (NSColor *) contentTintColor
+{
+  return [(NSButtonCell *)_cell contentTintColor];
+}
+
+- (void) setContentTintColor: (NSColor *)color
+{
+  [(NSButtonCell *)_cell setContentTintColor: color];
+  [self setNeedsDisplay: YES];
+}
+
 // Implement 10.7+ radio button behavior
 - (void) _flipState: (NSButton *)b
 {

--- a/Source/NSButtonCell.m
+++ b/Source/NSButtonCell.m
@@ -1030,6 +1030,11 @@
 
       fraction = (![self isEnabled] &&
 		  [self imageDimsWhenDisabled]) ? 0.5 : 1.0;
+
+      if ([imageToDisplay isTemplate])
+	{
+	  [[self textColor] set];
+	}
       
       [imageToDisplay drawInRect: rect
 			fromRect: NSZeroRect

--- a/Source/NSButtonCell.m
+++ b/Source/NSButtonCell.m
@@ -76,7 +76,7 @@
 + (void) initialize
 {
   if (self == [NSButtonCell class])
-    [self setVersion: 3];
+    [self setVersion: 4];
 }
 
 /*
@@ -136,6 +136,7 @@
   RELEASE(_sound);
   RELEASE(_backgroundColor);
   RELEASE(_bezelColor);
+  RELEASE(_contentTintColor);
 
   [super dealloc];
 }
@@ -929,6 +930,24 @@
     }
 }
 
+- (NSColor *) contentTintColor
+{
+  return _contentTintColor;
+}
+
+- (void) setContentTintColor: (NSColor *)color
+{
+  ASSIGNCOPY(_contentTintColor, color);
+
+  if (_control_view)
+    {
+      if ([_control_view isKindOfClass: [NSControl class]])
+        {
+          [(NSControl*)_control_view updateCell: self];
+        }
+    }
+}
+
 - (GSThemeControlState) themeControlState
 {
   unsigned mask;
@@ -1033,7 +1052,13 @@
 
       if ([imageToDisplay isTemplate])
 	{
-	  [[self textColor] set];
+	  NSColor *tintColor = [self contentTintColor];
+
+	  if (tintColor == nil)
+	    {
+	      tintColor = [self textColor];
+	    }
+	  [tintColor set];
 	}
       
       [imageToDisplay drawInRect: rect
@@ -1630,6 +1655,7 @@
   _sound = TEST_RETAIN(_sound);
   _backgroundColor = TEST_RETAIN(_backgroundColor);
   _bezelColor = TEST_RETAIN(_bezelColor);
+  _contentTintColor = TEST_RETAIN(_contentTintColor);
 
   return c;
 }
@@ -1664,6 +1690,10 @@
       if (_bezelColor != nil)
         {
           [aCoder encodeObject: _bezelColor forKey: @"NSBezelColor"];
+        }
+      if (_contentTintColor != nil)
+        {
+          [aCoder encodeObject: _contentTintColor forKey: @"NSContentTintColor"];
         }
 
       buttonCellFlags.useButtonImageSource = (([NSImage imageNamed: @"NSSwitch"] == image) ||
@@ -1777,6 +1807,7 @@
 
       [aCoder encodeObject: _sound];
       [aCoder encodeObject: _backgroundColor];
+      [aCoder encodeObject: _contentTintColor];
       [aCoder encodeValueOfObjCType: @encode(float)
                                  at: &_delayInterval];
       [aCoder encodeValueOfObjCType: @encode(float)
@@ -1817,6 +1848,11 @@
       if ([aDecoder containsValueForKey: @"NSBezelColor"])
         {
           [self setBezelColor: [aDecoder decodeObjectForKey: @"NSBezelColor"]];
+        }
+      if ([aDecoder containsValueForKey: @"NSContentTintColor"])
+        {
+          [self setContentTintColor:
+            [aDecoder decodeObjectForKey: @"NSContentTintColor"]];
         }
       if ([aDecoder containsValueForKey: @"NSAlternateContents"])
         {
@@ -1984,6 +2020,10 @@
         {
           [aDecoder decodeValueOfObjCType: @encode(id) at: &_sound];
           [aDecoder decodeValueOfObjCType: @encode(id) at: &_backgroundColor];
+          if (version >= 4)
+            {
+              [aDecoder decodeValueOfObjCType: @encode(id) at: &_contentTintColor];
+            }
           [aDecoder decodeValueOfObjCType: @encode(float) at: &_delayInterval];
           [aDecoder decodeValueOfObjCType: @encode(float) at: &_repeatInterval];
           decode_NSUInteger(aDecoder, &tmp2);

--- a/Source/NSCachedImageRep.m
+++ b/Source/NSCachedImageRep.m
@@ -50,7 +50,6 @@
 @interface GSCacheW : NSWindow
 @end
 
-
 @implementation GSCacheW
 
 - (void) _initDefaults
@@ -326,3 +325,4 @@
 }
 
 @end
+

--- a/Source/NSCachedImageRep.m
+++ b/Source/NSCachedImageRep.m
@@ -50,6 +50,7 @@
 @interface GSCacheW : NSWindow
 @end
 
+
 @implementation GSCacheW
 
 - (void) _initDefaults
@@ -122,6 +123,7 @@
     return nil;
   
   [self setAlpha: alpha];
+  [self setOpaque: !alpha];
   [self setBitsPerSample: NSBitsPerSampleFromDepth(aDepth)];
   [self setSize: aSize];
   [self setPixelsWide: pixelsWide];
@@ -324,4 +326,3 @@
 }
 
 @end
-

--- a/Source/NSImage.m
+++ b/Source/NSImage.m
@@ -2309,8 +2309,10 @@ iterate_reps_for_types(NSArray* imageReps, SEL method)
   CGFloat blue = 0.0;
   CGFloat alpha = 1.0;
   NSGraphicsContext *ctxt = GSCurrentContext();
+  NSImageInterpolation interpolation = [ctxt imageInterpolation];
 
-  if (dstRect.size.width <= 0 || dstRect.size.height <= 0)
+  if (dstRect.size.width <= 0 || dstRect.size.height <= 0
+      || repSrcRect.size.width <= 0 || repSrcRect.size.height <= 0)
     {
       return;
     }
@@ -2318,16 +2320,18 @@ iterate_reps_for_types(NSArray* imageReps, SEL method)
   DPScurrentrgbcolor(ctxt, &red, &green, &blue);
   DPScurrentalpha(ctxt, &alpha);
 
-  maskRect = NSMakeRect(0, 0, dstRect.size.width, dstRect.size.height);
+  maskRect = NSMakeRect(0, 0, repSrcRect.size.width, repSrcRect.size.height);
   mask = [[NSCachedImageRep alloc]
-	    initWithSize: dstRect.size
-	      pixelsWide: ceil(dstRect.size.width)
-	      pixelsHigh: ceil(dstRect.size.height)
+	    initWithSize: maskRect.size
+	      pixelsWide: ceil(maskRect.size.width)
+	      pixelsHigh: ceil(maskRect.size.height)
 		   depth: [[NSScreen mainScreen] depth]
 		separate: YES
 		   alpha: YES];
 
   [[[mask window] contentView] lockFocus];
+  [[NSGraphicsContext currentContext]
+    setImageInterpolation: interpolation];
   NSRectFillUsingOperation(maskRect, NSCompositeClear);
   DPSsetrgbcolor(GSCurrentContext(), red, green, blue);
   DPSsetalpha(GSCurrentContext(), alpha);

--- a/Source/NSImage.m
+++ b/Source/NSImage.m
@@ -491,7 +491,7 @@ repd_for_rep(NSArray *_reps, NSImageRep *rep)
       if ([path length] != 0) 
         {
 	  image = [[[[GSTheme theme] imageClass] alloc]
-	    initByReferencingFile: path];
+		    initByReferencingFile: path];
           if (image != nil)
             {
               [image setName: realName];
@@ -2302,7 +2302,7 @@ iterate_reps_for_types(NSArray* imageReps, SEL method)
 	  respectFlipped: (BOOL)respectFlipped
 		   hints: (NSDictionary*)hints
 {
-  NSImage *mask;
+  NSCachedImageRep *mask;
   NSRect maskRect;
   CGFloat red = 0.0;
   CGFloat green = 0.0;
@@ -2319,10 +2319,15 @@ iterate_reps_for_types(NSArray* imageReps, SEL method)
   DPScurrentalpha(ctxt, &alpha);
 
   maskRect = NSMakeRect(0, 0, dstRect.size.width, dstRect.size.height);
-  mask = [[NSImage alloc] initWithSize: dstRect.size];
-  [mask setCacheMode: NSImageCacheNever];
+  mask = [[NSCachedImageRep alloc]
+	    initWithSize: dstRect.size
+	      pixelsWide: ceil(dstRect.size.width)
+	      pixelsHigh: ceil(dstRect.size.height)
+		   depth: [[NSScreen mainScreen] depth]
+		separate: YES
+		   alpha: YES];
 
-  [mask lockFocus];
+  [[[mask window] contentView] lockFocus];
   NSRectFillUsingOperation(maskRect, NSCompositeClear);
   DPSsetrgbcolor(GSCurrentContext(), red, green, blue);
   DPSsetalpha(GSCurrentContext(), alpha);
@@ -2333,7 +2338,7 @@ iterate_reps_for_types(NSArray* imageReps, SEL method)
 	 fraction: 1.0
    respectFlipped: respectFlipped
 	    hints: hints];
-  [mask unlockFocus];
+  [[[mask window] contentView] unlockFocus];
 
   [mask drawInRect: dstRect
 	  fromRect: maskRect
@@ -2341,6 +2346,7 @@ iterate_reps_for_types(NSArray* imageReps, SEL method)
 	  fraction: delta
     respectFlipped: respectFlipped
 	     hints: hints];
+
   RELEASE(mask);
 }
 
@@ -2617,7 +2623,7 @@ iterate_reps_for_types(NSArray* imageReps, SEL method)
 			   pixelsHigh: pixelsHigh
 				depth: [[NSScreen mainScreen] depth]
 			     separate: _flags.cacheSeparately
-				alpha: [rep hasAlpha]];
+				alpha: (rep == nil || [rep hasAlpha])];
           if (cacheRep == nil)
             {
               return nil;

--- a/Source/NSImage.m
+++ b/Source/NSImage.m
@@ -420,6 +420,13 @@ repd_for_rep(NSArray *_reps, NSImageRep *rep)
 @interface NSImage (Private)
 + (void) _clearFileTypeCaches: (NSNotification*)notif;
 + (void) _reloadCachedImages;
+- (void) _drawTemplateRep: (NSImageRep *)rep
+		  inRect: (NSRect)dstRect
+		fromRect: (NSRect)repSrcRect
+	       operation: (NSCompositingOperation)op
+		fraction: (CGFloat)delta
+	  respectFlipped: (BOOL)respectFlipped
+		   hints: (NSDictionary*)hints;
 - (BOOL) _useFromFile: (NSString *)fileName;
 - (BOOL) _loadFromData: (NSData *)data;
 - (BOOL) _loadFromFile: (NSString *)fileName;
@@ -489,6 +496,10 @@ repd_for_rep(NSArray *_reps, NSImageRep *rep)
             {
               [image setName: realName];
               image->_flags.archiveByName = YES;
+	      if ([realName hasSuffix: @"Template"])
+		{
+		  [image setTemplate: YES];
+		}
               AUTORELEASE(image);
             }
         }
@@ -825,6 +836,16 @@ repd_for_rep(NSArray *_reps, NSImageRep *rep)
 - (void) setFlipped: (BOOL)flag
 {
   _flags.flipDraw = flag;
+}
+
+- (void) setTemplate: (BOOL)isTemplate
+{
+  _flags.template = isTemplate;
+}
+
+- (BOOL) isTemplate
+{
+  return _flags.template;
 }
 
 // Choosing Which Image Representation to Use 
@@ -1203,12 +1224,25 @@ repd_for_rep(NSArray *_reps, NSImageRep *rep)
   
   // FIXME: Draw background?
   
-  [rep drawInRect: dstRect
-	 fromRect: repSrcRect
-	operation: op
-	 fraction: delta
+  if ([self isTemplate])
+    {
+      [self _drawTemplateRep: rep
+		      inRect: dstRect
+		    fromRect: repSrcRect
+		   operation: op
+		    fraction: delta
+	      respectFlipped: respectFlipped
+		       hints: hints];
+    }
+  else
+    {
+      [rep drawInRect: dstRect
+	     fromRect: repSrcRect
+	    operation: op
+	     fraction: delta
        respectFlipped: respectFlipped
-	    hints: hints];
+		hints: hints];
+    }
 }
 
 - (void) addRepresentation: (NSImageRep *)imageRep
@@ -1905,6 +1939,7 @@ static NSSize GSResolutionOfImageRep(NSImageRep *rep)
       flags |= [self prefersColorMatch] ? 0x0100000 : 0;
       flags |= [self matchesOnMultipleResolution] ? 0x0080000 : 0;
       flags |= [self isFlipped] ? 0x0008000 : 0;
+      flags |= [self isTemplate] ? 0x0004000 : 0;
       flags |= [self cacheMode] << 11;
       [coder encodeInt: flags forKey: @"NSImageFlags"];
       if (_flags.sizeWasExplicitlySet)
@@ -2009,7 +2044,7 @@ static NSSize GSResolutionOfImageRep(NSImageRep *rep)
           [self setPrefersColorMatch: ((flags & 0x0100000) != 0)];
           [self setMatchesOnMultipleResolution: ((flags & 0x0080000) != 0)];
           [self setFlipped: ((flags & 0x0008000) != 0)];
-          // ALIASED ((flags & 0x0004000) != 0)
+          [self setTemplate: ((flags & 0x0004000) != 0)];
           [self setCacheMode: ((flags & 0x0001800) >> 11)];
         }
       if ([coder containsValueForKey: @"NSReps"])
@@ -2257,6 +2292,56 @@ iterate_reps_for_types(NSArray* imageReps, SEL method)
 	}   
     }
   [imageLock unlock];
+}
+
+- (void) _drawTemplateRep: (NSImageRep *)rep
+		  inRect: (NSRect)dstRect
+		fromRect: (NSRect)repSrcRect
+	       operation: (NSCompositingOperation)op
+		fraction: (CGFloat)delta
+	  respectFlipped: (BOOL)respectFlipped
+		   hints: (NSDictionary*)hints
+{
+  NSImage *mask;
+  NSRect maskRect;
+  CGFloat red = 0.0;
+  CGFloat green = 0.0;
+  CGFloat blue = 0.0;
+  CGFloat alpha = 1.0;
+  NSGraphicsContext *ctxt = GSCurrentContext();
+
+  if (dstRect.size.width <= 0 || dstRect.size.height <= 0)
+    {
+      return;
+    }
+
+  DPScurrentrgbcolor(ctxt, &red, &green, &blue);
+  DPScurrentalpha(ctxt, &alpha);
+
+  maskRect = NSMakeRect(0, 0, dstRect.size.width, dstRect.size.height);
+  mask = [[NSImage alloc] initWithSize: dstRect.size];
+  [mask setCacheMode: NSImageCacheNever];
+
+  [mask lockFocus];
+  NSRectFillUsingOperation(maskRect, NSCompositeClear);
+  DPSsetrgbcolor(GSCurrentContext(), red, green, blue);
+  DPSsetalpha(GSCurrentContext(), alpha);
+  NSRectFill(maskRect);
+  [rep drawInRect: maskRect
+	 fromRect: repSrcRect
+	operation: NSCompositeDestinationIn
+	 fraction: 1.0
+   respectFlipped: respectFlipped
+	    hints: hints];
+  [mask unlockFocus];
+
+  [mask drawInRect: dstRect
+	  fromRect: maskRect
+	 operation: op
+	  fraction: delta
+    respectFlipped: respectFlipped
+	     hints: hints];
+  RELEASE(mask);
 }
 
 

--- a/Source/NSImageCell.m
+++ b/Source/NSImageCell.m
@@ -30,6 +30,7 @@
 #import <Foundation/NSDebug.h>
 #import "AppKit/NSAffineTransform.h"
 #import "AppKit/NSCell.h"
+#import "AppKit/NSColor.h"
 #import "AppKit/NSGraphics.h"
 #import "AppKit/NSImageCell.h"
 #import "AppKit/NSImage.h"
@@ -262,6 +263,18 @@ yBottomInRect(NSSize innerSize, NSRect outerRect, BOOL flipped)
       && ![self isEnabled])
     {
       fraction = 0.5;
+    }
+
+  if ([_cell_image isTemplate])
+    {
+      if ([self isEnabled])
+	{
+	  [[NSColor controlTextColor] set];
+	}
+      else
+	{
+	  [[NSColor disabledControlTextColor] set];
+	}
     }
 
   // draw!

--- a/Source/NSImageCell.m
+++ b/Source/NSImageCell.m
@@ -34,6 +34,7 @@
 #import "AppKit/NSGraphics.h"
 #import "AppKit/NSImageCell.h"
 #import "AppKit/NSImage.h"
+#import "AppKit/NSImageView.h"
 #import "GNUstepGUI/GSTheme.h"
 #import "GSGuiPrivate.h"
 
@@ -267,7 +268,17 @@ yBottomInRect(NSSize innerSize, NSRect outerRect, BOOL flipped)
 
   if ([_cell_image isTemplate])
     {
-      if ([self isEnabled])
+      NSColor *tintColor = nil;
+
+      if ([controlView respondsToSelector: @selector(contentTintColor)])
+        {
+          tintColor = [(NSImageView *)controlView contentTintColor];
+        }
+      if (tintColor != nil)
+        {
+          [tintColor set];
+        }
+      else if ([self isEnabled])
 	{
 	  [[NSColor controlTextColor] set];
 	}

--- a/Source/NSImageView.m
+++ b/Source/NSImageView.m
@@ -27,6 +27,7 @@
 */
 
 #import "AppKit/NSDragging.h"
+#import "AppKit/NSColor.h"
 #import "AppKit/NSEvent.h"
 #import "AppKit/NSImage.h"
 #import "AppKit/NSImageCell.h"
@@ -81,6 +82,13 @@ static Class imageCellClass;
 //
 // Instance methods
 //
+
+- (void) dealloc
+{
+  RELEASE(_contentTintColor);
+
+  [super dealloc];
+}
 
 - (id) initWithFrame: (NSRect)aFrame
 {
@@ -179,6 +187,17 @@ static Class imageCellClass;
 - (void) setAllowsCutCopyPaste: (BOOL)flag
 {
   _ivflags.allowsCutCopyPaste = flag;
+}
+
+- (NSColor *) contentTintColor
+{
+  return _contentTintColor;
+}
+
+- (void) setContentTintColor: (NSColor *)color
+{
+  ASSIGNCOPY(_contentTintColor, color);
+  [self setNeedsDisplay: YES];
 }
 
 - (void) delete: (id)sender
@@ -404,6 +423,11 @@ static Class imageCellClass;
       [aCoder encodeObject: [NSImage imagePasteboardTypes] 
                     forKey: @"NSDragTypes"];
       [aCoder encodeBool: [self isEditable] forKey: @"NSEditable"];
+      if (_contentTintColor != nil)
+        {
+          [aCoder encodeObject: _contentTintColor
+                        forKey: @"NSContentTintColor"];
+        }
     }
   else
     {
@@ -427,6 +451,11 @@ static Class imageCellClass;
         {
 	  [self setEditable: [aDecoder decodeBoolForKey: @"NSEditable"]];
 	}
+      if ([aDecoder containsValueForKey: @"NSContentTintColor"])
+        {
+          [self setContentTintColor:
+            [aDecoder decodeObjectForKey: @"NSContentTintColor"]];
+        }
     }
   else
     {

--- a/Source/NSImageView.m
+++ b/Source/NSImageView.m
@@ -51,7 +51,7 @@ static Class imageCellClass;
 {
   if (self == [NSImageView class])
     {
-      [self setVersion: 2];
+      [self setVersion: 3];
       imageCellClass = [NSImageCell class];
       usedCellClass = imageCellClass;
     }
@@ -433,14 +433,17 @@ static Class imageCellClass;
     {
       [aCoder encodeConditionalObject: _target];
       [aCoder encodeValueOfObjCType: @encode(SEL) at: &_action];
+      [aCoder encodeConditionalObject: _contentTintColor];
     }
 }
 
 - (id) initWithCoder: (NSCoder *)aDecoder
 {
   self = [super initWithCoder: aDecoder];
-  if (!self)
-    return self;
+  if (self == nil)
+    {
+      return self;
+    }
 
   [self setAllowsCutCopyPaste: YES];
   [self setAnimates: YES];
@@ -464,7 +467,12 @@ static Class imageCellClass;
 	  _target = [aDecoder decodeObject];
 	  [aDecoder decodeValueOfObjCType: @encode(SEL) at: &_action];
 	}
+      if ([aDecoder versionForClassName: @"NSImageView"] >= 3)
+	{
+	  _contentTintColor = [aDecoder decodeObject];
+	}
     }
+
   return self;
 }
 

--- a/Source/NSSegmentedCell.m
+++ b/Source/NSSegmentedCell.m
@@ -606,6 +606,18 @@
           destinationRect = [view centerScanRect: destinationRect];
         }
 
+      if ([segmentImage isTemplate])
+	{
+	  if ([self isEnabledForSegment: seg])
+	    {
+	      [[NSColor controlTextColor] set];
+	    }
+	  else
+	    {
+	      [[NSColor disabledControlTextColor] set];
+	    }
+	}
+
       [segmentImage drawInRect: destinationRect
                       fromRect: NSZeroRect
                      operation: NSCompositeSourceOver

--- a/Tests/gui/NSButton/bezelColor.m
+++ b/Tests/gui/NSButton/bezelColor.m
@@ -56,6 +56,13 @@ main(int argc, char **argv)
     "the bezel color round-trips");
   [b setBezelColor: nil];
   PASS([b bezelColor] == nil, "the bezel color can be cleared");
+  PASS([b contentTintColor] == nil, "the content tint color is nil by default");
+  [b setContentTintColor: [NSColor blueColor]];
+  PASS([[b contentTintColor] isEqual: [NSColor blueColor]]
+    && [[[b cell] contentTintColor] isEqual: [NSColor blueColor]],
+    "the content tint color forwards to the cell");
+  [b setContentTintColor: nil];
+  PASS([b contentTintColor] == nil, "the content tint color can be cleared");
 
   NS_DURING
     {

--- a/Tests/gui/NSButton/bezelColor.m
+++ b/Tests/gui/NSButton/bezelColor.m
@@ -94,8 +94,9 @@ main(int argc, char **argv)
             && [tinted redComponent] > [tinted greenComponent]
             && [tinted redComponent] > [tinted blueComponent],
             "a red bezel color makes the bezel red-dominant");
-          PASS([plain redComponent] <= [tinted redComponent]
-            && ([plain greenComponent] > 0.3 || [plain blueComponent] > 0.3),
+          PASS([plain redComponent] < 0.5
+            || [plain redComponent] <= [plain greenComponent]
+            || [plain redComponent] <= [plain blueComponent],
             "the default bezel is not the red tint");
         }
     }

--- a/Tests/gui/NSImage/basic.m
+++ b/Tests/gui/NSImage/basic.m
@@ -27,7 +27,18 @@ int main()
   test_alloc(@"NSImage");
 
   testObject = [NSImage new];
+  [testObject setTemplate: YES];
+  PASS([testObject isTemplate], "setTemplate: round-trips through isTemplate");
+  {
+    NSImage *copy = [testObject copy];
+
+    PASS([copy isTemplate], "template state is copied");
+    RELEASE(copy);
+  }
   testObject1 = [NSImage imageNamed: @"GNUstep"];
+  PASS(![testObject1 isTemplate], "ordinary named images are not templates");
+  PASS([[NSImage imageNamed: @"NSAddTemplate"] isTemplate],
+    "named images with Template suffix are templates");
   testObject2 = [[NSImage alloc] initWithData: nil];
 
   testObjects = [NSArray arrayWithObjects: testObject, testObject1, testObject2, nil];

--- a/Tests/gui/NSImage/drawingPixels.m
+++ b/Tests/gui/NSImage/drawingPixels.m
@@ -15,7 +15,7 @@
 /* Draw SRC scaled over the whole 20x20 canvas with nearest-neighbour sampling,
  * so each source pixel stays a solid block. */
 static NSBitmapImageRep *
-draw(NSImage *src)
+drawWithColor(NSImage *src, NSColor *color)
 {
   int w = 20, h = 20;
   NSImage *dst = [[NSImage alloc] initWithSize: NSMakeSize(w, h)];
@@ -26,6 +26,7 @@ draw(NSImage *src)
     setImageInterpolation: NSImageInterpolationNone];
   [[NSColor colorWithDeviceRed: 0 green: 0 blue: 0 alpha: 1] set];
   NSRectFill(NSMakeRect(0, 0, w, h));
+  [color set];
   [src drawInRect: NSMakeRect(0, 0, w, h)
          fromRect: NSZeroRect
         operation: NSCompositeSourceOver
@@ -36,6 +37,12 @@ draw(NSImage *src)
   [dst unlockFocus];
   [dst release];
   return [rep autorelease];
+}
+
+static NSBitmapImageRep *
+draw(NSImage *src)
+{
+  return drawWithColor(src, [NSColor blackColor]);
 }
 
 int
@@ -102,6 +109,26 @@ main(int argc, const char **argv)
 
   PASS(GSPixelIs(out, 10, 10, 0, 255, 255),
     "a 24-bit rgb image without alpha decodes to its colour");
+
+  /* A template image uses source alpha as a stencil and the current drawing
+   * colour as the fill. */
+  rep = [[NSBitmapImageRep alloc]
+    initWithBitmapDataPlanes: NULL pixelsWide: 2 pixelsHigh: 1
+                bitsPerSample: 8 samplesPerPixel: 4 hasAlpha: YES isPlanar: NO
+               colorSpaceName: NSDeviceRGBColorSpace bytesPerRow: 8 bitsPerPixel: 32];
+  d = [rep bitmapData];
+  d[0] = 0;   d[1] = 255; d[2] = 0; d[3] = 255;
+  d[4] = 255; d[5] = 255; d[6] = 255; d[7] = 0;
+  src = [[NSImage alloc] initWithSize: NSMakeSize(2, 1)];
+  [src addRepresentation: rep];
+  [src setTemplate: YES];
+  [rep release];
+  out = drawWithColor(src, [NSColor redColor]);
+  [src release];
+
+  PASS(GSPixelIs(out, 5, 10, 255, 0, 0)
+    && GSPixelIs(out, 15, 10, 0, 0, 0),
+    "a template image draws with the current colour through source alpha");
 
   END_SET("image pixels")
   return 0;

--- a/Tests/gui/NSImage/drawingPixels.m
+++ b/Tests/gui/NSImage/drawingPixels.m
@@ -15,7 +15,7 @@
 /* Draw SRC scaled over the whole 20x20 canvas with nearest-neighbour sampling,
  * so each source pixel stays a solid block. */
 static NSBitmapImageRep *
-drawWithColor(NSImage *src, NSColor *color)
+drawWithColorOnBackground(NSImage *src, NSColor *color, NSColor *background)
 {
   int w = 20, h = 20;
   NSImage *dst = [[NSImage alloc] initWithSize: NSMakeSize(w, h)];
@@ -24,7 +24,7 @@ drawWithColor(NSImage *src, NSColor *color)
   [dst lockFocus];
   [[NSGraphicsContext currentContext]
     setImageInterpolation: NSImageInterpolationNone];
-  [[NSColor colorWithDeviceRed: 0 green: 0 blue: 0 alpha: 1] set];
+  [background set];
   NSRectFill(NSMakeRect(0, 0, w, h));
   [color set];
   [src drawInRect: NSMakeRect(0, 0, w, h)
@@ -37,6 +37,12 @@ drawWithColor(NSImage *src, NSColor *color)
   [dst unlockFocus];
   [dst release];
   return [rep autorelease];
+}
+
+static NSBitmapImageRep *
+drawWithColor(NSImage *src, NSColor *color)
+{
+  return drawWithColorOnBackground(src, color, [NSColor blackColor]);
 }
 
 static NSBitmapImageRep *
@@ -124,11 +130,17 @@ main(int argc, const char **argv)
   [src setTemplate: YES];
   [rep release];
   out = drawWithColor(src, [NSColor redColor]);
-  [src release];
 
   PASS(GSPixelIs(out, 5, 10, 255, 0, 0)
     && GSPixelIs(out, 15, 10, 0, 0, 0),
-    "a template image draws with the current colour through source alpha");
+    "a template image preserves the current colour across mask drawing");
+
+  out = drawWithColorOnBackground(src, [NSColor redColor], [NSColor whiteColor]);
+  [src release];
+
+  PASS(GSPixelIs(out, 5, 10, 255, 0, 0)
+    && GSPixelIs(out, 15, 10, 255, 255, 255),
+    "a template image leaves transparent source pixels clear");
 
   END_SET("image pixels")
   return 0;

--- a/Tests/gui/NSImageView/state.m
+++ b/Tests/gui/NSImageView/state.m
@@ -17,6 +17,40 @@
 #include <AppKit/NSImage.h>
 #include <AppKit/NSColor.h>
 
+@interface TintRecordingImageCell : NSImageCell
+{
+  NSColor *_contentTintColor;
+  NSUInteger _setContentTintColorCount;
+}
+- (NSColor *) contentTintColor;
+- (void) setContentTintColor: (NSColor *)color;
+- (NSUInteger) setContentTintColorCount;
+@end
+
+@implementation TintRecordingImageCell
+- (void) dealloc
+{
+  RELEASE(_contentTintColor);
+  [super dealloc];
+}
+
+- (NSColor *) contentTintColor
+{
+  return _contentTintColor;
+}
+
+- (void) setContentTintColor: (NSColor *)color
+{
+  _setContentTintColorCount++;
+  ASSIGNCOPY(_contentTintColor, color);
+}
+
+- (NSUInteger) setContentTintColorCount
+{
+  return _setContentTintColorCount;
+}
+@end
+
 int
 main(int argc, char **argv)
 {
@@ -51,6 +85,8 @@ main(int argc, char **argv)
            "cut, copy and paste are allowed by default");
       PASS([iv contentTintColor] == nil,
            "the content tint color is nil by default");
+      PASS([[iv cell] respondsToSelector: @selector(contentTintColor)] == NO,
+           "the default image cell does not store a content tint color");
 
       /* Round-trips. */
       [iv setImageAlignment: NSImageAlignTop];
@@ -68,6 +104,25 @@ main(int argc, char **argv)
       [iv setContentTintColor: nil];
       PASS([iv contentTintColor] == nil,
            "setContentTintColor: can clear the content tint color");
+
+      /* Unlike NSButton, NSImageView keeps contentTintColor on the view. */
+      {
+        Class originalCellClass = [NSImageView cellClass];
+        TintRecordingImageCell *tintCell;
+
+        [NSImageView setCellClass: [TintRecordingImageCell class]];
+        iv = AUTORELEASE([[NSImageView alloc]
+          initWithFrame: NSMakeRect(0, 0, 80, 80)]);
+        [NSImageView setCellClass: originalCellClass];
+
+        tintCell = (TintRecordingImageCell *)[iv cell];
+        [iv setContentTintColor: [NSColor blueColor]];
+        PASS([[iv contentTintColor] isEqual: [NSColor blueColor]],
+             "setContentTintColor: stores the color on the image view");
+        PASS([tintCell contentTintColor] == nil
+          && [tintCell setContentTintColorCount] == 0,
+             "setContentTintColor: is not forwarded to the image cell");
+      }
 
       /* Image round-trip. */
       NSImage *img = AUTORELEASE([[NSImage alloc] initWithSize: NSMakeSize(16, 16)]);

--- a/Tests/gui/NSImageView/state.m
+++ b/Tests/gui/NSImageView/state.m
@@ -15,6 +15,7 @@
 #include <AppKit/NSImageView.h>
 #include <AppKit/NSImageCell.h>
 #include <AppKit/NSImage.h>
+#include <AppKit/NSColor.h>
 
 int
 main(int argc, char **argv)
@@ -48,6 +49,8 @@ main(int argc, char **argv)
       PASS([iv isEditable] == NO, "an image view is not editable by default");
       PASS([iv allowsCutCopyPaste] == YES,
            "cut, copy and paste are allowed by default");
+      PASS([iv contentTintColor] == nil,
+           "the content tint color is nil by default");
 
       /* Round-trips. */
       [iv setImageAlignment: NSImageAlignTop];
@@ -59,6 +62,12 @@ main(int argc, char **argv)
            "setImageFrameStyle: round trips");
       [iv setEditable: YES];
       PASS([iv isEditable] == YES, "setEditable: round trips");
+      [iv setContentTintColor: [NSColor redColor]];
+      PASS([[iv contentTintColor] isEqual: [NSColor redColor]],
+           "setContentTintColor: round trips");
+      [iv setContentTintColor: nil];
+      PASS([iv contentTintColor] == nil,
+           "setContentTintColor: can clear the content tint color");
 
       /* Image round-trip. */
       NSImage *img = AUTORELEASE([[NSImage alloc] initWithSize: NSMakeSize(16, 16)]);


### PR DESCRIPTION
This PR adds setTemplate:/template to enable stencil images to be created.  This is to improve compatibility with currently macOS.

The test for this is here: https://github.com/gcasa/NSImage_template_test

<img width="430" height="338" alt="fixed_example" src="https://github.com/user-attachments/assets/2a3bf43e-2123-48d9-8002-81ad26554638" />
