### PR TITLE
Give a Windows printer a PPD so its paper sizes are not 0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2026-08-11 Todd White <todd.white@thalion.global>
 
+	* Printing/GSWIN32/GSWIN32Printer.m: Give an enumerated printer
+	the generic PostScript PPD and parse it, so that
+	-pageSizeForPaper: and +[NSPrintInfo sizeForPaperName:] answer a
+	size rather than 0 by 0.  An unreadable PPD is a warning and the
+	printer is still returned.
+
+2026-08-11 Todd White <todd.white@thalion.global>
+
 	* Source/NSTabView.m: Give each item's tooltip the area that
 	item's tab occupies, renewed after each draw, since the theme
 	settles the tab rects as it draws.

--- a/Printing/GSWIN32/GSWIN32Printer.m
+++ b/Printing/GSWIN32/GSWIN32Printer.m
@@ -79,8 +79,13 @@ NSMutableDictionary *EnumeratePrinters(DWORD flags)
     else
       {
 	int i = 0;
-	
+	NSString *ppdPath;
+
 	printers = [NSMutableDictionary dictionary];
+	ppdPath = [NSBundle
+		    pathForLibraryResource: @"Generic-PostScript_Printer-Postscript"
+				    ofType: @"ppd"
+			       inDirectory: @"PostScript/PPD"];
 	NSLog(@"Printers found: %d\n\n",returned);
 	for (i = 0; i < returned; i++)
 	  {
@@ -102,7 +107,13 @@ NSMutableDictionary *EnumeratePrinters(DWORD flags)
 			      forKey:@"Note"];
 		    [entry setObject:@"Generic Postscript Printer"
 			      forKey:@"Type"];
-		    
+
+		    if (ppdPath != nil)
+		      {
+			[entry setObject:ppdPath
+				  forKey:@"PPDPath"];
+		      }
+
 		    [printers setObject:entry
 				 forKey:printerName];
 		    /*
@@ -178,8 +189,20 @@ NSMutableDictionary *EnumeratePrinters(DWORD flags)
                         withHost: [printerEntry objectForKey: @"Host"]
                         withNote: [printerEntry objectForKey: @"Note"]];
 
-  // [printer parsePPDAtPath: [printerEntry objectForKey: @"PPDPath"]];
-                         
+  /* A stored printer may reference a PPD that no longer exists; an unreadable
+     PPD is a warning here and the printer is returned without it, so the caller
+     uses its defaults. */
+  NS_DURING
+    {
+      [printer parsePPDAtPath: [printerEntry objectForKey: @"PPDPath"]];
+    }
+  NS_HANDLER
+    {
+      NSLog(@"Could not read the PPD for printer %@: %@",
+            name, [localException reason]);
+    }
+  NS_ENDHANDLER
+
   return AUTORELEASE(printer);
 }
 


### PR DESCRIPTION
On Windows every paper size came back as 0 by 0.
+[NSPrintInfo sizeForPaperName:] and -[NSPrinter pageSizeForPaper:] read
PaperDimension from the printer's PPD table, and a GSWIN32Printer had no PPD.
EnumeratePrinters built an entry holding Host, Note and Type, and the parse in
+printerWithName: was commented out.

An enumerated entry now carries the generic PostScript PPD, which is the type
the bundle already reports for it, and the parse runs. It is wrapped as the
GSLPR bundle wraps it, so a printer whose PPD cannot be read is still returned.

The sizes are the standard ones the generic PPD holds rather than the paper
list a driver reports. DeviceCapabilities is not consulted.

Tests/gui/NSPrintInfo/dictionary.m and Tests/gui/NSPDFInfo/initdefaults.m.

3 failed before, 0 after.

Closes #895.
