### PR TITLE
Read the printers the GSWIN32 bundle says it reads

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2026-08-11 Todd White <todd.white@thalion.global>
+
+	* Printing/GSWIN32/GSWIN32Printer.m: Read the printers named
+	in the GSWIN32Printers user default, which the fallback message
+	already said were read, and merge them over the printers the
+	spooler reports.  Fall back on an empty dictionary rather than
+	on nil, which EnumeratePrinters answers only when EnumPrinters
+	fails.
+	* Tests/gui/NSPrinter/badPPD.m: Write the entry under the key
+	of each bundle that reads one, since which bundle is loaded is
+	a property of the platform.
+
 2026-08-10 Todd White <todd.white@thalion.global>
 
 	* Source/NSTabViewItem.m: Copy the string passed to

--- a/Printing/GSWIN32/GSWIN32Printer.m
+++ b/Printing/GSWIN32/GSWIN32Printer.m
@@ -195,17 +195,33 @@ NSMutableDictionary *EnumeratePrinters(DWORD flags)
 + (NSDictionary*) printersDictionary
 {
   static BOOL didWarn;
-  NSDictionary *printers;
-  
+  NSUserDefaults *defaults;
+  NSDictionary *configured;
+  NSMutableDictionary *printers;
+
+  defaults = [NSUserDefaults standardUserDefaults];
+  configured = [defaults dictionaryForKey: @"GSWIN32Printers"];
+
   printers = EnumeratePrinters(PRINTER_ENUM_LOCAL);
-  if (!printers) //Not set, make a default printer because we are nice.
+  if (printers == nil) //EnumPrinters failed; it answers an empty dictionary
+    {                  //when it succeeds and the spooler holds no printer.
+      printers = [NSMutableDictionary dictionary];
+    }
+
+  // A printer named in the defaults was configured deliberately, so it wins
+  // over one of the same name that the spooler reported.
+  if ([configured count] > 0)
     {
+      [printers addEntriesFromDictionary: configured];
+    }
+
+  if ([printers count] == 0) //Nothing anywhere, make a default printer
+    {                        //because we are nice.
       NSString *ppdPath;
       NSMutableDictionary *printerEntry;
-      
-      printers = [NSMutableDictionary dictionary];
+
       printerEntry = [NSMutableDictionary dictionary];
-      
+
       ppdPath = [NSBundle
 		      pathForLibraryResource: @"Generic-PostScript_Printer-Postscript"
 				      ofType: @"ppd"

--- a/Tests/gui/NSPrinter/badPPD.m
+++ b/Tests/gui/NSPrinter/badPPD.m
@@ -1,12 +1,19 @@
-/* A printer stored in the GSLPRPrinters defaults can point at a PPD file that
-   has moved or been removed. Loading it must not raise an uncaught exception
-   (which aborts the application while it is only setting up printing); the
-   printer is returned without the PPD so the caller falls back to its defaults.
+/* A printer stored in a printing bundle's defaults can point at a PPD file
+   that has moved or been removed. Loading it must not raise an uncaught
+   exception (which aborts the application while it is only setting up
+   printing); the printer is returned without the PPD so the caller falls back
+   to its defaults.
+
+   The entry is written under the key of each bundle that reads one, since
+   which bundle is loaded is a property of the platform: GSLPR on Unix and
+   GSWIN32 on Windows, where only one of the two is installed.
 */
 #include "Testing.h"
 
+#include <Foundation/NSArray.h>
 #include <Foundation/NSAutoreleasePool.h>
 #include <Foundation/NSDictionary.h>
+#include <Foundation/NSEnumerator.h>
 #include <Foundation/NSException.h>
 #include <Foundation/NSString.h>
 #include <Foundation/NSUserDefaults.h>
@@ -19,7 +26,11 @@ main(int argc, char **argv)
   START_SET("NSPrinter missing PPD")
 
   NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
-  id saved = [ud objectForKey: @"GSLPRPrinters"];
+  NSArray *keys = [NSArray arrayWithObjects:
+    @"GSLPRPrinters", @"GSWIN32Printers", nil];
+  NSMutableDictionary *saved = [NSMutableDictionary dictionary];
+  NSEnumerator *keyEnum;
+  NSString *key;
   NSDictionary *entry;
   NSDictionary *printers;
   NSPrinter *printer = nil;
@@ -31,7 +42,18 @@ main(int argc, char **argv)
     @"test", @"Note",
     nil];
   printers = [NSDictionary dictionaryWithObject: entry forKey: @"MissingPPDPrinter"];
-  [ud setObject: printers forKey: @"GSLPRPrinters"];
+
+  keyEnum = [keys objectEnumerator];
+  while ((key = [keyEnum nextObject]) != nil)
+    {
+      id was = [ud objectForKey: key];
+
+      if (was != nil)
+	{
+	  [saved setObject: was forKey: key];
+	}
+      [ud setObject: printers forKey: key];
+    }
 
   PASS_RUNS(({
     printer = [NSPrinter printerWithName: @"MissingPPDPrinter"];
@@ -39,10 +61,20 @@ main(int argc, char **argv)
   PASS(printer != nil,
        "a printer is still returned when its PPD is missing");
 
-  if (saved != nil)
-    [ud setObject: saved forKey: @"GSLPRPrinters"];
-  else
-    [ud removeObjectForKey: @"GSLPRPrinters"];
+  keyEnum = [keys objectEnumerator];
+  while ((key = [keyEnum nextObject]) != nil)
+    {
+      id was = [saved objectForKey: key];
+
+      if (was != nil)
+	{
+	  [ud setObject: was forKey: key];
+	}
+      else
+	{
+	  [ud removeObjectForKey: key];
+	}
+    }
 
   END_SET("NSPrinter missing PPD")
 


### PR DESCRIPTION
Fixes #896.

+printersDictionary answered EnumeratePrinters alone and never read the user defaults, while the message it logs when it finds nothing names the GSWIN32Printers key. A printer configured through the defaults was invisible, and +[NSPrinter printerWithName:] raised NSGenericException for it.

The key is read and merged over the printers the spooler reports, so a name configured deliberately wins and the printers Windows knows about are still listed. GSLPR reads GSLPRPrinters in the same way.

The fallback is reached on an empty dictionary rather than on nil: EnumeratePrinters answers nil only when EnumPrinters fails, so on a machine holding no printer the fallback entry could not be reached at all.

badPPD.m wrote its entry under GSLPRPrinters alone, so on Windows it configured a bundle that was not loaded; it writes under the key of each bundle that reads one.

Verified on MSYS2 UCRT64, the platform of the Windows MinGW job, where only GSWIN32.bundle is installed: badPPD.m:38 and :40 failed before and pass after, with 4 spooler printers still enumerated. On Linux the set gives 13 passed before and after.
