### PR TITLE
Fix selectionIndexes init of nib-decoded NSArrayControllers

### DIFF
--- a/Source/NSArrayController.m
+++ b/Source/NSArrayController.m
@@ -624,6 +624,13 @@ atArrangedObjectIndexes: (NSIndexSet*)idx
       return nil;
     }
 
+  /* -initWithContent: sets this up, but nib-decoded controllers arrive
+     through this initializer and were left with a nil ivar - and
+     -selectedObjects on a nil index set loops forever in NSArray's
+     -objectsAtIndexes: ([nil firstIndex] is 0, -indexGreaterThanIndex:
+     stays 0, so the loop appends object 0 without end). */
+  _selection_indexes = [[NSIndexSet alloc] init];
+
   if ([coder allowsKeyedCoding])
     {
       if ([coder containsValueForKey: @"NSAvoidsEmptySelection"])

--- a/Source/NSArrayController.m
+++ b/Source/NSArrayController.m
@@ -624,11 +624,6 @@ atArrangedObjectIndexes: (NSIndexSet*)idx
       return nil;
     }
 
-  /* -initWithContent: sets this up, but nib-decoded controllers arrive
-     through this initializer and were left with a nil ivar - and
-     -selectedObjects on a nil index set loops forever in NSArray's
-     -objectsAtIndexes: ([nil firstIndex] is 0, -indexGreaterThanIndex:
-     stays 0, so the loop appends object 0 without end). */
   _selection_indexes = [[NSIndexSet alloc] init];
 
   if ([coder allowsKeyedCoding])


### PR DESCRIPTION
Without the fix, _selectionIndexes would remain nil and eventually freeze the app. With the fix, selection works.

AI disclosure: this fix made with AI support.