### PR TITLE
Watch a data link source with whatever the platform provides

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,17 @@
 2026-08-11 Todd White <todd.white@thalion.global>
 
+	* Headers/AppKit/NSDataLinkManager.h:
+	* Source/NSDataLinkManager.m: Watch the source file of a data
+	link with whatever the platform provides.  inotify reports the
+	file; on Windows a change notification handle reports its
+	directory, and every link taking its source from there is
+	reported; where there is neither, a timer compares each file's
+	modification date and size.  Before this the manager built and
+	accepted links on a platform with no inotify and never asked
+	the delegate, so a link never refreshed.
+
+2026-08-11 Todd White <todd.white@thalion.global>
+
 	* Source/NSApplication.m: Set the hidden flag, post the hide
 	notifications and swap the Hide menu item where an application
 	is hidden by miniaturizing its windows, which is the path taken

--- a/Headers/AppKit/NSDataLinkManager.h
+++ b/Headers/AppKit/NSDataLinkManager.h
@@ -54,6 +54,13 @@ APPKIT_EXPORT_CLASS
   NSThread            *_monitorThread;
   int                  _inotifyFD;
   NSMutableDictionary *_watchDescriptors;
+  /* The source file of each watched link, by path.  Every mechanism needs it:
+     the Windows watcher to say which link a directory's change belongs to, and
+     the timer to know which files to examine. */
+  NSMutableDictionary *_watchedLinks;
+  /* How each source file was last seen: its modification date and size. */
+  NSMutableDictionary *_watchedStamps;
+  id                   _pollTimer;
 
   struct __dlmFlags {
     unsigned areLinkOutlinesVisible:1;

--- a/Source/NSDataLinkManager.m
+++ b/Source/NSDataLinkManager.m
@@ -29,9 +29,12 @@
 #include "config.h"
 #import <Foundation/NSArchiver.h>
 #import <Foundation/NSArray.h>
+#import <Foundation/NSDate.h>
 #import <Foundation/NSDictionary.h>
 #import <Foundation/NSEnumerator.h>
+#import <Foundation/NSFileManager.h>
 #import <Foundation/NSThread.h>
+#import <Foundation/NSTimer.h>
 #import <Foundation/NSValue.h>
 
 #import "AppKit/NSPanel.h"
@@ -39,8 +42,18 @@
 #import "AppKit/NSDataLink.h"
 #import "AppKit/NSPasteboard.h"
 
+/* A source file is watched by whichever mechanism the platform has.  inotify
+   reports the file itself; the Windows notification handle reports that
+   something in a directory changed, and every link taking its source from
+   there is reported; where there is neither, a timer compares each file's
+   modification date and size.  All three end at -_noteSourceEditedForLink:,
+   which runs on the main thread. */
 #ifdef HAVE_SYS_INOTIFY_H
 #import <sys/inotify.h>
+#define GS_MONITOR_INOTIFY 1
+#elif defined(_WIN32)
+#include <windows.h>
+#define GS_MONITOR_WIN32 1
 #endif
 
 #import <unistd.h>
@@ -48,10 +61,22 @@
 
 #import "GSFastEnumeration.h"
 
+/* How often the timer reads the dates, in seconds, where no notification
+   mechanism is available. */
+#define GS_POLL_INTERVAL 1.0
+
 @interface NSDataLinkManager (Private)
 - (void) stopMonitoring;
 - (void) startMonitoring;
 - (void) monitorLoop;
+- (BOOL) _startNativeMonitoring;
+- (void) _startPolling;
+- (void) _stopPolling;
+- (void) _pollSources: (id)timer;
+- (BOOL) _noteStampOfPath: (NSString *)path;
+- (void) _sourceChangedForLinkAtPath: (NSString *)path;
+- (void) _directoryChanged: (NSString *)directory;
+- (void) _noteSourceEditedForLink: (NSDataLink *)link;
 @end
 
 // Private setters/getters for links...
@@ -145,9 +170,11 @@
       _sourceLinks = [[NSMutableArray alloc] init];
       _destinationLinks = [[NSMutableArray alloc] init];
       _watchDescriptors = [[NSMutableDictionary alloc] init];
+      _watchedLinks = [[NSMutableDictionary alloc] init];
+      _watchedStamps = [[NSMutableDictionary alloc] init];
       _nextLinkNumber = 1;
       _inotifyFD = -1;
-#ifdef HAVE_SYS_INOTIFY_H
+#ifdef GS_MONITOR_INOTIFY
       _inotifyFD = inotify_init();
       if (_inotifyFD < 0)
 	{
@@ -173,6 +200,8 @@
   RELEASE(_sourceLinks);
   RELEASE(_destinationLinks);
   RELEASE(_watchDescriptors);
+  RELEASE(_watchedLinks);
+  RELEASE(_watchedStamps);
   RELEASE(_monitorThread);
   [super dealloc];
 }
@@ -182,42 +211,163 @@
 //
 - (void)stopMonitoring
 {
-#ifdef HAVE_SYS_INOTIFY_H
-  NSArray *allKeys = [_watchDescriptors allKeys];
-  NSEnumerator *en = [allKeys objectEnumerator];
-  NSNumber *key = nil;
+  [self _stopPolling];
 
-  while ((key = [en nextObject]) != nil)
+  /* The thread is asked to stop before anything it waits on is taken away. */
+  if (_monitorThread && [_monitorThread isExecuting])
     {
-      inotify_rm_watch(_inotifyFD, [key intValue]);
+      NSDate *limit = [NSDate dateWithTimeIntervalSinceNow: 1.0];
+
+      [_monitorThread cancel];  // thread must check isCancelled
+      while ([_monitorThread isExecuting]
+	&& [limit timeIntervalSinceNow] > 0.0)
+	{
+	  [NSThread sleepForTimeInterval: 0.02];
+	}
     }
 
-  [_watchDescriptors removeAllObjects];
+#ifdef GS_MONITOR_INOTIFY
+  {
+    NSEnumerator *en = [[_watchDescriptors allKeys] objectEnumerator];
+    NSNumber *key = nil;
+
+    while ((key = [en nextObject]) != nil)
+      {
+	inotify_rm_watch(_inotifyFD, [key intValue]);
+      }
+  }
 
   if (_inotifyFD >= 0)
     {
       close(_inotifyFD);
       _inotifyFD = -1;
     }
+#endif
 
-  if (_monitorThread && [_monitorThread isExecuting])
+#ifdef GS_MONITOR_WIN32
+  {
+    NSArray *values;
+    NSEnumerator *en;
+    NSValue *value = nil;
+
+    @synchronized(self)
+      {
+	values = [[_watchDescriptors allValues] copy];
+	[_watchDescriptors removeAllObjects];
+      }
+    en = [values objectEnumerator];
+    while ((value = [en nextObject]) != nil)
+      {
+	FindCloseChangeNotification((HANDLE)[value pointerValue]);
+      }
+    RELEASE(values);
+  }
+#endif
+
+  [_watchDescriptors removeAllObjects];
+  [_watchedLinks removeAllObjects];
+  [_watchedStamps removeAllObjects];
+}
+
+/* Start whichever notification mechanism the platform has.  Answers NO when
+   there is none to start, and the timer stands in for it. */
+- (BOOL) _startNativeMonitoring
+{
+#ifdef GS_MONITOR_INOTIFY
+  /* With no descriptor to read there is nothing to wait on, and the loop
+     would spin. */
+  if (_inotifyFD < 0)
     {
-      [_monitorThread cancel];  // thread must check isCancelled
+      return NO;
     }
+#endif
+
+#if defined(GS_MONITOR_INOTIFY) || defined(GS_MONITOR_WIN32)
+  _monitorThread = [[NSThread alloc] initWithTarget: self
+					   selector: @selector(monitorLoop)
+					     object: nil];
+  [_monitorThread start];
+  return YES;
+#else
+  return NO;
 #endif
 }
 
 - (void)startMonitoring
 {
-  /* With no descriptor to read there is nothing to wait on, and the loop
-     would spin. */
-  if (_inotifyFD < 0)
+  if ([self _startNativeMonitoring] == NO)
+    {
+      [self _startPolling];
+    }
+}
+
+/* Read the dates of every watched source.  This is what the timer runs, and
+   what the Windows watcher runs when a directory reports a change: the
+   notification says a directory changed, and the dates say which file. */
+- (void) _pollSources: (id)timer
+{
+  NSEnumerator *en = [[_watchedLinks allKeys] objectEnumerator];
+  NSString *path;
+
+  while ((path = [en nextObject]) != nil)
+    {
+      if ([self _noteStampOfPath: path] == YES)
+	{
+	  [self _sourceChangedForLinkAtPath: path];
+	}
+    }
+}
+
+- (void) _startPolling
+{
+  if (_pollTimer != nil)
     {
       return;
     }
+  _pollTimer = [NSTimer scheduledTimerWithTimeInterval: GS_POLL_INTERVAL
+						target: self
+					      selector: @selector(_pollSources:)
+					      userInfo: nil
+					       repeats: YES];
+}
 
-  _monitorThread = [[NSThread alloc] initWithTarget:self selector:@selector(monitorLoop) object:nil];
-  [_monitorThread start];
+- (void) _stopPolling
+{
+  if (_pollTimer != nil)
+    {
+      [_pollTimer invalidate];
+      _pollTimer = nil;
+    }
+}
+
+/* Answers YES when the file differs from the way it was last seen, and records
+   how it is now.  A file just added is recorded without being reported, since
+   nothing has changed yet.
+
+   The size is compared as well as the modification date: a file rewritten in
+   the same second as the reading before it keeps its date, and the timer has
+   nothing else to go on. */
+- (BOOL) _noteStampOfPath: (NSString *)path
+{
+  NSDictionary *attributes;
+  NSString *now;
+  NSString *before;
+
+  attributes = [[NSFileManager defaultManager] fileAttributesAtPath: path
+							traverseLink: YES];
+  if (attributes == nil)
+    {
+      return NO;
+    }
+
+  now = [NSString stringWithFormat: @"%@ %llu",
+    [attributes objectForKey: NSFileModificationDate],
+    (unsigned long long)[attributes fileSize]];
+
+  before = [_watchedStamps objectForKey: path];
+  [_watchedStamps setObject: now forKey: path];
+
+  return (before != nil && [now isEqual: before] == NO);
 }
 
 /* Watch the file a link takes its contents from, and remember which link the
@@ -225,41 +375,132 @@
    so the table keeps the most recently added link for it. */
 - (void) _watchSourceOfLink: (NSDataLink *)link
 {
-#ifdef HAVE_SYS_INOTIFY_H
   NSString *path = [link sourceFilename];
-  int wd;
 
-  if (_inotifyFD < 0 || path == nil)
+  if (path == nil)
     {
       return;
     }
 
-  wd = inotify_add_watch(_inotifyFD, [path fileSystemRepresentation],
-			 IN_CLOSE_WRITE | IN_MODIFY | IN_MOVE_SELF);
-  if (wd < 0)
-    {
-      return;
-    }
+  /* Recorded for every mechanism, and with the date the file has now, so that
+     the first comparison reports a change made after this point and not the
+     file's whole history. */
+  [_watchedLinks setObject: link forKey: path];
+  [self _noteStampOfPath: path];
 
-  [_watchDescriptors setObject: link forKey: [NSNumber numberWithInt: wd]];
+#ifdef GS_MONITOR_INOTIFY
+  {
+    int wd;
+
+    if (_inotifyFD < 0)
+      {
+	return;
+      }
+
+    wd = inotify_add_watch(_inotifyFD, [path fileSystemRepresentation],
+			   IN_CLOSE_WRITE | IN_MODIFY | IN_MOVE_SELF);
+    if (wd < 0)
+      {
+	return;
+      }
+
+    [_watchDescriptors setObject: link forKey: [NSNumber numberWithInt: wd]];
+  }
+#endif
+
+#ifdef GS_MONITOR_WIN32
+  {
+    NSString *directory = [path stringByDeletingLastPathComponent];
+    HANDLE handle;
+
+    /* One notification handle serves every link in a directory, so a
+       directory already watched is left alone. */
+    if ([directory length] == 0
+      || [_watchDescriptors objectForKey: directory] != nil)
+      {
+	return;
+      }
+
+    handle = FindFirstChangeNotificationW(
+      (const unichar *)[directory cStringUsingEncoding: NSUTF16StringEncoding],
+      FALSE, FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_FILE_NAME);
+    if (handle == INVALID_HANDLE_VALUE || handle == NULL)
+      {
+	/* Nothing to wait on for this directory: the timer reads its dates
+	   instead, which is the same answer a platform with no notification
+	   mechanism at all gets. */
+	[self _startPolling];
+	return;
+      }
+
+    /* The monitoring thread waits on these handles, so the table it reads is
+       not written without the lock it takes. */
+    @synchronized(self)
+      {
+	[_watchDescriptors setObject: [NSValue valueWithPointer: handle]
+			      forKey: directory];
+      }
+  }
 #endif
 }
 
 - (void) _unwatchSourceOfLink: (NSDataLink *)link
 {
-#ifdef HAVE_SYS_INOTIFY_H
-  NSArray *keys = [_watchDescriptors allKeysForObject: link];
-  NSEnumerator *en = [keys objectEnumerator];
-  NSNumber *key;
+  NSString *path = [link sourceFilename];
 
-  while ((key = [en nextObject]) != nil)
+  if (path != nil)
     {
-      if (_inotifyFD >= 0)
-	{
-	  inotify_rm_watch(_inotifyFD, [key intValue]);
-	}
-      [_watchDescriptors removeObjectForKey: key];
+      [_watchedLinks removeObjectForKey: path];
+      [_watchedStamps removeObjectForKey: path];
     }
+
+#ifdef GS_MONITOR_INOTIFY
+  {
+    NSArray *keys = [_watchDescriptors allKeysForObject: link];
+    NSEnumerator *en = [keys objectEnumerator];
+    NSNumber *key;
+
+    while ((key = [en nextObject]) != nil)
+      {
+	if (_inotifyFD >= 0)
+	  {
+	    inotify_rm_watch(_inotifyFD, [key intValue]);
+	  }
+	[_watchDescriptors removeObjectForKey: key];
+      }
+  }
+#endif
+
+#ifdef GS_MONITOR_WIN32
+  {
+    NSString *directory = [path stringByDeletingLastPathComponent];
+    NSEnumerator *en = [[_watchedLinks allKeys] objectEnumerator];
+    NSString *other;
+    NSValue *value;
+
+    /* The handle is the directory's, so it stays while any other link in that
+       directory is still watched. */
+    while ((other = [en nextObject]) != nil)
+      {
+	if ([[other stringByDeletingLastPathComponent] isEqual: directory])
+	  {
+	    return;
+	  }
+      }
+
+    @synchronized(self)
+      {
+	value = [_watchDescriptors objectForKey: directory];
+	if (value != nil)
+	  {
+	    [_watchDescriptors removeObjectForKey: directory];
+	  }
+      }
+    if (value != nil)
+      {
+	FindCloseChangeNotification((HANDLE)[value pointerValue]);
+      }
+  }
 #endif
 }
 
@@ -267,8 +508,40 @@
    delegate is never messaged from the monitoring thread. */
 - (void) _sourceChangedForWatch: (NSNumber *)descriptor
 {
-  NSDataLink *link = [_watchDescriptors objectForKey: descriptor];
+  [self _noteSourceEditedForLink:
+    [_watchDescriptors objectForKey: descriptor]];
+}
 
+/* The Windows watcher and the timer name the file rather than a watch. */
+- (void) _sourceChangedForLinkAtPath: (NSString *)path
+{
+  [self _noteSourceEditedForLink: [_watchedLinks objectForKey: path]];
+}
+
+/* A directory the Windows watcher reported.  Every link taking its source from
+   that directory is reported, without consulting the file's modification date:
+   the notification is the platform saying something there changed, and a date
+   is too coarse to confirm it.  An edit made in the same second as the one
+   before it leaves the date alone, and the delegate exists to decide whether
+   the change matters. */
+- (void) _directoryChanged: (NSString *)directory
+{
+  NSEnumerator *en = [[_watchedLinks allKeys] objectEnumerator];
+  NSString *path;
+
+  while ((path = [en nextObject]) != nil)
+    {
+      if ([[path stringByDeletingLastPathComponent] isEqual: directory])
+	{
+	  /* Read now, so that a later poll does not report it again. */
+	  [self _noteStampOfPath: path];
+	  [self _sourceChangedForLinkAtPath: path];
+	}
+    }
+}
+
+- (void) _noteSourceEditedForLink: (NSDataLink *)link
+{
   if (link == nil)
     {
       return;
@@ -288,7 +561,68 @@
 
 - (void)monitorLoop
 {
-#ifdef HAVE_SYS_INOTIFY_H
+#ifdef GS_MONITOR_WIN32
+  while (![[NSThread currentThread] isCancelled])
+    {
+      CREATE_AUTORELEASE_POOL(pool);
+      NSArray *directories;
+      HANDLE handles[MAXIMUM_WAIT_OBJECTS];
+      DWORD count = 0;
+      DWORD result;
+
+      /* The table belongs to the main thread, so it is read under a lock and
+	 the handles are copied out before waiting on them. */
+      @synchronized(self)
+	{
+	  NSEnumerator *en;
+	  NSString *directory;
+
+	  directories = [_watchDescriptors allKeys];
+	  en = [directories objectEnumerator];
+	  while ((directory = [en nextObject]) != nil
+	    && count < MAXIMUM_WAIT_OBJECTS)
+	    {
+	      NSValue *value = [_watchDescriptors objectForKey: directory];
+
+	      if (value != nil)
+		{
+		  handles[count++] = (HANDLE)[value pointerValue];
+		}
+	    }
+	  directories = [directories copy];
+	}
+      [directories autorelease];
+
+      if (count == 0)
+	{
+	  /* No directory is watched yet; wait rather than spin, and look
+	     again for one a link may have added meanwhile. */
+	  DESTROY(pool);
+	  [NSThread sleepForTimeInterval: 0.1];
+	  continue;
+	}
+
+      /* The wait ends on its own so that a cancelled thread stops, and so
+	 that a directory added since the snapshot is picked up. */
+      result = WaitForMultipleObjects(count, handles, FALSE, 500);
+      if (result >= WAIT_OBJECT_0 && result < WAIT_OBJECT_0 + count)
+	{
+	  DWORD index = result - WAIT_OBJECT_0;
+	  NSString *directory = [directories objectAtIndex: index];
+
+	  /* Re-arm before the change is examined, so an edit made while it is
+	     being read is not missed. */
+	  FindNextChangeNotification(handles[index]);
+
+	  [self performSelectorOnMainThread: @selector(_directoryChanged:)
+				 withObject: directory
+			      waitUntilDone: NO];
+	}
+      DESTROY(pool);
+    }
+#endif
+
+#ifdef GS_MONITOR_INOTIFY
   char buffer[1024];
   while (![[NSThread currentThread] isCancelled])
     {


### PR DESCRIPTION
Fixes #898.

NSDataLinkManager watched source files with inotify, which only Linux has. Everywhere else the manager still built and still accepted links, so nothing reported that monitoring was not running: the delegate was never asked and a link never refreshed.

On Windows a change notification handle watches the directory a source file is in, and every link taking its source from there is reported. No modification date is consulted to confirm it, since an edit made in the same second as the reading before it leaves the date alone, and the delegate exists to decide whether the change matters.

Where there is neither, or a native one cannot start, a timer compares each source file's modification date and size.

All three end at one private method that runs on the main thread, so the delegate is still never messaged from the monitoring thread.

Tests/gui/NSDataLink on MSYS2 UCRT64, the platform of the Windows MinGW job: sourceMonitoring.m:98 failed before and 101 assertions pass after, the delegate asked 106ms after the write. On Linux the set gives 101 passed before and after, against the built library rather than the installed one.
