### PR TITLE
Feature: show the tooltip an NSTabViewItem carries

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-08-11 Todd White <todd.white@thalion.global>
+
+	* Source/NSTabView.m: Give each item's tooltip the area that
+	item's tab occupies, renewed after each draw, since the theme
+	settles the tab rects as it draws.
+	* Tests/gui/NSTabView/toolTips.m: Cover it.
+
 2026-08-10 Todd White <todd.white@thalion.global>
 
 	* Source/NSTabViewItem.m: Copy the string passed to

--- a/Source/NSTabView.m
+++ b/Source/NSTabView.m
@@ -436,6 +436,31 @@
 		   inView: self
 		   withItems: _items
 		   selectedItem: _selected];
+
+  [self _updateToolTips];
+}
+
+/* An item's tooltip belongs to the area its tab occupies, and that area is
+ * known only once the theme has drawn: -[NSTabViewItem drawLabel:inRect:] is
+ * what records it.  The tooltips are therefore renewed after each draw, from
+ * the rects the draw just settled.
+ */
+- (void) _updateToolTips
+{
+  NSEnumerator	*enumerator = [_items objectEnumerator];
+  NSTabViewItem	*item;
+
+  [self removeAllToolTips];
+  while ((item = [enumerator nextObject]) != nil)
+    {
+      NSString	*tip = [item toolTip];
+      NSRect	 rect = [item _tabRect];
+
+      if ([tip length] > 0 && NO == NSIsEmptyRect(rect))
+	{
+	  [self addToolTipRect: rect owner: tip userData: NULL];
+	}
+    }
 }
 
 - (BOOL) isOpaque

--- a/Tests/gui/NSTabView/toolTips.m
+++ b/Tests/gui/NSTabView/toolTips.m
@@ -1,0 +1,120 @@
+/* A tab view gives each item's tooltip the area that item's tab occupies.
+
+   The tab rects are settled by the theme as it draws, so the tooltips are
+   asked for after a draw.  What the tab view asks for is recorded by a
+   subclass rather than inferred from the screen: NSView keeps no public list
+   of the tooltip rects it holds.
+*/
+#import "Testing.h"
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSGeometry.h>
+#import <Foundation/NSValue.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSTabView.h>
+#import <AppKit/NSTabViewItem.h>
+
+static NSMutableArray *tips = nil;
+static NSMutableArray *rects = nil;
+static int removals = 0;
+
+@interface RecordingTabView : NSTabView
+@end
+
+@implementation RecordingTabView
+
+- (NSToolTipTag) addToolTipRect: (NSRect)aRect
+			  owner: (id)anObject
+		       userData: (void *)data
+{
+  [tips addObject: anObject];
+  [rects addObject: [NSValue valueWithRect: aRect]];
+  return [super addToolTipRect: aRect owner: anObject userData: data];
+}
+
+- (void) removeAllToolTips
+{
+  removals++;
+  [super removeAllToolTips];
+}
+
+@end
+
+static NSTabViewItem *
+mk(NSString *ident, NSString *label, NSString *tip)
+{
+  NSTabViewItem *it = AUTORELEASE([[NSTabViewItem alloc]
+    initWithIdentifier: ident]);
+
+  [it setLabel: label];
+  [it setView: AUTORELEASE([[NSView alloc]
+    initWithFrame: NSMakeRect(0, 0, 50, 50)])];
+  if (tip != nil)
+    {
+      [it setToolTip: tip];
+    }
+  return it;
+}
+
+int
+main(int argc, const char **argv)
+{
+  NSAutoreleasePool *arp = [NSAutoreleasePool new];
+
+  START_SET("NSTabView toolTips")
+
+  NS_DURING
+    [NSApplication sharedApplication];
+  NS_HANDLER
+    if ([[localException name] isEqualToString: NSInternalInconsistencyException])
+      SKIP("It looks like GNUstep backend is not yet installed")
+  NS_ENDHANDLER
+
+  tips = [NSMutableArray new];
+  rects = [NSMutableArray new];
+
+  NS_DURING
+    {
+      NSWindow		*w;
+      RecordingTabView	*tv;
+      NSTabViewItem	*withTip;
+
+      w = AUTORELEASE([[NSWindow alloc]
+	initWithContentRect: NSMakeRect(0, 0, 200, 120)
+		  styleMask: NSWindowStyleMaskBorderless
+		    backing: NSBackingStoreBuffered
+		      defer: NO]);
+      tv = AUTORELEASE([[RecordingTabView alloc]
+	initWithFrame: NSMakeRect(0, 0, 200, 120)]);
+      withTip = mk(@"a", @"A", @"the first tab");
+      [tv addTabViewItem: withTip];
+      [tv addTabViewItem: mk(@"b", @"B", nil)];
+      [w setContentView: tv];
+      [tv display];
+
+      PASS([tips count] == 1,
+	   "one tooltip is registered, for the one item that has one");
+      if ([tips count] == 1)
+	{
+	  PASS([[tips objectAtIndex: 0] isEqual: @"the first tab"],
+	       "the tooltip registered is the item's own");
+	  PASS(NSEqualRects([[rects objectAtIndex: 0] rectValue],
+			    [withTip _tabRect]),
+	       "the rect registered is the rect that item's tab occupies");
+	}
+      PASS(removals > 0, "the tooltips are renewed rather than accumulated");
+    }
+  NS_HANDLER
+    PASS(0 == 1, "drawing the tab view raised");
+  NS_ENDHANDLER
+
+  DESTROY(tips);
+  DESTROY(rects);
+
+  END_SET("NSTabView toolTips")
+
+  [arp release];
+  return 0;
+}


### PR DESCRIPTION
NSTabView did nothing with the tooltips of its items, which is the other half
of #894. The first half, the leak, is #905. This will close #894 

The area a tooltip belongs to is the area that item's tab occupies.
-[NSTabViewItem drawLabel:inRect:] records that rect as the theme draws, so it
is known after a draw and not before, and the tooltips are renewed there from
the rects the draw settled.

Tests/gui/NSTabView/toolTips.m records what the tab view asks for, since
NSView keeps no public list of the tooltip rects it holds: one tooltip is
registered for the one item that has one, the string is the item's own, and the
rect is that item's tab rect. Against master the set is 2 failed; with this
change NSTabView is 52 passed and 0 failed, NSTabViewItem 10 and
NSTabViewController 29, both unchanged.

Two things a maintainer may want differently. The tooltips are renewed on every
draw, because there is no updateTrackingAreas in this NSView to hang them on.
And -removeAllToolTips is used to renew them, which also drops a tooltip a
client added to the tab view itself.
