### PR TITLE
Add methods to handle sending the image and badge over a DO connection via GSDockManager protocol

### DIFF
--- a/Headers/AppKit/NSDockTile.h
+++ b/Headers/AppKit/NSDockTile.h
@@ -59,8 +59,7 @@
 extern "C" {
 #endif
 
-@class NSView, NSString;
-@class NSImageRep;
+@class NSView, NSString, NSImage;
 
 APPKIT_EXPORT_CLASS
 @interface NSDockTile : NSObject
@@ -71,7 +70,6 @@ APPKIT_EXPORT_CLASS
   BOOL      _showsApplicationBadge;
   NSString *_badgeLabel;
   NSImage  *_appIconImage;
-  NSImage  *_dockTileImage;
 }
 
 /**
@@ -143,4 +141,3 @@ APPKIT_EXPORT_CLASS
 #endif	/* GS_API_MACOSX */
 
 #endif	/* _NSDockTile_h_GNUSTEP_GUI_INCLUDE */
-

--- a/Source/GSIconManager.h
+++ b/Source/GSIconManager.h
@@ -39,3 +39,6 @@ GSGetIconFrame(NSWindow *window);
 
 void
 GSUpdateIconManager(NSImage *image, NSString *badgeLabel);
+
+void
+GSRequestUserAttention(NSUInteger requestType);

--- a/Source/GSIconManager.h
+++ b/Source/GSIconManager.h
@@ -24,6 +24,8 @@
 
 #import <Foundation/NSGeometry.h>
 
+@class NSImage;
+@class NSString;
 #import "AppKit/NSWindow.h"
 
 NSSize
@@ -34,3 +36,6 @@ GSRemoveIcon(NSWindow *window);
 
 NSRect
 GSGetIconFrame(NSWindow *window); 
+
+void
+GSUpdateIconManager(NSImage *image, NSString *badgeLabel);

--- a/Source/GSIconManager.h
+++ b/Source/GSIconManager.h
@@ -42,3 +42,6 @@ GSUpdateIconManager(NSImage *image, NSString *badgeLabel);
 
 void
 GSRequestUserAttention(NSUInteger requestType);
+
+void
+GSCancelUserAttentionRequest(NSInteger request);

--- a/Source/GSIconManager.m
+++ b/Source/GSIconManager.m
@@ -45,6 +45,8 @@
  - (void) setApplicationIconData: (NSData *)data
                        badgeText: (NSString *)badgeText
                     appProcessId: (int)aProcessId;
+ - (void) requestUserAttention: (NSInteger)requestType
+		   appProcessId: (int)aProcessId;
 @end
 
 static BOOL verify = NO;
@@ -296,6 +298,31 @@ GSSendApplicationIconData(NSData *data, NSString *badgeText)
   NS_ENDHANDLER
 
   return sent;
+}
+
+void
+GSRequestUserAttention(NSUInteger requestType)
+{
+  checkVerify();
+
+  if (gsim == nil)
+    {
+      return;
+    }
+
+  NS_DURING
+    {
+      if ([gsim respondsToSelector: @selector(requestUserAttention:appProcessId:)])
+	{
+	  [gsim requestUserAttention: requestType
+			appProcessId: appId];
+	}
+    }
+  NS_HANDLER
+    {
+      GSLostIconManager();
+    }
+  NS_ENDHANDLER
 }
 
 NSRect

--- a/Source/GSIconManager.m
+++ b/Source/GSIconManager.m
@@ -54,9 +54,12 @@ static int appId = 0;
 static NSMutableSet *registeredIcons = nil;
 static unsigned int iconManagerUpdateCount = 0;
 static unsigned int lastIconManagerAttemptUpdate = 0;
+static NSData *lastApplicationIconData = nil;
+static NSString *lastApplicationIconBadgeText = nil;
 
 static void GSReleaseIconManager(void);
 static void GSLostIconManager(void);
+static BOOL GSSendApplicationIconData(NSData *data, NSString *badgeText);
 
 @interface GSIconManagerMonitor : NSObject
 + (id) _lostIconManager: (NSNotification *)notification;
@@ -104,6 +107,12 @@ GSGetIconManager(void)
 		   selector: @selector(_lostIconManager:)
 		       name: NSConnectionDidDieNotification
 		     object: gsimConnection];
+	      if (lastApplicationIconData != nil
+		  || lastApplicationIconBadgeText != nil)
+		{
+		  GSSendApplicationIconData(lastApplicationIconData,
+					   lastApplicationIconBadgeText);
+		}
 	    }
 	}
       NS_HANDLER
@@ -232,6 +241,13 @@ GSUpdateIconManager(NSImage *image, NSString *badgeLabel)
 
   iconManagerUpdateCount++;
 
+  if (image != nil)
+    {
+      iconData = [image TIFFRepresentation];
+    }
+  ASSIGN(lastApplicationIconData, iconData);
+  ASSIGNCOPY(lastApplicationIconBadgeText, badgeLabel);
+
   if (gsim == nil && verify)
     {
       if (iconManagerUpdateCount - lastIconManagerAttemptUpdate < 5)
@@ -249,18 +265,28 @@ GSUpdateIconManager(NSImage *image, NSString *badgeLabel)
       return;
     }
 
+  GSSendApplicationIconData(lastApplicationIconData,
+			   lastApplicationIconBadgeText);
+}
+
+static BOOL
+GSSendApplicationIconData(NSData *data, NSString *badgeText)
+{
+  BOOL sent = NO;
+
+  if (gsim == nil)
+    {
+      return NO;
+    }
+
   NS_DURING
     {
       if ([gsim respondsToSelector: @selector(setApplicationIconData:badgeText:appProcessId:)])
 	{
-	  if (image != nil)
-	    {
-	      iconData = [image TIFFRepresentation];
-	    }
-
-	  [gsim setApplicationIconData: iconData
-			     badgeText: badgeLabel
+	  [gsim setApplicationIconData: data
+			     badgeText: badgeText
 			  appProcessId: appId];
+	  sent = YES;
 	}
     }
   NS_HANDLER
@@ -268,6 +294,8 @@ GSUpdateIconManager(NSImage *image, NSString *badgeLabel)
       GSLostIconManager();
     }
   NS_ENDHANDLER
+
+  return sent;
 }
 
 NSRect

--- a/Source/GSIconManager.m
+++ b/Source/GSIconManager.m
@@ -27,6 +27,7 @@
 #import <Foundation/NSDistantObject.h>
 #import <Foundation/NSException.h>
 #import <Foundation/NSNotification.h>
+#import <Foundation/NSObject.h>
 #import <Foundation/NSSet.h>
 #import <Foundation/NSUserDefaults.h>
 #import <Foundation/NSValue.h>
@@ -37,16 +38,13 @@
 #import "AppKit/NSImage.h"
 #import "GSIconManager.h"
 
-@protocol GSIconManager
+@protocol GSIconManager <NSObject>
  - (NSRect) setWindow: (unsigned int)aWindowNumber appProcessId: (int)aProcessId;
  - (void) removeWindow: (unsigned int)aWindowNumber;
  - (NSSize) getSizeWindow;
  - (void) setApplicationIconData: (NSData *)data
                        badgeText: (NSString *)badgeText
                     appProcessId: (int)aProcessId;
- - (BOOL) respondsToSelector: (SEL)aSelector;
- - (id) retain;
- - (void) release; 
 @end
 
 static BOOL verify = NO;
@@ -155,25 +153,6 @@ checkVerify()
    }
 }
 
-static inline BOOL
-checkVerifyForUpdate()
-{
-  iconManagerUpdateCount++;
-
-  if (gsim == nil && verify)
-    {
-      if (iconManagerUpdateCount - lastIconManagerAttemptUpdate < 5)
-	{
-	  return NO;
-	}
-
-      verify = NO;
-    }
-
-  checkVerify();
-  return gsim != nil;
-}
-
 NSSize
 GSGetIconSize(void)
 {
@@ -251,7 +230,21 @@ GSUpdateIconManager(NSImage *image, NSString *badgeLabel)
 {
   NSData *iconData = nil;
 
-  if (checkVerifyForUpdate() == NO)
+  iconManagerUpdateCount++;
+
+  if (gsim == nil && verify)
+    {
+      if (iconManagerUpdateCount - lastIconManagerAttemptUpdate < 5)
+	{
+	  return;
+	}
+
+      verify = NO;
+    }
+
+  checkVerify();
+
+  if (gsim == nil)
     {
       return;
     }

--- a/Source/GSIconManager.m
+++ b/Source/GSIconManager.m
@@ -27,7 +27,9 @@
 #import <Foundation/NSDistantObject.h>
 #import <Foundation/NSException.h>
 #import <Foundation/NSNotification.h>
+#import <Foundation/NSSet.h>
 #import <Foundation/NSUserDefaults.h>
+#import <Foundation/NSValue.h>
 #import <Foundation/NSProcessInfo.h>
 
 #import <GNUstepGUI/GSDisplayServer.h>
@@ -51,7 +53,7 @@ static BOOL verify = NO;
 static id <GSIconManager>gsim = nil;
 static NSConnection *gsimConnection = nil;
 static int appId = 0;
-static int iconCount = 0;
+static NSMutableSet *registeredIcons = nil;
 static unsigned int iconManagerUpdateCount = 0;
 static unsigned int lastIconManagerAttemptUpdate = 0;
 
@@ -138,6 +140,7 @@ static void
 GSLostIconManager(void)
 {
   GSReleaseIconManager();
+  [registeredIcons removeAllObjects];
   verify = YES;
   lastIconManagerAttemptUpdate = iconManagerUpdateCount;
 }
@@ -208,8 +211,16 @@ GSRemoveIcon(NSWindow *window)
     {
       unsigned int winNum = 0;
       BOOL removed = NO;
+      NSNumber *winNumObject;
 
       NSConvertWindowNumberToGlobal([window windowNumber], &winNum);
+      winNumObject = [NSNumber numberWithUnsignedInt: winNum];
+
+      if ([registeredIcons containsObject: winNumObject] == NO)
+	{
+	  return;
+	}
+
       NS_DURING
 	{
 	  [gsim removeWindow: winNum];
@@ -226,9 +237,9 @@ GSRemoveIcon(NSWindow *window)
 	  return;
 	}
 
-      iconCount--;
+      [registeredIcons removeObject: winNumObject];
 
-      if (iconCount == 0)
+      if ([registeredIcons count] == 0)
 	{
 	  GSReleaseIconManager();
 	}
@@ -277,6 +288,7 @@ GSGetIconFrame(NSWindow *window)
     {
       unsigned int winNum = 0;
       BOOL added = NO;
+      NSNumber *winNumObject;
 
       NSConvertWindowNumberToGlobal([window windowNumber], &winNum);
       NS_DURING
@@ -295,7 +307,12 @@ GSGetIconFrame(NSWindow *window)
 
       if (added == YES)
 	{
-	  iconCount++;
+	  winNumObject = [NSNumber numberWithUnsignedInt: winNum];
+	  if (registeredIcons == nil)
+	    {
+	      registeredIcons = [[NSMutableSet alloc] initWithCapacity: 1];
+	    }
+	  [registeredIcons addObject: winNumObject];
 	}
     }
   else

--- a/Source/GSIconManager.m
+++ b/Source/GSIconManager.m
@@ -73,18 +73,17 @@ static void GSReleaseIconManager(void);
 static void
 GSGetIconManager(void)
 {
-  if ([[NSUserDefaults standardUserDefaults] boolForKey: @"GSUseIconManager"])
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+
+  if ([defaults objectForKey: @"GSUseIconManager"] == nil ||
+      [defaults boolForKey: @"GSUseIconManager"])
     {
       appId = [[NSProcessInfo processInfo] processIdentifier];
 
       gsim = (id <GSIconManager>)[NSConnection rootProxyForConnectionWithRegisteredName: @"GSIconManager" 
                                                                                    host: @""];
    
-      if (gsim == nil)
-	{
-	  NSLog (@"Error: could not connect to server GSIconManager");
-	}
-      else if (RETAIN(gsim) != nil)
+      if (gsim != nil && RETAIN(gsim) != nil)
 	{
 	  gsimConnection = RETAIN([(NSDistantObject *)gsim connectionForProxy]);
 	  [[NSNotificationCenter defaultCenter]

--- a/Source/GSIconManager.m
+++ b/Source/GSIconManager.m
@@ -24,6 +24,9 @@
 
 #import <Foundation/NSConnection.h>
 #import <Foundation/NSData.h>
+#import <Foundation/NSDistantObject.h>
+#import <Foundation/NSException.h>
+#import <Foundation/NSNotification.h>
 #import <Foundation/NSUserDefaults.h>
 #import <Foundation/NSProcessInfo.h>
 
@@ -46,8 +49,26 @@
 
 static BOOL verify = NO;
 static id <GSIconManager>gsim = nil;
+static NSConnection *gsimConnection = nil;
 static int appId = 0;
 static int iconCount = 0;
+
+static void GSReleaseIconManager(void);
+
+@interface GSIconManagerMonitor : NSObject
++ (id) _lostIconManager: (NSNotification *)notification;
+@end
+
+@implementation GSIconManagerMonitor
++ (id) _lostIconManager: (NSNotification *)notification
+{
+  if ([notification object] == gsimConnection)
+    {
+      GSReleaseIconManager();
+    }
+  return self;
+}
+@end
 
 static void
 GSGetIconManager(void)
@@ -63,9 +84,31 @@ GSGetIconManager(void)
 	{
 	  NSLog (@"Error: could not connect to server GSIconManager");
 	}
-
-      [gsim retain];
+      else if (RETAIN(gsim) != nil)
+	{
+	  gsimConnection = RETAIN([(NSDistantObject *)gsim connectionForProxy]);
+	  [[NSNotificationCenter defaultCenter]
+	    addObserver: [GSIconManagerMonitor class]
+	       selector: @selector(_lostIconManager:)
+		   name: NSConnectionDidDieNotification
+		 object: gsimConnection];
+	}
     }
+}
+
+static void
+GSReleaseIconManager(void)
+{
+  if (gsimConnection != nil)
+    {
+      [[NSNotificationCenter defaultCenter]
+	removeObserver: [GSIconManagerMonitor class]
+		  name: NSConnectionDidDieNotification
+		object: gsimConnection];
+      DESTROY(gsimConnection);
+    }
+  DESTROY(gsim);
+  verify = NO;
 }
 
 static inline void
@@ -87,7 +130,16 @@ GSGetIconSize(void)
 
   if (gsim != nil)
     {
-      iconSize = [gsim getSizeWindow];
+      NS_DURING
+	{
+	  iconSize = [gsim getSizeWindow];
+	}
+      NS_HANDLER
+	{
+	  GSReleaseIconManager();
+	  iconSize = [GSCurrentServer() iconSize];
+	}
+      NS_ENDHANDLER
     }
   else
     {
@@ -105,16 +157,30 @@ GSRemoveIcon(NSWindow *window)
   if (gsim != nil)
     {
       unsigned int winNum = 0;
+      BOOL removed = NO;
 
       NSConvertWindowNumberToGlobal([window windowNumber], &winNum);
-      [gsim removeWindow: winNum];
+      NS_DURING
+	{
+	  [gsim removeWindow: winNum];
+	  removed = YES;
+	}
+      NS_HANDLER
+	{
+	  GSReleaseIconManager();
+	}
+      NS_ENDHANDLER
+
+      if (removed == NO)
+	{
+	  return;
+	}
 
       iconCount--;
 
       if (iconCount == 0)
 	{
-	  DESTROY(gsim);
-	  verify = NO;
+	  GSReleaseIconManager();
 	}
     }
 }
@@ -131,19 +197,25 @@ GSUpdateIconManager(NSImage *image, NSString *badgeLabel)
       return;
     }
 
-  if (![gsim respondsToSelector: @selector(setApplicationIconData:badgeText:appProcessId:)])
+  NS_DURING
     {
-      return;
-    }
+      if ([gsim respondsToSelector: @selector(setApplicationIconData:badgeText:appProcessId:)])
+	{
+	  if (image != nil)
+	    {
+	      iconData = [image TIFFRepresentation];
+	    }
 
-  if (image != nil)
+	  [gsim setApplicationIconData: iconData
+			     badgeText: badgeLabel
+			  appProcessId: appId];
+	}
+    }
+  NS_HANDLER
     {
-      iconData = [image TIFFRepresentation];
+      GSReleaseIconManager();
     }
-
-  [gsim setApplicationIconData: iconData
-                     badgeText: badgeLabel
-                  appProcessId: appId];
+  NS_ENDHANDLER
 }
 
 NSRect
@@ -156,12 +228,27 @@ GSGetIconFrame(NSWindow *window)
   if (gsim != nil)
     {
       unsigned int winNum = 0;
+      BOOL added = NO;
 
       NSConvertWindowNumberToGlobal([window windowNumber], &winNum);
-      iconRect = [gsim setWindow: winNum
-                    appProcessId: appId];
+      NS_DURING
+	{
+	  iconRect = [gsim setWindow: winNum
+			appProcessId: appId];
+	  added = YES;
+	}
+      NS_HANDLER
+	{
+	  GSReleaseIconManager();
+	  iconRect = [window frame];
+	  iconRect.size = [GSCurrentServer() iconSize];
+	}
+      NS_ENDHANDLER
 
-      iconCount++;
+      if (added == YES)
+	{
+	  iconCount++;
+	}
     }
   else
     {

--- a/Source/GSIconManager.m
+++ b/Source/GSIconManager.m
@@ -23,17 +23,23 @@
 */
 
 #import <Foundation/NSConnection.h>
+#import <Foundation/NSData.h>
 #import <Foundation/NSUserDefaults.h>
 #import <Foundation/NSProcessInfo.h>
 
 #import <GNUstepGUI/GSDisplayServer.h>
 #import "AppKit/NSGraphics.h"
+#import "AppKit/NSImage.h"
 #import "GSIconManager.h"
 
 @protocol GSIconManager
  - (NSRect) setWindow: (unsigned int)aWindowNumber appProcessId: (int)aProcessId;
  - (void) removeWindow: (unsigned int)aWindowNumber;
  - (NSSize) getSizeWindow;
+ - (void) setApplicationIconData: (NSData *)data
+                       badgeText: (NSString *)badgeText
+                    appProcessId: (int)aProcessId;
+ - (BOOL) respondsToSelector: (SEL)aSelector;
  - (id) retain;
  - (void) release; 
 @end
@@ -111,6 +117,33 @@ GSRemoveIcon(NSWindow *window)
 	  verify = NO;
 	}
     }
+}
+
+void
+GSUpdateIconManager(NSImage *image, NSString *badgeLabel)
+{
+  NSData *iconData = nil;
+
+  checkVerify();
+
+  if (gsim == nil)
+    {
+      return;
+    }
+
+  if (![gsim respondsToSelector: @selector(setApplicationIconData:badgeText:appProcessId:)])
+    {
+      return;
+    }
+
+  if (image != nil)
+    {
+      iconData = [image TIFFRepresentation];
+    }
+
+  [gsim setApplicationIconData: iconData
+                     badgeText: badgeLabel
+                  appProcessId: appId];
 }
 
 NSRect

--- a/Source/GSIconManager.m
+++ b/Source/GSIconManager.m
@@ -52,8 +52,11 @@ static id <GSIconManager>gsim = nil;
 static NSConnection *gsimConnection = nil;
 static int appId = 0;
 static int iconCount = 0;
+static unsigned int iconManagerUpdateCount = 0;
+static unsigned int lastIconManagerAttemptUpdate = 0;
 
 static void GSReleaseIconManager(void);
+static void GSLostIconManager(void);
 
 @interface GSIconManagerMonitor : NSObject
 + (id) _lostIconManager: (NSNotification *)notification;
@@ -64,7 +67,7 @@ static void GSReleaseIconManager(void);
 {
   if ([notification object] == gsimConnection)
     {
-      GSReleaseIconManager();
+      GSLostIconManager();
     }
   return self;
 }
@@ -75,23 +78,44 @@ GSGetIconManager(void)
 {
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
+  lastIconManagerAttemptUpdate = iconManagerUpdateCount;
+
   if ([defaults objectForKey: @"GSUseIconManager"] == nil ||
       [defaults boolForKey: @"GSUseIconManager"])
     {
+      id <GSIconManager>proxy = nil;
+      BOOL retainedProxy = NO;
+
       appId = [[NSProcessInfo processInfo] processIdentifier];
 
-      gsim = (id <GSIconManager>)[NSConnection rootProxyForConnectionWithRegisteredName: @"GSIconManager" 
-                                                                                   host: @""];
-   
-      if (gsim != nil && RETAIN(gsim) != nil)
+      NS_DURING
 	{
-	  gsimConnection = RETAIN([(NSDistantObject *)gsim connectionForProxy]);
-	  [[NSNotificationCenter defaultCenter]
-	    addObserver: [GSIconManagerMonitor class]
-	       selector: @selector(_lostIconManager:)
-		   name: NSConnectionDidDieNotification
-		 object: gsimConnection];
+	  proxy = (id <GSIconManager>)
+	    [NSConnection rootProxyForConnectionWithRegisteredName: @"GSIconManager"
+							      host: @""];
+
+	  if (proxy != nil && RETAIN(proxy) != nil)
+	    {
+	      retainedProxy = YES;
+	      gsimConnection = RETAIN([(NSDistantObject *)proxy connectionForProxy]);
+	      gsim = proxy;
+	      [[NSNotificationCenter defaultCenter]
+		addObserver: [GSIconManagerMonitor class]
+		   selector: @selector(_lostIconManager:)
+		       name: NSConnectionDidDieNotification
+		     object: gsimConnection];
+	    }
 	}
+      NS_HANDLER
+	{
+	  if (retainedProxy == YES)
+	    {
+	      RELEASE(proxy);
+	    }
+	  DESTROY(gsimConnection);
+	  gsim = nil;
+	}
+      NS_ENDHANDLER
     }
 }
 
@@ -110,6 +134,14 @@ GSReleaseIconManager(void)
   verify = NO;
 }
 
+static void
+GSLostIconManager(void)
+{
+  GSReleaseIconManager();
+  verify = YES;
+  lastIconManagerAttemptUpdate = iconManagerUpdateCount;
+}
+
 static inline void
 checkVerify()
 {
@@ -118,6 +150,25 @@ checkVerify()
       GSGetIconManager();
       verify = YES;
    }
+}
+
+static inline BOOL
+checkVerifyForUpdate()
+{
+  iconManagerUpdateCount++;
+
+  if (gsim == nil && verify)
+    {
+      if (iconManagerUpdateCount - lastIconManagerAttemptUpdate < 5)
+	{
+	  return NO;
+	}
+
+      verify = NO;
+    }
+
+  checkVerify();
+  return gsim != nil;
 }
 
 NSSize
@@ -135,7 +186,7 @@ GSGetIconSize(void)
 	}
       NS_HANDLER
 	{
-	  GSReleaseIconManager();
+	  GSLostIconManager();
 	  iconSize = [GSCurrentServer() iconSize];
 	}
       NS_ENDHANDLER
@@ -166,7 +217,7 @@ GSRemoveIcon(NSWindow *window)
 	}
       NS_HANDLER
 	{
-	  GSReleaseIconManager();
+	  GSLostIconManager();
 	}
       NS_ENDHANDLER
 
@@ -189,9 +240,7 @@ GSUpdateIconManager(NSImage *image, NSString *badgeLabel)
 {
   NSData *iconData = nil;
 
-  checkVerify();
-
-  if (gsim == nil)
+  if (checkVerifyForUpdate() == NO)
     {
       return;
     }
@@ -212,7 +261,7 @@ GSUpdateIconManager(NSImage *image, NSString *badgeLabel)
     }
   NS_HANDLER
     {
-      GSReleaseIconManager();
+      GSLostIconManager();
     }
   NS_ENDHANDLER
 }
@@ -238,7 +287,7 @@ GSGetIconFrame(NSWindow *window)
 	}
       NS_HANDLER
 	{
-	  GSReleaseIconManager();
+	  GSLostIconManager();
 	  iconRect = [window frame];
 	  iconRect.size = [GSCurrentServer() iconSize];
 	}

--- a/Source/GSIconManager.m
+++ b/Source/GSIconManager.m
@@ -47,6 +47,8 @@
                     appProcessId: (int)aProcessId;
  - (void) requestUserAttention: (NSInteger)requestType
 		   appProcessId: (int)aProcessId;
+ - (void) cancelUserAttentionRequest: (NSInteger)request
+			appProcessId: (int)aProcessId;
 @end
 
 static BOOL verify = NO;
@@ -316,6 +318,31 @@ GSRequestUserAttention(NSUInteger requestType)
 	{
 	  [gsim requestUserAttention: requestType
 			appProcessId: appId];
+	}
+    }
+  NS_HANDLER
+    {
+      GSLostIconManager();
+    }
+  NS_ENDHANDLER
+}
+
+void
+GSCancelUserAttentionRequest(NSInteger request)
+{
+  checkVerify();
+
+  if (gsim == nil)
+    {
+      return;
+    }
+
+  NS_DURING
+    {
+      if ([gsim respondsToSelector: @selector(cancelUserAttentionRequest:appProcessId:)])
+	{
+	  [gsim cancelUserAttentionRequest: request
+			      appProcessId: appId];
 	}
     }
   NS_HANDLER

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -2492,6 +2492,10 @@ image.</p><p>See Also: -applicationIconImage</p>
         [current setMiniwindowImage: _app_icon];
     }
 
+  GSUpdateIconManager(_app_icon,
+    (_dock_tile != nil && [_dock_tile showsApplicationBadge])
+      ? [_dock_tile badgeLabel] : nil);
+
   DESTROY(old_app_icon);
 }
 
@@ -4460,4 +4464,3 @@ struct _DelegateWrapper
 }
 
 @end
-

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -3864,8 +3864,8 @@ struct _DelegateWrapper
  */
 - (NSInteger) requestUserAttention: (NSRequestUserAttentionType)requestType
 {
-  // FIXME
-  return 0;
+  GSRequestUserAttention(requestType);
+  return requestType;
 }
 
 - (NSApplicationPresentationOptions) currentPresentationOptions

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -3865,7 +3865,7 @@ struct _DelegateWrapper
 - (NSInteger) requestUserAttention: (NSRequestUserAttentionType)requestType
 {
   GSRequestUserAttention(requestType);
-  return requestType;
+  return 0;
 }
 
 - (NSApplicationPresentationOptions) currentPresentationOptions

--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -3853,7 +3853,7 @@ struct _DelegateWrapper
  */
 - (void) cancelUserAttentionRequest: (NSInteger)request
 {
-  // FIXME
+  GSCancelUserAttentionRequest(request);
 }
 
 /**

--- a/Source/NSDockTile.m
+++ b/Source/NSDockTile.m
@@ -27,6 +27,7 @@
 #import "AppKit/NSApplication.h"
 #import "AppKit/NSAffineTransform.h"
 #import "AppKit/NSDockTile.h"
+#import "AppKit/NSGraphics.h"
 #import "AppKit/NSView.h"
 #import "AppKit/NSImage.h"
 #import "AppKit/NSImageRep.h"
@@ -40,6 +41,13 @@
 #import "GNUstepGUI/GSTheme.h"
 #import "GNUstepGUI/GSDisplayServer.h"
 #import "GSIconManager.h"
+
+static void
+clearDockTileRect(NSSize size)
+{
+  NSRectFillUsingOperation(NSMakeRect(0, 0, size.width, size.height),
+			   NSCompositeClear);
+}
 
 static void
 drawViewHierarchy(NSView *view)
@@ -88,10 +96,9 @@ drawViewHierarchy(NSView *view)
       NSImageRep *_imageRep;
       GSDisplayServer *server = GSCurrentServer();
       NSSize size = [server iconSize]; 
-      NSRect rect = NSMakeRect(0, 0, size.width, size.height);
       
       _size = size;
-      _contentView = [[NSView alloc] initWithFrame: rect];
+      _contentView = nil;
       _badgeLabel = nil;
       _owner = nil;
       _showsApplicationBadge = YES;
@@ -125,6 +132,7 @@ drawViewHierarchy(NSView *view)
 - (void) setContentView: (NSView *)contentView
 {
   ASSIGN(_contentView, contentView);
+  [self display];
 }
 
 - (NSSize) size
@@ -181,11 +189,15 @@ drawViewHierarchy(NSView *view)
 
 - (void)draw
 {
-  [_appIconImage compositeToPoint: NSZeroPoint operation: NSCompositeCopy];
+  clearDockTileRect(_size);
 
   if (_contentView != nil)
     {
       drawViewHierarchy(_contentView);
+    }
+  else
+    {
+      [_appIconImage compositeToPoint: NSZeroPoint operation: NSCompositeCopy];
     }
 
   if (_showsApplicationBadge && _badgeLabel)

--- a/Source/NSDockTile.m
+++ b/Source/NSDockTile.m
@@ -25,13 +25,10 @@
 */
 
 #import "AppKit/NSApplication.h"
-#import "AppKit/NSAffineTransform.h"
 #import "AppKit/NSDockTile.h"
 #import "AppKit/NSGraphics.h"
 #import "AppKit/NSView.h"
 #import "AppKit/NSImage.h"
-#import "AppKit/NSImageRep.h"
-#import "AppKit/NSCustomImageRep.h"
 #import "AppKit/NSFont.h"
 #import "AppKit/NSStringDrawing.h"
 #import "AppKit/NSAttributedString.h"
@@ -50,41 +47,6 @@ clearDockTileRect(NSSize size)
 }
 
 static void
-drawViewHierarchy(NSView *view)
-{
-  NSArray *subviews;
-  NSUInteger count;
-  NSUInteger i;
-  NSRect bounds;
-
-  if ([view isHidden])
-    {
-      return;
-    }
-
-  bounds = [view bounds];
-  NSRectClip(bounds);
-  [view drawRect: bounds];
-
-  subviews = [view subviews];
-  count = [subviews count];
-  for (i = 0; i < count; i++)
-    {
-      NSView *subview = [subviews objectAtIndex: i];
-      NSAffineTransform *transform;
-      NSRect frame = [subview frame];
-
-      [NSGraphicsContext saveGraphicsState];
-      transform = [NSAffineTransform transform];
-      [transform translateXBy: frame.origin.x - bounds.origin.x
-                          yBy: frame.origin.y - bounds.origin.y];
-      [transform concat];
-      drawViewHierarchy(subview);
-      [NSGraphicsContext restoreGraphicsState];
-    }
-}
-
-static void
 drawDockTileContentView(NSView *view)
 {
   if (view == nil)
@@ -97,10 +59,6 @@ drawDockTileContentView(NSView *view)
       [view displayRectIgnoringOpacity: [view bounds]
                              inContext: [NSGraphicsContext currentContext]];
     }
-  else
-    {
-      drawViewHierarchy(view);
-    }
 }
 
 @implementation NSDockTile
@@ -110,7 +68,6 @@ drawDockTileContentView(NSView *view)
   self = [super init];
   if (self != nil)
     {
-      NSImageRep *_imageRep;
       GSDisplayServer *server = GSCurrentServer();
       NSSize size = [server iconSize]; 
       
@@ -121,13 +78,6 @@ drawDockTileContentView(NSView *view)
       _showsApplicationBadge = YES;
       _appIconImage = [NSImage imageNamed: @"NSApplicationIcon"];
       RETAIN(_appIconImage);
-      _imageRep = [[NSCustomImageRep alloc] initWithDrawSelector: @selector(draw) delegate: self];
-      [_imageRep setSize: [_appIconImage size]];
-      _dockTileImage = [[NSImage alloc] initWithSize: [_appIconImage size]];
-      [_dockTileImage setCacheMode: NSImageCacheNever]; // Only needed because NSImage caches NSCustomImageReps
-      [_dockTileImage addRepresentation: _imageRep];
-      RELEASE(_imageRep);
-      [NSApp setApplicationIconImage: _dockTileImage];
     }
   return self;
 }
@@ -137,7 +87,6 @@ drawDockTileContentView(NSView *view)
   RELEASE(_contentView);
   RELEASE(_badgeLabel);
   RELEASE(_appIconImage);
-  RELEASE(_dockTileImage);
   [super dealloc];
 }
 

--- a/Source/NSDockTile.m
+++ b/Source/NSDockTile.m
@@ -25,6 +25,7 @@
 */
 
 #import "AppKit/NSApplication.h"
+#import "AppKit/NSAffineTransform.h"
 #import "AppKit/NSDockTile.h"
 #import "AppKit/NSView.h"
 #import "AppKit/NSImage.h"
@@ -39,6 +40,43 @@
 #import "GNUstepGUI/GSTheme.h"
 #import "GNUstepGUI/GSDisplayServer.h"
 #import "GSIconManager.h"
+
+static void
+drawViewHierarchy(NSView *view)
+{
+  NSArray *subviews;
+  NSUInteger count;
+  NSUInteger i;
+  BOOL drawSelf;
+
+  if ([view isHidden])
+    {
+      return;
+    }
+
+  drawSelf = (view != [[NSApp iconWindow] contentView]);
+  if (drawSelf)
+    {
+      [view drawRect: [view bounds]];
+    }
+
+  subviews = [view subviews];
+  count = [subviews count];
+  for (i = 0; i < count; i++)
+    {
+      NSView *subview = [subviews objectAtIndex: i];
+      NSAffineTransform *transform;
+      NSRect frame = [subview frame];
+
+      [NSGraphicsContext saveGraphicsState];
+      transform = [NSAffineTransform transform];
+      [transform translateXBy: frame.origin.x
+                          yBy: frame.origin.y];
+      [transform concat];
+      drawViewHierarchy(subview);
+      [NSGraphicsContext restoreGraphicsState];
+    }
+}
 
 @implementation NSDockTile
 
@@ -113,8 +151,6 @@
 {
   _showsApplicationBadge = flag;
   [self display];
-  GSUpdateIconManager([NSApp applicationIconImage],
-    _showsApplicationBadge ? _badgeLabel : nil);
 }
 
 - (NSString *) badgeLabel
@@ -126,18 +162,31 @@
 {
   ASSIGNCOPY(_badgeLabel, label);
   [self display];
-  GSUpdateIconManager([NSApp applicationIconImage],
-    _showsApplicationBadge ? _badgeLabel : nil);
 }
 
 - (void) display
 {
+  NSImage *image = nil;
+
   [_contentView setNeedsDisplay: YES];
+
+  image = [[NSImage alloc] initWithSize: _size];
+  [image lockFocus];
+  [self draw];
+  [image unlockFocus];
+
+  GSUpdateIconManager(image, _showsApplicationBadge ? _badgeLabel : nil);
+  RELEASE(image);
 }
 
 - (void)draw
 {
   [_appIconImage compositeToPoint: NSZeroPoint operation: NSCompositeCopy];
+
+  if (_contentView != nil)
+    {
+      drawViewHierarchy(_contentView);
+    }
 
   if (_showsApplicationBadge && _badgeLabel)
     {

--- a/Source/NSDockTile.m
+++ b/Source/NSDockTile.m
@@ -46,21 +46,6 @@ clearDockTileRect(NSSize size)
 			   NSCompositeClear);
 }
 
-static void
-drawDockTileContentView(NSView *view)
-{
-  if (view == nil)
-    {
-      return;
-    }
-
-  if ([view canDraw])
-    {
-      [view displayRectIgnoringOpacity: [view bounds]
-                             inContext: [NSGraphicsContext currentContext]];
-    }
-}
-
 @implementation NSDockTile
 
 - (instancetype) init
@@ -159,7 +144,11 @@ drawDockTileContentView(NSView *view)
 
   if (_contentView != nil)
     {
-      drawDockTileContentView(_contentView);
+      if ([_contentView canDraw])
+	{
+	  [_contentView displayRectIgnoringOpacity: [_contentView bounds]
+					inContext: [NSGraphicsContext currentContext]];
+	}
     }
   else
     {

--- a/Source/NSDockTile.m
+++ b/Source/NSDockTile.m
@@ -55,18 +55,16 @@ drawViewHierarchy(NSView *view)
   NSArray *subviews;
   NSUInteger count;
   NSUInteger i;
-  BOOL drawSelf;
+  NSRect bounds;
 
   if ([view isHidden])
     {
       return;
     }
 
-  drawSelf = (view != [[NSApp iconWindow] contentView]);
-  if (drawSelf)
-    {
-      [view drawRect: [view bounds]];
-    }
+  bounds = [view bounds];
+  NSRectClip(bounds);
+  [view drawRect: bounds];
 
   subviews = [view subviews];
   count = [subviews count];
@@ -78,11 +76,30 @@ drawViewHierarchy(NSView *view)
 
       [NSGraphicsContext saveGraphicsState];
       transform = [NSAffineTransform transform];
-      [transform translateXBy: frame.origin.x
-                          yBy: frame.origin.y];
+      [transform translateXBy: frame.origin.x - bounds.origin.x
+                          yBy: frame.origin.y - bounds.origin.y];
       [transform concat];
       drawViewHierarchy(subview);
       [NSGraphicsContext restoreGraphicsState];
+    }
+}
+
+static void
+drawDockTileContentView(NSView *view)
+{
+  if (view == nil)
+    {
+      return;
+    }
+
+  if ([view canDraw])
+    {
+      [view displayRectIgnoringOpacity: [view bounds]
+                             inContext: [NSGraphicsContext currentContext]];
+    }
+  else
+    {
+      drawViewHierarchy(view);
     }
 }
 
@@ -193,7 +210,7 @@ drawViewHierarchy(NSView *view)
 
   if (_contentView != nil)
     {
-      drawViewHierarchy(_contentView);
+      drawDockTileContentView(_contentView);
     }
   else
     {

--- a/Source/NSDockTile.m
+++ b/Source/NSDockTile.m
@@ -38,6 +38,7 @@
 
 #import "GNUstepGUI/GSTheme.h"
 #import "GNUstepGUI/GSDisplayServer.h"
+#import "GSIconManager.h"
 
 @implementation NSDockTile
 
@@ -112,6 +113,8 @@
 {
   _showsApplicationBadge = flag;
   [self display];
+  GSUpdateIconManager([NSApp applicationIconImage],
+    _showsApplicationBadge ? _badgeLabel : nil);
 }
 
 - (NSString *) badgeLabel
@@ -123,6 +126,8 @@
 {
   ASSIGNCOPY(_badgeLabel, label);
   [self display];
+  GSUpdateIconManager([NSApp applicationIconImage],
+    _showsApplicationBadge ? _badgeLabel : nil);
 }
 
 - (void) display

--- a/Source/NSDockTile.m
+++ b/Source/NSDockTile.m
@@ -142,13 +142,10 @@ clearDockTileRect(NSSize size)
 {
   clearDockTileRect(_size);
 
-  if (_contentView != nil)
+  if (_contentView != nil && [_contentView canDraw])
     {
-      if ([_contentView canDraw])
-	{
-	  [_contentView displayRectIgnoringOpacity: [_contentView bounds]
-					inContext: [NSGraphicsContext currentContext]];
-	}
+      [_contentView displayRectIgnoringOpacity: [_contentView bounds]
+                                      inContext: [NSGraphicsContext currentContext]];
     }
   else
     {

--- a/Tests/gui/NSDockTile/ownership.m
+++ b/Tests/gui/NSDockTile/ownership.m
@@ -27,7 +27,9 @@ main(int argc, char **argv)
     NSView	*view;
 
     tile = [[NSDockTile alloc] init];
-    view = [tile contentView];
+    view = [[NSView alloc] initWithFrame: NSMakeRect(0, 0, 10, 10)];
+    [tile setContentView: view];
+    RELEASE(view);
     RETAIN(view);
 
     /* One retain and one release, leaving the tile alive throughout. */


### PR DESCRIPTION
This addresses issue#927.  This change adds methods to send the image data and badge information over the GSIconManager protocol.  These methods are optional so that this doesn't break the existing contract between GNUstep and older users of this protocol.  I am using NSData to keep the utilization overhead low.

I am using the app in https://github.com/gcasa/apps-dock to test this change.  It is currently working.  The main driver for this is to make integration between GNUstep and external dock applications easier.  This does not change how the external app works, only how the dock manages the app.  I've used my work on the apps-dock DockWM to shape the changes I've made to libs-gui.  I have made them as minimal as possible.

Disclosure: I am using AI to help debug and test this.  The apps-dock application uses AI pretty extensively; this change uses it in a limited way to suggest fixes when needed and to optimize the libs-gui changes.