### PR TITLE
Add support for NSContentSetBinding to NSArrayController

### DIFF
--- a/Headers/AppKit/NSKeyValueBinding.h
+++ b/Headers/AppKit/NSKeyValueBinding.h
@@ -109,6 +109,7 @@ APPKIT_EXPORT NSString *NSContentArrayBinding;
 APPKIT_EXPORT NSString *NSContentBinding;
 APPKIT_EXPORT NSString *NSContentDictionaryBinding;
 APPKIT_EXPORT NSString *NSContentObjectBinding;
+APPKIT_EXPORT NSString *NSContentSetBinding;
 APPKIT_EXPORT NSString *NSContentValuesBinding;
 APPKIT_EXPORT NSString *NSEditableBinding;
 APPKIT_EXPORT NSString *NSEnabledBinding;

--- a/Source/NSArrayController.m
+++ b/Source/NSArrayController.m
@@ -147,6 +147,7 @@
   if (self == [NSArrayController class])
     {
       [self exposeBinding: NSContentArrayBinding];
+      [self exposeBinding: NSContentSetBinding];
       [self exposeBinding: NSSelectionIndexesBinding];
       [self setKeys: [NSArray arrayWithObjects: NSContentBinding, NSContentObjectBinding, nil]
 	    triggerChangeNotificationsForDependentKey: @"arrangedObjects"];
@@ -545,7 +546,8 @@ atArrangedObjectIndexes: (NSIndexSet*)idx
   withKeyPath: (NSString *)keyPath
       options: (NSDictionary *)options
 {
-  if ([binding isEqual: NSContentArrayBinding])
+  if ([binding isEqual: NSContentArrayBinding]
+    || [binding isEqual: NSContentSetBinding])
     {
       GSKeyValueBinding *kvb;
 
@@ -573,6 +575,10 @@ atArrangedObjectIndexes: (NSIndexSet*)idx
   if ([binding isEqual: NSContentArrayBinding])
     {
       return [NSArray class];
+    }
+  else if ([binding isEqual: NSContentSetBinding])
+    {
+      return [NSSet class];
     }
   else
     {

--- a/Source/externs.m
+++ b/Source/externs.m
@@ -695,6 +695,7 @@ APPKIT_DECLARE NSString *NSContentArrayBinding = @"contentArray";
 APPKIT_DECLARE NSString *NSContentBinding = @"content";
 APPKIT_DECLARE NSString *NSContentDictionaryBinding = @"contentDictionary";
 APPKIT_DECLARE NSString *NSContentObjectBinding = @"contentObject";
+APPKIT_DECLARE NSString *NSContentSetBinding = @"contentSet";
 APPKIT_DECLARE NSString *NSContentValuesBinding = @"contentValues";
 APPKIT_DECLARE NSString *NSEditableBinding = @"editable";
 APPKIT_DECLARE NSString *NSEnabledBinding = @"enabled";


### PR DESCRIPTION
To repro #916:

```
/*
 * Repro for: NSArrayController does not expose the Cocoa "contentSet"
 * binding (gnustep-gui-contentset-binding.patch).
 *
 * Cocoa's NSArrayController exposes three content bindings: contentArray,
 * contentSet and contentObject. Xcode emits contentSet bindings whenever a
 * table is driven by a to-many Core Data relationship (an NSSet), e.g.:
 *
 *   <binding destination="objectController" name="contentSet"
 *            keyPath="selection.emails"/>
 *
 * gnustep-gui only exposes contentArray, so loading such a xib logs
 *
 *   No binding exposed on <NSArrayController: 0x...> for contentSet
 *
 * and the controller's content silently stays empty: every table bound to a
 * to-many relationship renders zero rows even though the relationship has
 * objects in it.
 *
 * Build (adjust paths to your GNUstep install):
 *   clang contentset-binding-test.m -o contentset-binding-test \
 *     -fobjc-runtime=gnustep-2.0 -fexceptions -fblocks \
 *     -I$PREFIX/Local/Library/Headers \
 *     -L$PREFIX/lib -L$PREFIX/Local/Library/Libraries \
 *     -Wl,--no-as-needed -lgnustep-gui -lgnustep-base -lobjc
 *
 * Run:
 *   Unpatched gui: logs "No binding exposed ... for contentSet",
 *                  arrangedObjects count = 0  -> FAIL
 *   Patched gui:   arrangedObjects count = 3  -> PASS
 */
#import <AppKit/AppKit.h>

@interface Owner : NSObject
{
  NSMutableSet *things;
}
- (NSMutableSet *) things;
- (void) setThings: (NSMutableSet *)set;
@end

@implementation Owner
- (NSMutableSet *) things { return things; }
- (void) setThings: (NSMutableSet *)set
{
  [set retain];
  [things release];
  things = set;
}
- (void) dealloc { [things release]; [super dealloc]; }
@end

int main(void)
{
  NSAutoreleasePool *pool = [NSAutoreleasePool new];

  Owner *owner = [Owner new];
  [owner setThings: [NSMutableSet setWithObjects:
    @"first", @"second", @"third", nil]];

  NSArrayController *ac = [[NSArrayController alloc] initWithContent: nil];

  /* Exactly what nib loading does for
   *   <binding name="contentSet" keyPath="things" destination=Owner>
   */
  [ac bind: @"contentSet" toObject: owner withKeyPath: @"things" options: nil];

  NSUInteger count = [[ac arrangedObjects] count];
  NSLog(@"arrangedObjects count = %lu (expected 3)", (unsigned long)count);
  NSLog(@"%@", count == 3 ? @"PASS" : @"FAIL: contentSet binding ignored");

  [pool drain];
  return count == 3 ? 0 : 1;
}
```

AI disclosure: AI was used to find & fix the bug.