### PR TITLE
Hide an application properly when its windows are miniaturized

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,14 @@
 2026-08-11 Todd White <todd.white@thalion.global>
 
+	* Source/NSApplication.m: Set the hidden flag, post the hide
+	notifications and swap the Hide menu item where an application
+	is hidden by miniaturizing its windows, which is the path taken
+	on Windows and the path taken anywhere when GSSuppressAppIcon is
+	set.  Deminiaturize those windows again in
+	-unhideWithoutActivation.
+
+2026-08-11 Todd White <todd.white@thalion.global>
+
 	* Printing/GSWIN32/GSWIN32Printer.m: Give an enumerated printer
 	the generic PostScript PPD and parse it, so that
 	-pageSizeForPaper: and +[NSPrintInfo sizeForPaperName:] answer a

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -2540,22 +2540,45 @@ image.</p><p>See Also: -applicationIconImage</p>
  */
 - (void) hide: (id)sender
 {
-#ifdef __MINGW32__
-  [self miniaturizeAll: sender];
-#else
   if (_app_is_hidden == NO)
     {
-      if (![[NSUserDefaults standardUserDefaults]
-	     boolForKey: @"GSSuppressAppIcon"])
+      NSDictionary	*info;
+      id<NSMenuItem>	menuItem;
+      BOOL		miniaturize;
+
+#ifdef __MINGW32__
+      miniaturize = YES;
+#else
+      /*Minimize all windows if there isn't an AppIcon. This isn't the
+	most elegant solution, but avoids to loss the app if the user
+	hide it. */
+      miniaturize = [[NSUserDefaults standardUserDefaults]
+		      boolForKey: @"GSSuppressAppIcon"];
+#endif
+
+      [nc postNotificationName: NSApplicationWillHideNotification
+			object: self];
+
+      menuItem = [sender isKindOfClass: [NSMenuItem class]]
+		   ? sender
+		   : [_main_menu itemWithTitle: _(@"Hide")];
+      if (menuItem)
+	{
+	  [menuItem setAction: @selector(unhide:)];
+	  [menuItem setTitle: _(@"Show")];
+	}
+
+      _app_is_hidden = YES;
+
+      if (miniaturize)
+	{
+	  [self miniaturizeAll: sender];
+	}
+      else
 	{
 	  NSArray		*windows_list;
-	  NSDictionary  	*info;
 	  NSWindow		*win;
 	  NSEnumerator  	*iter;
-          id<NSMenuItem>  	menuItem;
-
-	  [nc postNotificationName: NSApplicationWillHideNotification
-	                    object: self];
 
 	  if ([self keyWindow] != nil)
 	    {
@@ -2601,17 +2624,7 @@ image.</p><p>See Also: -applicationIconImage</p>
                   [win orderOut: self];
                 }
 	    }
-	  menuItem = [sender isKindOfClass:[NSMenuItem class]]
-		       ? sender
-		       : [_main_menu itemWithTitle:_(@"Hide")];
-	  if (menuItem)
-	    {
-	      [menuItem setAction:@selector(unhide:)];
-	      [menuItem setTitle:_(@"Show")];
-	    }
 
-	  _app_is_hidden = YES;
-	  
 	  if (YES == [[NSUserDefaults standardUserDefaults]
 		       boolForKey: @"GSSuppressAppIcon"])
 	    {
@@ -2638,25 +2651,17 @@ image.</p><p>See Also: -applicationIconImage</p>
 	   */
 	  [self deactivate];
 	  _unhide_on_activation = YES;
-	  
-	  info = [self _notificationUserInfo];
-	  [nc postNotificationName: NSApplicationDidHideNotification
-			    object: self
-		          userInfo: info];
-	  [[[NSWorkspace sharedWorkspace] notificationCenter]
-	    postNotificationName: NSApplicationDidHideNotification
-		          object: [NSWorkspace sharedWorkspace]
-		        userInfo: info];
 	}
-      else
-	{
-	  /*Minimize all windows if there isn't an AppIcon. This isn't the
-	    most elegant solution, but avoids to loss the app if the user
-	    hide it. */
-	  [self miniaturizeAll: sender];
-	}
+
+      info = [self _notificationUserInfo];
+      [nc postNotificationName: NSApplicationDidHideNotification
+			object: self
+		      userInfo: info];
+      [[[NSWorkspace sharedWorkspace] notificationCenter]
+	postNotificationName: NSApplicationDidHideNotification
+		      object: [NSWorkspace sharedWorkspace]
+		    userInfo: info];
     }
-#endif
 }
 
 /**<p>Returns whether app is currently in hidden state.</p>
@@ -2714,6 +2719,25 @@ image.</p><p>See Also: -applicationIconImage</p>
       _app_is_hidden = NO;
 
       count = [_hidden count];
+      if (count == 0)
+	{
+	  /* Nothing was ordered out, so the application was hidden by
+	     miniaturizing its windows, and they are brought back the way
+	     they were put away.  A window the user had miniaturized before
+	     the application was hidden comes back with them. */
+	  NSArray      *windows = [self windows];
+	  NSEnumerator *iter = [windows objectEnumerator];
+	  NSWindow     *win;
+
+	  while ((win = [iter nextObject]) != nil)
+	    {
+	      if ([win isMiniaturized])
+		{
+		  [win deminiaturize: self];
+		}
+	    }
+	}
+
       for (i = 0; i < count; i++)
         {
           NSWindow *win = [_hidden objectAtIndex: i];


### PR DESCRIPTION
Fixes #897.

On Windows hide: called miniaturizeAll: and returned, leaving _app_is_hidden NO. isHidden then contradicted the call that had just run, unhide: did nothing because it acts only on a hidden application, and neither hide notification was posted.

The same omission was reached on any platform, not only Windows: the branch taken when GSSuppressAppIcon is set also miniaturized the windows and did no bookkeeping either.

Both now call one private method that posts NSApplicationWillHideNotification, miniaturizes, swaps the Hide menu item to Show and sets the flag before posting NSApplicationDidHideNotification.

unhideWithoutActivation deminiaturizes those windows again. It tells the two ways of hiding apart by whether any window was ordered out: the ordering path fills the hidden list, the miniaturizing path leaves it empty. A window the user had miniaturized before hiding comes back with them.

Tests/gui/NSApplication on MSYS2 UCRT64, the platform of the Windows MinGW job: basic.m:239 failed before and 41 assertions pass after. Line 242 passed before only because the flag never became YES. On Linux the set gives 41 passed, against the built library rather than the installed one.
