### PR TITLE
Fix: copy the tooltip an NSTabViewItem is given and release it

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-08-10 Todd White <todd.white@thalion.global>
+
+	* Source/NSTabViewItem.m: Copy the string passed to
+	-setToolTip:, which AppKit declares as a copy property, and
+	release it in -dealloc.
+	* Tests/gui/NSTabViewItem/toolTipMemory.m: Cover both.
+
 2026-07-14 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Source/GSTheme.m:

--- a/Source/NSTabViewItem.m
+++ b/Source/NSTabViewItem.m
@@ -64,6 +64,7 @@
   RELEASE(_label);
   RELEASE(_view);
   RELEASE(_color);
+  TEST_RELEASE(_toolTip);
   [super dealloc];
 }
 
@@ -251,7 +252,7 @@
 
 - (void) setToolTip: (NSString*)toolTip
 {
-  ASSIGN(_toolTip, toolTip);
+  ASSIGNCOPY(_toolTip, toolTip);
 }
 
 - (NSString*) toolTip

--- a/Tests/gui/NSTabViewItem/toolTipMemory.m
+++ b/Tests/gui/NSTabViewItem/toolTipMemory.m
@@ -1,0 +1,57 @@
+/* What -[NSTabViewItem setToolTip:] does with the string it is given.
+
+   AppKit declares the property as
+     @property (copy, nullable) NSString *toolTip;
+   so the item holds a copy, and it gives that copy up when it is released.
+*/
+#include "Testing.h"
+
+#include <Foundation/NSAutoreleasePool.h>
+#include <Foundation/NSString.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSTabViewItem.h>
+
+int main()
+{
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  NSTabViewItem		*item;
+  NSMutableString	*mutable;
+  NSString		*tip;
+  NSUInteger		 before;
+
+  START_SET("NSTabViewItem toolTip memory")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  /* The property is declared copy, so a string that changes afterwards does
+   * not change the tooltip. */
+  item = AUTORELEASE([[NSTabViewItem alloc] initWithIdentifier: @"copy"]);
+  mutable = [NSMutableString stringWithString: @"one"];
+  [item setToolTip: mutable];
+  [mutable appendString: @" two"];
+  PASS([[item toolTip] isEqual: @"one"],
+       "the tooltip is a copy of the string it was given");
+
+  /* An item that is released gives up the tooltip it holds.  The string is
+   * made rather than a literal, so its retain count is its own. */
+  tip = [[NSString alloc] initWithString: @"a tooltip"];
+  before = [tip retainCount];
+  item = [[NSTabViewItem alloc] initWithIdentifier: @"release"];
+  [item setToolTip: tip];
+  PASS([[item toolTip] isEqual: tip], "the tooltip reads back");
+  [item release];
+  PASS([tip retainCount] == before,
+       "releasing the item releases the tooltip it held");
+  [tip release];
+
+  END_SET("NSTabViewItem toolTip memory")
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
-[NSTabViewItem setToolTip:] assigned the string to _toolTip, and -dealloc
released the identifier, the label, the view and the colour but not the
tooltip, so a tooltip set on an item was leaked. Reported in #894.

AppKit declares the property as

    @property (copy, nullable) NSString *toolTip;

so the string is now copied rather than retained, and it is released in
-dealloc.

Tests/gui/NSTabViewItem/toolTipMemory.m covers both: a mutable string changed
after -setToolTip: does not change the tooltip, and a string handed to an item
has the retain count it started with once the item is released. Against master
the set is 11 passed and 2 failed; with this change it is 13 passed and 0
failed. NSTabView is 48 passed and NSTabViewController 29 passed, unchanged
either way.

The other half of #894, that a tab view does nothing with the tooltips of its
items, is untouched.
