### PR TITLE
Fix memory leak in GSCSConstraint initializer

### DIFF
--- a/Source/GSCSConstraint.m
+++ b/Source/GSCSConstraint.m
@@ -42,8 +42,14 @@
   self = [super init];
   if (self)
     {
-      ASSIGN(_strength, strength != nil ? [strength copy]
-                                        : [GSCSStrength strengthRequired]);
+      if (strength != nil)
+        {
+          ASSIGNCOPY(_strength, strength);
+        }
+      else
+        {
+          ASSIGN(_strength, [GSCSStrength strengthRequired]);
+        }
       ASSIGN(_expression, expression);
       ASSIGN(_variable, variable);
       _type = type;


### PR DESCRIPTION
Avoid double retain of the `strength` argument when it is non-nil.  Fixes #933.