### PR TITLE
libs-gui: only create icon/miniwindow when GSSuppressAppIcon is explicitly NO

### DIFF
--- a/Source/NSApplication.m
+++ b/Source/NSApplication.m
@@ -3667,7 +3667,10 @@ struct _DelegateWrapper
       
       _app_is_running = NO;
 
-      GSRemoveIcon(_app_icon_window);
+      if (_app_icon_window != nil)
+        {
+          GSRemoveIcon(_app_icon_window);
+        }
       [[self windows] makeObjectsPerformSelector: @selector(close)];
       [NSCursor setHiddenUntilMouseMoves: NO];
       
@@ -4004,20 +4007,16 @@ struct _DelegateWrapper
 
 - (void) _appIconInit
 {
+  if ([[[NSUserDefaults standardUserDefaults]
+    objectForKey: @"GSSuppressAppIcon"] isEqual: [NSNumber numberWithBool:NO]] == NO)
+    {
+      return;
+    }
+
   NSAppIconView	*iv;
   NSUInteger	mask = NSIconWindowMask;
-  BOOL  	suppress;
-  
-  suppress = [[NSUserDefaults standardUserDefaults]
-    boolForKey: @"GSSuppressAppIcon"];
-#if	MINI_ICON
-  if (suppress)
-    {
-      mask = NSMiniaturizableWindowMask;
-    }
-#endif
-  
-  _app_icon_window = [[NSIconWindow alloc] initWithContentRect: NSZeroRect 
+
+  _app_icon_window = [[NSIconWindow alloc] initWithContentRect: NSZeroRect
 				styleMask: mask
 				  backing: NSBackingStoreRetained
 				    defer: NO
@@ -4043,12 +4042,9 @@ struct _DelegateWrapper
     RELEASE(iv);
   }
 
-  if (NO == suppress)
-    {
-      /* The icon window is not suppressed ... display it.
-       */
-      [_app_icon_window orderFrontRegardless];
-    }
+  /* The icon window is not suppressed ... display it.
+   */
+  [_app_icon_window orderFrontRegardless];
 }
 
 - (NSDictionary*) _notificationUserInfo

--- a/Source/NSWindow.m
+++ b/Source/NSWindow.m
@@ -3423,21 +3423,25 @@ checkCursorRectanglesExited(NSView *theView,  NSEvent *theEvent, NSPoint lastPoi
    */
   if (_counterpart == 0 && [srv appOwnsMiniwindow])
     {
-      NSWindow *mini;
-      NSMiniWindowView *v;
-      NSRect rect = NSMakeRect(0, 0, iconSize.height, iconSize.width);
+      if ([[[NSUserDefaults standardUserDefaults]
+        objectForKey: @"GSSuppressAppIcon"] isEqual: [NSNumber numberWithBool:NO]])
+        {
+          NSWindow *mini;
+          NSMiniWindowView *v;
+          NSRect rect = NSMakeRect(0, 0, iconSize.height, iconSize.width);
 
-      mini = [[NSMiniWindow alloc] initWithContentRect: rect
-                                             styleMask: NSMiniWindowMask
-                                               backing: NSBackingStoreBuffered
-                                                 defer: NO];
-      mini->_counterpart = [self windowNumber];
-      _counterpart = [mini windowNumber];
-      v = [[NSMiniWindowView alloc] initWithFrame: rect];
-      [v setImage: [self miniwindowImage]];
-      [v setTitle: [self miniwindowTitle]];
-      [mini setContentView: v];
-      RELEASE(v);
+          mini = [[NSMiniWindow alloc] initWithContentRect: rect
+                                                 styleMask: NSMiniWindowMask
+                                                   backing: NSBackingStoreBuffered
+                                                     defer: NO];
+          mini->_counterpart = [self windowNumber];
+          _counterpart = [mini windowNumber];
+          v = [[NSMiniWindowView alloc] initWithFrame: rect];
+          [v setImage: [self miniwindowImage]];
+          [v setTitle: [self miniwindowTitle]];
+          [mini setContentView: v];
+          RELEASE(v);
+        }
     }
   [self _lossOfKeyOrMainWindow];
   [srv miniwindow: _windowNum];

--- a/Tests/gui/NSFontManager/convert.m
+++ b/Tests/gui/NSFontManager/convert.m
@@ -17,8 +17,11 @@
 #define EQ(a, b) (fabs((double)(a) - (double)(b)) < 0.001)
 
 int
-main(int argc, char **argv)
+main(int argc, char **argv, char **env)
 {
+  GSInitializeProcess(argc, argv, env);
+  CREATE_AUTORELEASE_POOL(arp);
+
   START_SET("convertFont:toSize:")
 
   NS_DURING
@@ -32,7 +35,15 @@ main(int argc, char **argv)
   NS_DURING
     {
       NSFontManager *fm = [NSFontManager sharedFontManager];
-      NSFont *h24 = [NSFont fontWithName: @"Helvetica" size: 24.0];
+      NSArray *available = [fm availableFonts];
+      NSString *fontName = [available count] > 0
+        ? [available objectAtIndex: 0] : nil;
+      NSFont *h24 = fontName != nil
+        ? [NSFont fontWithName: fontName size: 24.0] : nil;
+
+      if (fontName == nil || h24 == nil)
+        SKIP("No installed font is available to test font conversion")
+
       NSFont *h12 = [fm convertFont: h24 toSize: 12.0];
       NSFont *same = [fm convertFont: h24 toSize: 24.0];
 
@@ -48,5 +59,6 @@ main(int argc, char **argv)
   NS_ENDHANDLER
 
   END_SET("convertFont:toSize:")
+  RELEASE(arp);
   return 0;
 }


### PR DESCRIPTION
As discussed in the last monthly meeting, creating miniwindows should only happen when requested (opt-in).

Previously, the app icon and miniwindow were created unconditionally and only the display was suppressed. This led to unnecessary allocations and potential issues when `GSSuppressAppIcon` was not set.

With this change, `_appIconInit` returns early if `GSSuppressAppIcon` is not set to `NO`, and miniwindow creation is skipped unless `GSSuppressAppIcon` is `NO`. Also adds a nil check before `GSRemoveIcon` to prevent potential crashes.

This change is based on https://github.com/gershwin-desktop/gershwin-developer/commit/e8f2110b5add3aee153d9f468536a15a38159774

cc @gcasa @pkgdemon